### PR TITLE
Added a fix for securitymonkey supervisor program. The error that I was ...

### DIFF
--- a/docs/quickstart1.rst
+++ b/docs/quickstart1.rst
@@ -333,6 +333,7 @@ it were to crash.
 
     [program:securitymonkey]
     command=python /home/ubuntu/security_monkey/manage.py run_api_server
+    environment=SECURITY_MONKEY_SETTINGS="/home/ubuntu/security_monkey/env-config/config-deploy.py"
 
     [program:securitymonkeyscheduler]
     command=python /home/ubuntu/security_monkey/manage.py start_scheduler


### PR DESCRIPTION
...receiving was:

```
RuntimeError: The environment variable 'SECURITY_MONKEY_SETTINGS' is not set and as such configuration could not be loaded.  
```

After setting this varible in the ini and issued reread and update in the supervisorctl it started working.
