### PR TITLE
Make the SES region configurable

### DIFF
--- a/docs/quickstart1.rst
+++ b/docs/quickstart1.rst
@@ -326,6 +326,7 @@ Edit /usr/local/src/security_monkey/env-config/config-deploy.py:
 
     # These are only required if using SMTP instead of SES
     EMAILS_USE_SMTP = True     # Otherwise, Use SES
+    SES_REGION = 'us-east-1'
     MAIL_SERVER = 'smtp.<YOUREMAILPROVIDER>.com'
     MAIL_PORT = 465
     MAIL_USE_SSL = True

--- a/env-config/config-deploy.py
+++ b/env-config/config-deploy.py
@@ -15,7 +15,7 @@
 # This will be fed into Flask/SQLAlchemy inside security_monkey/__init__.py
 
 LOG_LEVEL = "DEBUG"
-LOG_FILE = "security_monkey-deploy.log"
+LOG_FILE = "/var/log/security_monkey/security_monkey-deploy.log"
 
 SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:securitymonkeypassword@localhost:5432/secmonkey'
 
@@ -51,6 +51,7 @@ SECURITY_TEAM_EMAIL = ['securityteam@example.com']
 
 # These are only required if using SMTP instead of SES
 EMAILS_USE_SMTP = False     # Otherwise, Use SES
+SES_REGION = 'us-east-1'
 MAIL_SERVER = 'smtp.example.com'
 MAIL_PORT = 465
 MAIL_USE_SSL = True

--- a/env-config/config-local.py
+++ b/env-config/config-local.py
@@ -51,6 +51,7 @@ SECURITY_TEAM_EMAIL = ['securityteam@example.com']
 
 # These are only required if using SMTP instead of SES
 EMAILS_USE_SMTP = False     # Otherwise, Use SES
+SES_REGION = 'us-east-1'
 MAIL_SERVER = 'smtp.example.com'
 MAIL_PORT = 465
 MAIL_USE_SSL = True

--- a/security_monkey/common/sts_connect.py
+++ b/security_monkey/common/sts_connect.py
@@ -22,6 +22,7 @@
 from security_monkey.datastore import Account
 import boto
 import boto.ec2
+import boto.ses
 import boto.iam
 import boto.sns
 import boto.sqs
@@ -94,6 +95,16 @@ def connect(account_name, connection_type, **args):
             **args)
 
     if connection_type == 'ses':
+        if 'region' in args:
+            region = args['region']
+            del args['region']
+            return boto.ses.connect_to_region(
+                region,
+                aws_access_key_id=role.credentials.access_key,
+                aws_secret_access_key=role.credentials.secret_key,
+                security_token=role.credentials.session_token,
+                **args)
+
         return boto.connect_ses(
             role.credentials.access_key,
             role.credentials.secret_key,

--- a/security_monkey/common/utils/utils.py
+++ b/security_monkey/common/utils/utils.py
@@ -79,7 +79,8 @@ def send_email(subject=None, recipients=[], html=""):
 
     else:
         try:
-            ses = boto.connect_ses()
+            ses_region = app.config.get('SES_REGION', 'us-east-1')
+            ses = boto.ses.connect_to_region(ses_region)
         except Exception, e:
             m = "Failed to connect to ses using boto. Check your boto credentials. {} {}".format(Exception, e)
             app.logger.debug(m)


### PR DESCRIPTION
Users in gov cloud or who have setup SES outside of us-east-1 are having trouble getting emails from security_monkey.  This makes a SES_REGION parameter in the config-deploy.py which can be used to specify which region SES is setup.
