### PR TITLE
Simplify nginx.conf

### DIFF
--- a/docs/quickstart1.rst
+++ b/docs/quickstart1.rst
@@ -449,40 +449,7 @@ Save the config file below to:
        access_log  /var/log/security_monkey/security_monkey.access.log;
        error_log   /var/log/security_monkey/security_monkey.error.log;
 
-        location /register {
-            proxy_read_timeout 120;
-            proxy_pass  http://127.0.0.1:5000;
-            proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
-            proxy_redirect off;
-            proxy_buffering off;
-            proxy_set_header        Host            $host;
-            proxy_set_header        X-Real-IP       $remote_addr;
-            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        location /logout {
-            proxy_read_timeout 120;
-            proxy_pass  http://127.0.0.1:5000;
-            proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
-            proxy_redirect off;
-            proxy_buffering off;
-            proxy_set_header        Host            $host;
-            proxy_set_header        X-Real-IP       $remote_addr;
-            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        location /login {
-            proxy_read_timeout 120;
-            proxy_pass  http://127.0.0.1:5000;
-            proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
-            proxy_redirect off;
-            proxy_buffering off;
-            proxy_set_header        Host            $host;
-            proxy_set_header        X-Real-IP       $remote_addr;
-            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        location /api {
+       location ~* ^/(reset|confirm|healthcheck|register|login|logout|api) {
             proxy_read_timeout 120;
             proxy_pass  http://127.0.0.1:5000;
             proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;


### PR DESCRIPTION
Dedup a number of the nginx proxy config statements into one statement.  Also, add reset, confirm, and healthcheck.

```
location ~* ^/(reset|confirm|healthcheck|register|login|logout|api) {
```
