### PR TITLE
Feature/track s3 lifecycle rules

### DIFF
--- a/security_monkey/watchers/s3.py
+++ b/security_monkey/watchers/s3.py
@@ -51,12 +51,14 @@ def get_lifecycle_rules(bhandle):
         if rule.transition:
             lc_rule['transition'] = {
                 'days': rule.transition.days,
+                'date': rule.transition.date,
                 'storage_class': rule.transition.storage_class
             }
 
         if rule.expiration:
             lc_rule['expiration'] = {
-                'days': rule.expiration.days
+                'days': rule.expiration.days,
+                'date': rule.expiration.date
             }
 
         lifecycle.append(lc_rule)


### PR DESCRIPTION
Tracking S3 lifecycle rules.

There are no audit checks here.

A rule typically deletes objects or moves them to glacier after some number of days.
