### PR TITLE
Run job "now()" after a scheduler restart.

### DIFF
--- a/security_monkey/scheduler.py
+++ b/security_monkey/scheduler.py
@@ -20,6 +20,7 @@ from security_monkey import app, db, handler
 import traceback
 import time
 import logging
+from datetime import datetime, timedelta
 
 def __prep_accounts__(accounts):
     if accounts == 'all':
@@ -120,7 +121,7 @@ def setup_scheduler():
         accounts = [account.name for account in accounts]
         for account in accounts:
             print "Scheduler adding account {}".format(account)
-            scheduler.add_interval_job(run_change_reporter, minutes=interval, args=[account])
+            scheduler.add_interval_job(run_change_reporter, minutes=interval, start_date=datetime.now()+timedelta(seconds=2), args=[account])
             for monitor in all_monitors():
                 if monitor.has_auditor():
                     scheduler.add_cron_job(_audit_changes, hour=10, day_of_week="mon-fri", args=[account, monitor, True])


### PR DESCRIPTION
When adding a new account its necessary to restart scheduler after which it waits the default interval time before next run. If there are setup issues in the new account you'd be waiting for a while to resolve and try again. Hence the simple flag to make it start "now()"

15 minutes could save you... :)