### PR TITLE
Add add_account to manage.py

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -554,6 +554,18 @@ We plan to remove this requirement in the future.::
 
 The first run will occur in 15 minutes.  You can monitor all the log files in /var/log/security_monkey/.  In the browser, you can hit the ```AutoRefresh``` button so the browser will attempt to load results every 30 seconds.
 
+**Note: You can also add accounts via the command line with manage.py**::
+
+    $ python manage.py add_account --number 12345678910 --name account_foo
+    Successfully added account account_foo
+
+If an account with the same number already exists, this will do nothing, unless you pass ``--force``, in which case, it will override the existing account::
+
+    $ python manage.py add_account --number 12345678910 --name account_foo
+    An account with id 12345678910 already exists
+    $ python manage.py add_account --number 12345678910 --name account_foo --active false --force
+    Successfully added account account_foo
+
 Now What?
 =========
 

--- a/manage.py
+++ b/manage.py
@@ -72,6 +72,22 @@ def start_scheduler():
     scheduler.scheduler.start()
 
 
+@manager.option('-u', '--number', dest='number', type=unicode, required=True)
+@manager.option('-a', '--active', dest='active', type=bool, default=True)
+@manager.option('-t', '--thirdparty', dest='third_party', type=bool, default=False)
+@manager.option('-n', '--name', dest='name', type=unicode, required=True)
+@manager.option('-s', '--s3name', dest='s3_name', type=unicode, default=u'')
+@manager.option('-o', '--notes', dest='notes', type=unicode, default=u'')
+@manager.option('-f', '--force', dest='force', help='Override existing accounts', action='store_true')
+def add_account(number, third_party, name, s3_name, active, notes, force):
+    from security_monkey.common.utils.utils import add_account
+    res = add_account(number, third_party, name, s3_name, active, notes, force)
+    if res:
+        app.logger.info('Successfully added account {}'.format(name))
+    else:
+        app.logger.info('Account with id {} already exists'.format(number))
+
+
 class APIServer(Command):
     def __init__(self, host='127.0.0.1', port=app.config.get('API_PORT'), workers=6):
         self.address = "{}:{}".format(host, port)

--- a/security_monkey/common/utils/utils.py
+++ b/security_monkey/common/utils/utils.py
@@ -21,7 +21,8 @@
 
 """
 
-from security_monkey import app, mail
+from security_monkey import app, mail, db
+from security_monkey.datastore import Account
 from flask_mail import Message
 import boto
 import traceback
@@ -94,3 +95,25 @@ def send_email(subject=None, recipients=[], html=""):
             except Exception, e:
                 m = "Failed to send failure message with subject: {}\n{} {}".format(subject, Exception, e)
                 app.logger.debug(m)
+
+def add_account(number, third_party, name, s3_name, active, notes, edit=False):
+    ''' Adds an account. If one with the same number already exists, do nothing,
+    unless edit is True, in which case, override the existing account. Returns True
+    if an action is taken, False otherwise. '''
+    query = Account.query
+    query = query.filter(Account.number == number)
+    if query.count():
+        if not edit:
+            return False
+        else:
+            query.delete()
+    account = Account()
+    account.name = name
+    account.s3_name = s3_name
+    account.number = number
+    account.notes = notes
+    account.active = active
+    account.third_party = third_party
+    db.session.add(account)
+    db.session.commit()
+    return True


### PR DESCRIPTION
This adds the ability to add accounts via manage.py. This is useful for adding account via config files before starting the scheduler, to prevent manual work and a restart.