### PR TITLE
Addition of Role field to Account settings

### DIFF
--- a/dart/lib/component/account_view_component/account_view_component.html
+++ b/dart/lib/component/account_view_component/account_view_component.html
@@ -42,6 +42,13 @@
             </div>
           </div>
           <div class="form-group">
+            <label for="AccountRole" class="col-sm-2 control-label" tooltip-placement="right" tooltip="Enter the AWS role name.">Role</label>
+            <div class="col-sm-10">
+              <input type="text" class="form-control" id="AccountRole" placeholder="Role" ng-model="account.role" maxlength="256"
+              tooltip-placement="left" tooltip="Enter the AWS role name.">
+            </div>
+          </div>
+          <div class="form-group">
             <label for="AccountNotes" class="col-sm-2 control-label" tooltip-placement="right" tooltip="Any account notes can go here. (Up to 256 characters).">Notes</label>
             <div class="col-sm-10">
               <input type="text" class="form-control" id="AccountNotes" placeholder="Notes" ng-model="account.notes" maxlength="256"

--- a/dart/lib/component/settings_component/settings_component.html
+++ b/dart/lib/component/settings_component/settings_component.html
@@ -53,6 +53,7 @@
                             <th>Name</th>
                             <th>S3 Name</th>
                             <th>Account Number</th>
+                            <th>Role</th>
                             <th>Notes</th>
                             <th><button ng-click="createAccount()" class="btn btn-xs btn-primary"><i class="glyphicon glyphicon-plus"></i></button></th>
                         </tr>
@@ -69,6 +70,7 @@
                             <td><a href="#/viewaccount/{{account.id}}">{{account.name}}</a></td>
                             <td>{{account.s3_name}}</td>
                             <td>{{account.number}}</td>
+                            <td>{{account.role}}</td>
                             <td>{{account.notes}}</td>
                             <td></td>
                         </tr>

--- a/dart/lib/model/Account.dart
+++ b/dart/lib/model/Account.dart
@@ -7,6 +7,7 @@ class Account {
     String name;
     String s3_name;
     String number;
+    String role;
     String notes;
     bool _active;
     bool _third_party;
@@ -37,6 +38,7 @@ class Account {
         name = data['name'];
         s3_name = data['s3_name'];
         number = data['number'];
+        role = data['role'];
         notes = data['notes'];
     }
 
@@ -48,6 +50,7 @@ class Account {
             "name": name,
             "s3_name": s3_name,
             "number": number,
+            "role": role,
             "notes": notes
         };
         return JSON.encode(objmap);

--- a/dart/lib/model/hammock_config.dart
+++ b/dart/lib/model/hammock_config.dart
@@ -22,7 +22,7 @@ import 'dart:mirrors';
 
 import 'package:security_monkey/util/constants.dart';
 
-final serializeAWSAccount = serializer("accounts", ["id", "active", "third_party", "name", "s3_name", "number", "notes"]);
+final serializeAWSAccount = serializer("accounts", ["id", "active", "third_party", "name", "s3_name", "number", "role", "notes"]);
 final serializeIssue = serializer("issues", ["id", "score", "issue", "notes", "justified", "justified_user", "justification", "justified_date", "item_id"]);
 final serializeRevision = serializer("revisions", ["id", "item_id", "config", "active", "date_created", "diff_html"]);
 final serializeItem = serializer("items", ["id", "technology", "region", "account", "name"]);

--- a/manage.py
+++ b/manage.py
@@ -81,15 +81,16 @@ def sync_jira():
         app.logger.info('Jira sync not configured. Is SECURITY_MONKEY_JIRA_SYNC set?')
 
 @manager.option('-u', '--number', dest='number', type=unicode, required=True)
+@manager.option('-r', '--role', dest='role', type=unicode, required=True)
 @manager.option('-a', '--active', dest='active', type=bool, default=True)
 @manager.option('-t', '--thirdparty', dest='third_party', type=bool, default=False)
 @manager.option('-n', '--name', dest='name', type=unicode, required=True)
 @manager.option('-s', '--s3name', dest='s3_name', type=unicode, default=u'')
 @manager.option('-o', '--notes', dest='notes', type=unicode, default=u'')
 @manager.option('-f', '--force', dest='force', help='Override existing accounts', action='store_true')
-def add_account(number, third_party, name, s3_name, active, notes, force):
+def add_account(number, role, third_party, name, s3_name, active, notes, force):
     from security_monkey.common.utils.utils import add_account
-    res = add_account(number, third_party, name, s3_name, active, notes, force)
+    res = add_account(number, role, third_party, name, s3_name, active, notes, force)
     if res:
         app.logger.info('Successfully added account {}'.format(name))
     else:

--- a/security_monkey/common/utils/utils.py
+++ b/security_monkey/common/utils/utils.py
@@ -96,7 +96,7 @@ def send_email(subject=None, recipients=[], html=""):
                 m = "Failed to send failure message with subject: {}\n{} {}".format(subject, Exception, e)
                 app.logger.debug(m)
 
-def add_account(number, third_party, name, s3_name, active, notes, edit=False):
+def add_account(number, role, third_party, name, s3_name, active, notes, edit=False):
     ''' Adds an account. If one with the same number already exists, do nothing,
     unless edit is True, in which case, override the existing account. Returns True
     if an action is taken, False otherwise. '''
@@ -111,6 +111,7 @@ def add_account(number, third_party, name, s3_name, active, notes, edit=False):
     account.name = name
     account.s3_name = s3_name
     account.number = number
+    account.role = role
     account.notes = notes
     account.active = active
     account.third_party = third_party

--- a/security_monkey/datastore.py
+++ b/security_monkey/datastore.py
@@ -52,6 +52,7 @@ class Account(db.Model):
     notes = Column(String(256))
     s3_name = Column(String(32))
     number = Column(String(12))  # Not stored as INT because of potential leading-zeros.
+    role = Column(String(256))
     items = relationship("Item", backref="account")
     issue_categories = relationship("AuditorSettings", backref="account")
 

--- a/security_monkey/views/__init__.py
+++ b/security_monkey/views/__init__.py
@@ -93,6 +93,7 @@ ACCOUNT_FIELDS = {
     'name': fields.String,
     's3_name': fields.String,
     'number': fields.String,
+    'role': fields.String,
     'notes': fields.String,
     'active': fields.Boolean,
     'third_party': fields.Boolean

--- a/security_monkey/views/account.py
+++ b/security_monkey/views/account.py
@@ -54,6 +54,7 @@ class AccountGetPutDelete(AuthenticatedService):
                     name: "example_name",
                     notes: null,
                     number: "111111111111",
+                    role: "SecurityMonkey",
                     active: true,
                     id: 1,
                     s3_name: "example_name",
@@ -95,6 +96,7 @@ class AccountGetPutDelete(AuthenticatedService):
                     'name': 'edited_account'
                     's3_name': 'edited_account',
                     'number': '0123456789',
+                    'role': 'SecurityMonkey',
                     'notes': 'this account is for ...',
                     'active': true,
                     'third_party': false
@@ -112,6 +114,7 @@ class AccountGetPutDelete(AuthenticatedService):
                     'name': 'edited_account'
                     's3_name': 'edited_account',
                     'number': '0123456789',
+                    'role': 'SecurityMonkey',
                     'notes': 'this account is for ...',
                     'active': true,
                     'third_party': false
@@ -128,6 +131,7 @@ class AccountGetPutDelete(AuthenticatedService):
         self.reqparse.add_argument('name', required=False, type=unicode, help='Must provide account name', location='json')
         self.reqparse.add_argument('s3_name', required=False, type=unicode, help='Will use name if s3_name not provided.', location='json')
         self.reqparse.add_argument('number', required=False, type=unicode, help='Add the account number if available.', location='json')
+        self.reqparse.add_argument('role', required=True, type=unicode, help='Add the account role if available.', location='json')
         self.reqparse.add_argument('notes', required=False, type=unicode, help='Add context.', location='json')
         self.reqparse.add_argument('active', required=False, type=bool, help='Determines whether this account should be interrogated by security monkey.', location='json')
         self.reqparse.add_argument('third_party', required=False, type=bool, help='Determines whether this account is a known friendly third party account.', location='json')
@@ -138,6 +142,7 @@ class AccountGetPutDelete(AuthenticatedService):
             account.name = args['name']
             account.s3_name = args['s3_name']
             account.number = args['number']
+            account.role = args['role']
             account.notes = args['notes']
             account.active = args['active']
             account.third_party = args['third_party']
@@ -221,6 +226,7 @@ class AccountPostList(AuthenticatedService):
                     'name': 'new_account'
                     's3_name': 'new_account',
                     'number': '0123456789',
+                    'role': 'SecurityMonkey',
                     'notes': 'this account is for ...',
                     'active': true,
                     'third_party': false
@@ -238,6 +244,7 @@ class AccountPostList(AuthenticatedService):
                     'name': 'new_account'
                     's3_name': 'new_account',
                     'number': '0123456789',
+                    'role': 'SecurityMonkey',
                     'notes': 'this account is for ...',
                     'active': true,
                     'third_party': false
@@ -253,6 +260,7 @@ class AccountPostList(AuthenticatedService):
         self.reqparse.add_argument('name', required=True, type=unicode, help='Must provide account name', location='json')
         self.reqparse.add_argument('s3_name', required=False, type=unicode, help='Will use name if s3_name not provided.', location='json')
         self.reqparse.add_argument('number', required=False, type=unicode, help='Add the account number if available.', location='json')
+        self.reqparse.add_argument('role', required=True, type=unicode, help='Add the account role if available.', location='json')
         self.reqparse.add_argument('notes', required=False, type=unicode, help='Add context.', location='json')
         self.reqparse.add_argument('active', required=False, type=bool, help='Determines whether this account should be interrogated by security monkey.', location='json')
         self.reqparse.add_argument('third_party', required=False, type=bool, help='Determines whether this account is a known friendly third party account.', location='json')
@@ -261,6 +269,7 @@ class AccountPostList(AuthenticatedService):
         name = args['name']
         s3_name = args.get('s3_name', name)
         number = args.get('number', None)
+        role = args.get('role', None)
         notes = args.get('notes', None)
         active = args.get('active', True)
         third_party = args.get('third_party', False)
@@ -269,6 +278,7 @@ class AccountPostList(AuthenticatedService):
         account.name = name
         account.s3_name = s3_name
         account.number = number
+        account.role = role
         account.notes = notes
         account.active = active
         account.third_party = third_party
@@ -310,6 +320,7 @@ class AccountPostList(AuthenticatedService):
                             name: "example_name",
                             notes: null,
                             number: "111111111111",
+                            role: "SecurityMonkey",
                             active: true,
                             id: 1,
                             s3_name: "example_name"


### PR DESCRIPTION
This adds support for customizing the name of the IAM role used for the assumeRole call.

This may be interesting to users who have used CloudFormation to create roles, which results in unique names including the CF stack name, and other data.

Thanks.
