### PR TITLE
Change datastore item name length to handle longer SNS topic prefixes

### DIFF
--- a/security_monkey/datastore.py
+++ b/security_monkey/datastore.py
@@ -145,7 +145,7 @@ class Item(db.Model):
     id = Column(Integer, primary_key=True)
     cloud = Column(String(32))  # AWS, Google, Other
     region = Column(String(32))
-    name = Column(String(285))  # Max AWS name = 255 chars.  Add 30 chars for ' (sg-xxxxxxxx in vpc-xxxxxxxx)'
+    name = Column(String(295))  # Max AWS name = 255 chars.  Add 40 chars for ' (sg-xxxxxxxx in vpc-xxxxxxxx)' and SNS topic headers
     tech_id = Column(Integer, ForeignKey("technology.id"), nullable=False)
     account_id = Column(Integer, ForeignKey("account.id"), nullable=False)
     revisions = relationship("ItemRevision", backref="item", cascade="all, delete, delete-orphan", order_by="desc(ItemRevision.date_created)")


### PR DESCRIPTION
Long SNS topic names will exceed the 285 character limit of the name
field. The prefix appears to be up to 40 character long in addition to
the 255 char name field for a total of 295 characters. An example
SNS prefix is "arn:aws:sns:ap-northeast-1:123456789012:".