### PR TITLE
Added url encoding to distinct callout in search_bar_component

### DIFF
--- a/dart/lib/component/search_bar_component/search_bar_component.dart
+++ b/dart/lib/component/search_bar_component/search_bar_component.dart
@@ -128,6 +128,7 @@ class SearchBarComponent {
         if (param_value == null) {
             param_value = "";
         }
+        param_value = Uri.encodeComponent(param_value);
         return "$param_url_name=$param_value";
     }
 }


### PR DESCRIPTION
Fixes issue #163 

Tested with an account name with a "+" in it. This encodes that as %2B.