### PR TITLE
Set folder for jinja templates relative to module instead of running path

### DIFF
--- a/security_monkey/common/jinja.py
+++ b/security_monkey/common/jinja.py
@@ -30,8 +30,7 @@ def get_jinja_env():
     """
     Returns a Jinja environment with a FileSystemLoader for our templates
     """
-    directory = os.path.abspath('security_monkey')
-    templates_directory = os.path.join(directory, templates)
+    templates_directory = os.path.abspath(os.path.join(__file__, '..', '..', templates))
     jinja_environment = jinja2.Environment(loader=jinja2.FileSystemLoader(templates_directory))
     #jinja_environment.filters['dateformat'] = dateformat
     return jinja_environment


### PR DESCRIPTION
I noticed that the daily emails were not being sent because it could not find the jinja template. This was because I was not launching the script from the same directory as manage.py.

This fix means that we search for the templates directory relative to the security_monkey.jinja module instead.