### PR TITLE
SECURITY_TEAM_EMAIL should be an array

### DIFF
--- a/scripts/secmonkey_auto_install.sh
+++ b/scripts/secmonkey_auto_install.sh
@@ -361,7 +361,7 @@ SECURITY_PASSWORD_SALT = '${SECRET_PASSWORD_SALT}'
 SECURITY_POST_LOGIN_VIEW = 'https://$name'
 
 # This address gets all change notifications
-SECURITY_TEAM_EMAIL = '$recipient'
+SECURITY_TEAM_EMAIL = ['$recipient']
 EOF
 
 }


### PR DESCRIPTION
Fix SECURITY_TEAM_EMAIL in auto_install script. If it's written as a string - and not an array - it gets split in to individual characters, causing errors sending emails.