### PR TITLE
Update quickstart.rst. Added libffi-dev to dependencies.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -237,7 +237,7 @@ Create the logging folders::
 Let's install the tools we need for Security Monkey::
 
     $ sudo apt-get update
-    $ sudo apt-get -y install python-pip python-dev python-psycopg2 postgresql postgresql-contrib libpq-dev nginx supervisor git swig python-m2crypto
+    $ sudo apt-get -y install python-pip python-dev python-psycopg2 postgresql postgresql-contrib libffi-dev libpq-dev nginx supervisor git swig python-m2crypto
 
 Setup Postgres
 --------------


### PR DESCRIPTION
Added libffi-dev to dependencies. 

"sudo python setup.py install" was failing:

x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -c _configtest.c -o _configtest.o
success!
removing: _configtest.c _configtest.o
c/_cffi_backend.c:13:17: fatal error: ffi.h: No such file or directory
 #include <ffi.h>
                 ^
compilation terminated.
error: Setup script exited with error: command 'x86_64-linux-gnu-gcc' failed with exit status 1