### PR TITLE
Added exception handling around S3 buckets

### DIFF
--- a/security_monkey/watchers/s3.py
+++ b/security_monkey/watchers/s3.py
@@ -176,7 +176,7 @@ class S3(Watcher):
                     bucket_dict = self.conv_bucket_to_dict(bhandle, account, region, bucket.name, exception_map)
                 except Exception as e:
                     exc = S3PermissionsIssue(bucket.name)
-                    self.slurp_exception((self.index, account, region, bucket_name), exc, exception_map)
+                    self.slurp_exception((self.index, account, region, bucket.name), exc, exception_map)
                     continue
 
                 item = S3Item(account=account, region=region, name=bucket.name, config=bucket_dict)

--- a/security_monkey/watchers/s3.py
+++ b/security_monkey/watchers/s3.py
@@ -172,7 +172,12 @@ class S3(Watcher):
                     continue
 
                 app.logger.debug("Slurping %s (%s) from %s/%s" % (self.i_am_singular, bucket.name, account, region))
-                bucket_dict = self.conv_bucket_to_dict(bhandle, account, region, bucket.name, exception_map)
+                try:
+                    bucket_dict = self.conv_bucket_to_dict(bhandle, account, region, bucket.name, exception_map)
+                except Exception as e:
+                    exc = S3PermissionsIssue(bucket.name)
+                    self.slurp_exception((self.index, account, region, bucket_name), exc, exception_map)
+                    continue
 
                 item = S3Item(account=account, region=region, name=bucket.name, config=bucket_dict)
                 item_list.append(item)


### PR DESCRIPTION
The permissions required for the get_acl call are different than getting the object (s3:GetObjectAcl vs s3GetObject). If these permissions are missing, the call will raise an uncaught exception and crash the watcher/reporter.