### PR TITLE
Adding Egress rules to Security Group Watcher

### DIFF
--- a/security_monkey/watchers/security_group.py
+++ b/security_monkey/watchers/security_group.py
@@ -146,6 +146,19 @@ class SecurityGroup(Watcher):
                                 "owner_id": grant.owner_id
                             }
                             item_config['rules'].append(rule_config)
+
+                    for rule in sg.rules_egress:
+                        for grant in rule.grants:
+                            rule_config = {
+                                "ip_protocol": rule.ip_protocol,
+                                "from_port": rule.from_port,
+                                "to_port": rule.to_port,
+                                "cidr_ip": grant.cidr_ip,
+                                "group_id": grant.group_id,
+                                "name": grant.name,
+                                "owner_id": grant.owner_id
+                            }
+                            item_config['rules'].append(rule_config)
                     item_config['rules'] = sorted(item_config['rules'])
 
                     if self.get_detail_level() == 'SUMMARY':

--- a/security_monkey/watchers/security_group.py
+++ b/security_monkey/watchers/security_group.py
@@ -138,6 +138,7 @@ class SecurityGroup(Watcher):
                         for grant in rule.grants:
                             rule_config = {
                                 "ip_protocol": rule.ip_protocol,
+                                "rule_type": "ingress",
                                 "from_port": rule.from_port,
                                 "to_port": rule.to_port,
                                 "cidr_ip": grant.cidr_ip,
@@ -151,6 +152,7 @@ class SecurityGroup(Watcher):
                         for grant in rule.grants:
                             rule_config = {
                                 "ip_protocol": rule.ip_protocol,
+                                "rule_type": "egress",
                                 "from_port": rule.from_port,
                                 "to_port": rule.to_port,
                                 "cidr_ip": grant.cidr_ip,


### PR DESCRIPTION
It appears that the current watcher code for security groups does not include Egress rules.. this is a separate object within the boto call. This adds in the other object of the same form, rules_egress.
