### PR TITLE
Added ELB, RDS, and Redshift to security groups assigned_to field

### DIFF
--- a/security_monkey/watchers/security_group.py
+++ b/security_monkey/watchers/security_group.py
@@ -230,7 +230,8 @@ class SecurityGroup(Watcher):
                     item_config['rules'] = sorted(item_config['rules'])
 
                     if self.get_detail_level() == 'SUMMARY':
-                        num_inst = len(sg_instances.get(sg.id, [])) + len(sg_rds_instances.get(sg.id, [])) + len(sg_redshift_instances.get(sg.id, []))
+                        num_inst = (len(sg_instances.get(sg.id, [])) + len(sg_rds_instances.get(sg.id, [])) + 
+                                    len(sg_redshift_instances.get(sg.id, [])) + len(sg_elb_instances.get(sg.id, [])))
                         if sg.id in sg_instances:
                             item_config["assigned_to"] = "{} instances".format(num_inst)
                         else:


### PR DESCRIPTION
Adds ELB, RDS and Redshift to items that can be assigned a security group. This list may not be exhaustive of all technologies which could be associated with an SG.

The retrieval code is copied verbatim from the other watchers, so there is room for refactoring here. Of course, retrieving everything only once would be ideal.

I think this also needs modifications to work with non-vpc security groups.
