### PR TITLE
Adding special exception handling around bucket.get_location. Removed…

### DIFF
--- a/security_monkey/watchers/s3.py
+++ b/security_monkey/watchers/s3.py
@@ -141,13 +141,16 @@ class S3(Watcher):
                 try:
                     loc = self.wrap_aws_rate_limited_call(bucket.get_location)
                     region = self.translate_location_to_region(loc)
-                    if region == '':
-                        s3regionconn = self.wrap_aws_rate_limited_call(
-                            connect,
-                            account,
-                            's3',
-                            calling_format=OrdinaryCallingFormat()
-                        )
+                except Exception as e:
+                    exc = S3PermissionsIssue(bucket.name)
+                    # If we can't get the region, default to us-east-1 so we can fillout
+                    # the exception map.  Otherwise, none of the S3 buckets in this account will be monitored.
+                    self.slurp_exception((self.index, account, 'us-east-1', bucket.name), exc, exception_map)
+                    continue
+
+                try:
+                    if not region:
+                        s3regionconn = s3conn
                         region = 'us-east-1'
                     else:
                         s3regionconn = self.wrap_aws_rate_limited_call(
@@ -163,11 +166,8 @@ class S3(Watcher):
                         bucket,
                         validate=False
                     )
-                    s3regionconn.close()
                 except Exception as e:
                     exc = S3PermissionsIssue(bucket.name)
-                    # Unfortunately, we can't get the region, so the entire account
-                    # will be skipped in find_changes, not just the bad bucket.
                     self.slurp_exception((self.index, account), exc, exception_map)
                     continue
 


### PR DESCRIPTION
… redundant sts conn call. Removed conn.close()

It's possible to have an S3 bucket with permissions so messed up that you cannot call bucket.get_location() without throwing an exception.

Unfortunately, security_monkey will skip all other S3 buckets in the given account.  This PR patches the situation so only the bad bucket is ignored by security_monkey.

Future work should focus on displaying buckets with bad permissions up to the web UI.