### PR TITLE
Refactoring _check_rfc_1918 and improving VPC ELB Internet Accessible…

### DIFF
--- a/security_monkey/auditors/elb.py
+++ b/security_monkey/auditors/elb.py
@@ -21,7 +21,11 @@
 """
 from security_monkey.watchers.elb import ELB
 from security_monkey.auditor import Auditor
+from security_monkey.auditors.security_group import _check_rfc_1918
+from security_monkey.datastore import NetworkWhitelistEntry
+from security_monkey.datastore import Item
 
+import ipaddr
 
 # From https://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-security-policy-table.html
 DEPRECATED_CIPHERS = [
@@ -113,17 +117,50 @@ class ELBAuditor(Auditor):
     index = ELB.index
     i_am_singular = ELB.i_am_singular
     i_am_plural = ELB.i_am_plural
+    network_whitelist = []
 
     def __init__(self, accounts=None, debug=False):
         super(ELBAuditor, self).__init__(accounts=accounts, debug=debug)
+
+    def prep_for_audit(self):
+        self.network_whitelist = NetworkWhitelistEntry.query.all()
+
+    def _check_inclusion_in_network_whitelist(self, cidr):
+        for entry in self.network_whitelist:
+            if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork(str(entry.cidr)):
+                return True
+        return False
 
     def check_internet_scheme(self, elb_item):
         """
         alert when an ELB has an "internet-facing" scheme.
         """
         scheme = elb_item.config.get('scheme', None)
-        if scheme and scheme == u"internet-facing":
+        vpc = elb_item.config.get('vpc_id', None)
+        if scheme and scheme == u"internet-facing" and not vpc:
             self.add_issue(1, 'ELB is Internet accessible.', elb_item)
+        elif scheme and scheme == u"internet-facing" and vpc:
+            # Grab each attached security group and determine if they contain
+            # a public IP
+            security_groups = elb_item.config.get('security_groups', [])
+            for sgid in security_groups:
+                # shouldn't be more than one with that ID.
+                sg = Item.query.filter(Item.name.ilike('%'+sgid+'%')).first()
+                if not sg:
+                    # It's possible that the security group is new and not yet in the DB.
+                    continue
+
+                config = sg.revisions[0].config
+                for rule in config.get('rules', []):
+                    cidr = rule.get('cidr_ip', '')
+                    if rule.get('rule_type', None) == 'ingress' and cidr:
+                        if not _check_rfc_1918(cidr) and not self._check_inclusion_in_network_whitelist(cidr):
+                            notes = 'SG [{sgname}] via [{cidr}]'.format(
+                                sgname=sg.name,
+                                cidr=cidr
+                            )
+                            self.add_issue(1, 'VPC ELB is Internet accessible.', elb_item, notes=notes)
+                            return
 
     def check_listener_reference_policy(self, elb_item):
         """

--- a/security_monkey/auditors/rds_security_group.py
+++ b/security_monkey/auditors/rds_security_group.py
@@ -22,6 +22,8 @@
 from security_monkey.auditor import Auditor
 from security_monkey.watchers.rds_security_group import RDSSecurityGroup
 from security_monkey.datastore import NetworkWhitelistEntry
+from security_monkey.auditors.security_group import _check_rfc_1918
+
 import ipaddr
 
 class RDSSecurityGroupAuditor(Auditor):
@@ -42,21 +44,6 @@ class RDSSecurityGroupAuditor(Auditor):
                 return True
         return False
 
-    def _check_rfc_1918(self, cidr):
-        """
-        Non VPC RDS SG's should never use RFC-1918 CIDRs
-        """
-        if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork('10.0.0.0/8'):
-            return True
-
-        if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork('172.16.0.0/12'):
-            return True
-
-        if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork('192.168.0.0/16'):
-            return True
-
-        return False
-
     def check_rds_ec2_rfc1918(self, sg_item):
         """
         alert if non-vpc RDS SG contains RFC1918 CIDRS
@@ -69,7 +56,7 @@ class RDSSecurityGroupAuditor(Auditor):
 
         for ipr in sg_item.config.get("ip_ranges", []):
             cidr = ipr.get("cidr_ip", None)
-            if cidr and self._check_rfc_1918(cidr):
+            if cidr and _check_rfc_1918(cidr):
                 self.add_issue(severity, tag, sg_item, notes=cidr)
 
     def check_securitygroup_large_subnet(self, sg_item):


### PR DESCRIPTION
The ELB watcher use to flag any ELB with an "internet-facing" scheme as being Internet Accessible.

Now, it will flag an ELB as Internet Accessible if it matches this criteria:
1) It's an EC2-classic ELB.
2) It's a VPC ELB, with an "internet-facing" scheme, and attached to a security group that contains an ingress CIDR rule where the CIDR is not an RFC-1918 CIDR and is not included in a security_monkey NetworkWhitelist entry.