### PR TITLE
Seed Amazon owned AWS accounts

### DIFF
--- a/data/aws_accounts.json
+++ b/data/aws_accounts.json
@@ -1,0 +1,116 @@
+{
+    "CloudTrail Logs": [
+        {
+            "region": "ap-northeast-1",
+            "account_id": "216624486486"
+        },
+        {
+            "region": "ap-southeast-1",
+            "account_id": "903692715234"
+        },
+        {
+            "region": "ap-southeast-2",
+            "account_id": "284668455005"
+        },
+        {
+            "region": "eu-central-1",
+            "account_id": "035351147821"
+        },
+        {
+            "region": "eu-west-1",
+            "account_id": "859597730677"
+        },
+        {
+            "region": "sa-east-1",
+            "account_id": "814480443879"
+        },
+        {
+            "region": "us-east-1",
+            "account_id": "086441151436"
+        },
+        {
+            "region": "us-west-1",
+            "account_id": "388731089494"
+        },
+        {
+            "region": "us-west-2",
+            "account_id": "113285607260"
+        }
+    ],
+    "ELB Logs": [
+        {
+            "region": "us-east-1",
+            "account_id": "127311923021"
+        },
+        {
+            "region": "us-west-1",
+            "account_id": "027434742980"
+        },
+        {
+            "region": "us-west-2",
+            "account_id": "797873946194"
+        },
+        {
+            "region": "eu-west-1",
+            "account_id": "156460612806"
+        },
+        {
+            "region": "eu-central-1",
+            "account_id": "054676820928"
+        },
+        {
+            "region": "ap-northeast-1",
+            "account_id": "582318560864"
+        },
+        {
+            "region": "ap-southeast-1",
+            "account_id": "114774131450"
+        },
+        {
+            "region": "ap-southeast-2",
+            "account_id": "783225319266"
+        },
+        {
+            "region": "sa-east-1",
+            "account_id": "507241528517"
+        },
+        {
+            "region": "us-gov-west-1",
+            "account_id": "048591011584"
+        },
+        {
+            "region": "cn-north-1",
+            "account_id": "638102146993"
+        }
+    ],
+    "RedShift Logs": [
+        {
+            "region": "us-east-1",
+            "account_id": "193672423079"
+        },
+        {
+            "region": "us-west-2",
+            "account_id": "902366379725"
+        },
+        {
+            "region": "eu-central-1",
+            "account_id": "53454850223"
+        },
+        {
+            "region": "eu-west-1",
+            "account_id": "210876761215"
+        },
+        {
+            "region": "ap-northeast-1",
+            "account_id": "404641285394"
+        },
+        {
+            "region": "ap-southeast-1",
+            "account_id": "361669875840"
+        },
+        {
+            "region": "ap-southeast-2",
+            "account_id": "762762565011"
+        }
+    ]
+}

--- a/data/aws_accounts.json
+++ b/data/aws_accounts.json
@@ -1,116 +1,125 @@
 {
-    "CloudTrail Logs": [
-        {
-            "region": "ap-northeast-1",
-            "account_id": "216624486486"
-        },
-        {
-            "region": "ap-southeast-1",
-            "account_id": "903692715234"
-        },
-        {
-            "region": "ap-southeast-2",
-            "account_id": "284668455005"
-        },
-        {
-            "region": "eu-central-1",
-            "account_id": "035351147821"
-        },
-        {
-            "region": "eu-west-1",
-            "account_id": "859597730677"
-        },
-        {
-            "region": "sa-east-1",
-            "account_id": "814480443879"
-        },
-        {
-            "region": "us-east-1",
-            "account_id": "086441151436"
-        },
-        {
-            "region": "us-west-1",
-            "account_id": "388731089494"
-        },
-        {
-            "region": "us-west-2",
-            "account_id": "113285607260"
-        }
-    ],
-    "ELB Logs": [
-        {
-            "region": "us-east-1",
-            "account_id": "127311923021"
-        },
-        {
-            "region": "us-west-1",
-            "account_id": "027434742980"
-        },
-        {
-            "region": "us-west-2",
-            "account_id": "797873946194"
-        },
-        {
-            "region": "eu-west-1",
-            "account_id": "156460612806"
-        },
-        {
-            "region": "eu-central-1",
-            "account_id": "054676820928"
-        },
-        {
-            "region": "ap-northeast-1",
-            "account_id": "582318560864"
-        },
-        {
-            "region": "ap-southeast-1",
-            "account_id": "114774131450"
-        },
-        {
-            "region": "ap-southeast-2",
-            "account_id": "783225319266"
-        },
-        {
-            "region": "sa-east-1",
-            "account_id": "507241528517"
-        },
-        {
-            "region": "us-gov-west-1",
-            "account_id": "048591011584"
-        },
-        {
-            "region": "cn-north-1",
-            "account_id": "638102146993"
-        }
-    ],
-    "RedShift Logs": [
-        {
-            "region": "us-east-1",
-            "account_id": "193672423079"
-        },
-        {
-            "region": "us-west-2",
-            "account_id": "902366379725"
-        },
-        {
-            "region": "eu-central-1",
-            "account_id": "53454850223"
-        },
-        {
-            "region": "eu-west-1",
-            "account_id": "210876761215"
-        },
-        {
-            "region": "ap-northeast-1",
-            "account_id": "404641285394"
-        },
-        {
-            "region": "ap-southeast-1",
-            "account_id": "361669875840"
-        },
-        {
-            "region": "ap-southeast-2",
-            "account_id": "762762565011"
-        }
-    ]
+    "CloudTrail Logs": {
+        "url": "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-supported-regions.html",
+        "accounts": [
+            {
+                "region": "ap-northeast-1",
+                "account_id": "216624486486"
+            },
+            {
+                "region": "ap-southeast-1",
+                "account_id": "903692715234"
+            },
+            {
+                "region": "ap-southeast-2",
+                "account_id": "284668455005"
+            },
+            {
+                "region": "eu-central-1",
+                "account_id": "035351147821"
+            },
+            {
+                "region": "eu-west-1",
+                "account_id": "859597730677"
+            },
+            {
+                "region": "sa-east-1",
+                "account_id": "814480443879"
+            },
+            {
+                "region": "us-east-1",
+                "account_id": "086441151436"
+            },
+            {
+                "region": "us-west-1",
+                "account_id": "388731089494"
+            },
+            {
+                "region": "us-west-2",
+                "account_id": "113285607260"
+            }
+        ]
+    },
+    "ELB Logs": {
+        "url": "http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-access-logs.html",
+        "accounts": [
+            {
+                "region": "us-east-1",
+                "account_id": "127311923021"
+            },
+            {
+                "region": "us-west-1",
+                "account_id": "027434742980"
+            },
+            {
+                "region": "us-west-2",
+                "account_id": "797873946194"
+            },
+            {
+                "region": "eu-west-1",
+                "account_id": "156460612806"
+            },
+            {
+                "region": "eu-central-1",
+                "account_id": "054676820928"
+            },
+            {
+                "region": "ap-northeast-1",
+                "account_id": "582318560864"
+            },
+            {
+                "region": "ap-southeast-1",
+                "account_id": "114774131450"
+            },
+            {
+                "region": "ap-southeast-2",
+                "account_id": "783225319266"
+            },
+            {
+                "region": "sa-east-1",
+                "account_id": "507241528517"
+            },
+            {
+                "region": "us-gov-west-1",
+                "account_id": "048591011584"
+            },
+            {
+                "region": "cn-north-1",
+                "account_id": "638102146993"
+            }
+        ]
+    },
+    "RedShift Logs": {
+        "url": "http://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html",
+        "accounts": [
+            {
+                "region": "us-east-1",
+                "account_id": "193672423079"
+            },
+            {
+                "region": "us-west-2",
+                "account_id": "902366379725"
+            },
+            {
+                "region": "eu-central-1",
+                "account_id": "53454850223"
+            },
+            {
+                "region": "eu-west-1",
+                "account_id": "210876761215"
+            },
+            {
+                "region": "ap-northeast-1",
+                "account_id": "404641285394"
+            },
+            {
+                "region": "ap-southeast-1",
+                "account_id": "361669875840"
+            },
+            {
+                "region": "ap-southeast-2",
+                "account_id": "762762565011"
+            }
+        ]
+    }
 }

--- a/manage.py
+++ b/manage.py
@@ -95,8 +95,8 @@ def amazon_accounts():
 
     app.logger.info('Adding / updating Amazon owned accounts')
     try:
-        for group, accounts in data.items():
-            for aws_account in accounts:
+        for group, info in data.items():
+            for aws_account in info['accounts']:
                 acct_name = "{group} ({region})".format(group=group, region=aws_account['region'])
                 account = Account.query.filter(Account.number == aws_account['account_id']).first()
                 if not account:
@@ -109,6 +109,7 @@ def amazon_accounts():
                 account.active = False
                 account.third_party = True
                 account.name = acct_name
+                account.notes = info['url']
 
                 db.session.add(account)
 

--- a/manage.py
+++ b/manage.py
@@ -44,7 +44,7 @@ def run_change_reporter(accounts):
 @manager.option('-a', '--accounts', dest='accounts', type=unicode, default=u'all')
 @manager.option('-m', '--monitors', dest='monitors', type=unicode, default=u'all')
 def find_changes(accounts, monitors):
-    """Runs watchers"""
+    """ Runs watchers """
     sm_find_changes(accounts, monitors)
 
 
@@ -60,25 +60,62 @@ def audit_changes(accounts, monitors, send_report):
 @manager.option('-m', '--monitors', dest='monitors', type=unicode, default=u'all')
 @manager.option('-o', '--outputfolder', dest='outputfolder', type=unicode, default=u'backups')
 def backup_config_to_json(accounts, monitors, outputfolder):
-    """Saves the most current item revisions to a json file."""
+    """ Saves the most current item revisions to a json file. """
     sm_backup_config_to_json(accounts, monitors, outputfolder)
 
 
 @manager.command
 def start_scheduler():
-    """ starts the python scheduler to run the watchers and auditors"""
+    """ Starts the python scheduler to run the watchers and auditors """
     from security_monkey import scheduler
     scheduler.setup_scheduler()
     scheduler.scheduler.start()
 
+
 @manager.command
 def sync_jira():
+    """ Syncs issues with Jira """
     from security_monkey import jirasync
     if jirasync:
         app.logger.info('Syncing issues with Jira')
         jirasync.sync_issues()
     else:
         app.logger.info('Jira sync not configured. Is SECURITY_MONKEY_JIRA_SYNC set?')
+
+
+@manager.command
+def amazon_accounts():
+    """ Pre-populates standard AWS owned accounts """
+    import os
+    import json
+    from security_monkey.datastore import Account
+
+    data_file = os.path.join(os.path.dirname(__file__), "data", "aws_accounts.json")
+    data = json.load(open(data_file, 'r'))
+
+    app.logger.info('Adding / updating Amazon owned accounts')
+    try:
+        for group, accounts in data.items():
+            for aws_account in accounts:
+                acct_name = "{group} ({region})".format(group=group, region=aws_account['region'])
+                account = Account.query.filter(Account.number == aws_account['account_id']).first()
+                if not account:
+                    app.logger.debug('    Adding account {0}'.format(acct_name))
+                    account = Account()
+                else:
+                    app.logger.debug('    Updating account {0}'.format(acct_name))
+
+                account.number = aws_account['account_id']
+                account.active = False
+                account.third_party = True
+                account.name = acct_name
+
+                db.session.add(account)
+
+        db.session.commit()
+        app.logger.info('Finished adding Amazon owned accounts')
+    except Exception:
+        app.logger.exception("An error occured while adding accounts")
 
 @manager.option('-u', '--number', dest='number', type=unicode, required=True)
 @manager.option('-a', '--active', dest='active', type=bool, default=True)


### PR DESCRIPTION
Fix for #169. Imports known Amazon owned AWS accounts as third-party accounts. Also did a bit of formatting cleanup, making the formatting consistent