### PR TITLE
Updating docs/scripts to pin to dart 1.12.2-1

### DIFF
--- a/docs/dev_setup_ubuntu.rst
+++ b/docs/dev_setup_ubuntu.rst
@@ -141,7 +141,12 @@ We prefer the WebStorm IDE for developing with Dart: https://www.jetbrains.com/w
 
   sudo apt-get install default-jre default-jdk
 
-In addition to WebStorm, you will also need to have the Dart SDK installed.  Please download and install the Dart SDK from: https://www.dartlang.org/downloads/linux.html, and follow the installation instructions. 
+In addition to WebStorm, you will also need to have the Dart SDK installed.  Please download and install the Dart SDK (<=1.12.2-1) ::
+
+    sudo curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+    sudo curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list
+    sudo apt-get update
+    sudo apt-get install dart=1.12.2-1
 
 **Note:** You will need to install Dartium as well.  This requires extra steps and is unfortunately not available as a Debian package.  Dartium is packaged as a .zip file in the section "Installing from a zip file" on the Dart download page.  Download the Dartium zip file, and follow the following instructions:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -310,7 +310,7 @@ Next we'll clone and install the package::
     $ curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > dart_stable.list
     $ sudo mv dart_stable.list /etc/apt/sources.list.d/dart_stable.list
     $ sudo apt-get update
-    $ sudo apt-get install -y dart
+    $ sudo apt-get install -y dart=1.12.2-1
 
     # Build the Web UI
     $ cd /usr/local/src/security_monkey/dart

--- a/scripts/secmonkey_auto_install.sh
+++ b/scripts/secmonkey_auto_install.sh
@@ -38,6 +38,7 @@
 #       0.5.1 :: 2015/08/24-25   :: Typos, ownership & SECURITY_TEAM_EMAIL should be an array.
 #       0.5.2 :: 2015/09/01      :: Update for v0.3.8. Add dart support. Some cleanup.
 #       0.5.3 :: 2015/10/13      :: Created error and echo_usage functions for simplification.
+#       0.5.4 :: 2015/11/20      :: Pinned dart to dart=1.12.2-1
 #
 # To Do :: 
 #         Fix bug with password containing !
@@ -75,7 +76,7 @@ CLI switches -
               -w  >> Site (Domain) be used for the self-signed certificate
     "
 
-VERSION="0.5.3"
+VERSION="0.5.4"
 ARGS=$#
 
 err_code=10
@@ -559,7 +560,7 @@ build_static ()
     curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > dart_stable.list
     sudo mv dart_stable.list /etc/apt/sources.list.d/dart_stable.list
     sudo apt-get update
-    sudo apt-get install -y dart
+    sudo apt-get install -y dart=1.12.2-1
 
     cd /apps/security_monkey/dart
     /usr/lib/dart/bin/pub get


### PR DESCRIPTION
security_monkey does not build in dart 1.13.  Temporarily we are pinning to 1.12.2-1

Related to #259