### PR TITLE
Fix indentation mistake

### DIFF
--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -59,8 +59,7 @@ class Auditor(object):
 
         for account in self.accounts:
             users = User.query.filter(User.daily_audit_email==True).filter(User.accounts.any(name=account)).all()
-
-        self.emails.extend([user.email for user in users])
+            self.emails.extend([user.email for user in users])
 
     def add_issue(self, score, issue, item, notes=None):
         """


### PR DESCRIPTION
Found this while tracking down another bug.
I suspect this has been masked by the scheduler only passing in one account at a time and python "leaking" variables out of for loops.

Not a big issue but could cause unexpected behavior.