### PR TITLE
Added the ElasticSearch Watcher and Auditor (with tests).

### DIFF
--- a/security_monkey/auditors/elasticsearch_service.py
+++ b/security_monkey/auditors/elasticsearch_service.py
@@ -1,0 +1,181 @@
+#     Copyright 2015 Netflix, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.auditors.elb
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  Mike Grima <mgrima@netflix.com>
+
+"""
+from security_monkey.auditor import Auditor
+from security_monkey.common.arn import ARN
+from security_monkey.datastore import NetworkWhitelistEntry
+from security_monkey.watchers.elasticsearch_service import ElasticSearchService
+
+import ipaddr
+
+
+class ElasticSearchServiceAuditor(Auditor):
+    index = ElasticSearchService.index
+    i_am_singular = ElasticSearchService.i_am_singular
+    i_am_plural = ElasticSearchService.i_am_plural
+
+    def __init__(self, accounts=None, debug=False):
+        super(ElasticSearchServiceAuditor, self).__init__(accounts=accounts, debug=debug)
+
+    def prep_for_audit(self):
+        self.network_whitelist = NetworkWhitelistEntry.query.all()
+
+    def _parse_arn(self, arn_input, account_numbers, es_domain):
+        if arn_input == '*':
+            notes = "An ElasticSearch Service domain policy where { 'Principal': { 'AWS': '*' } } must also have"
+            notes += " a {'Condition': {'IpAddress': { 'AWS:SourceIp': '<ARN>' } } }"
+            notes += " or it is open to any AWS account."
+            self.add_issue(20, 'ES cluster open to all AWS accounts', es_domain, notes=notes)
+            return
+
+        arn = ARN(arn_input)
+        if arn.error:
+            self.add_issue(3, 'Auditor could not parse ARN', es_domain, notes=arn_input)
+            return
+
+        if arn.tech == 's3':
+            notes = "The ElasticSearch Service domain allows access from S3 bucket [{}]. ".format(arn.name)
+            notes += "Security Monkey does not yet have the capability to determine if this is "
+            notes += "a friendly S3 bucket.  Please verify manually."
+            self.add_issue(3, 'ES cluster allows access from S3 bucket', es_domain, notes=notes)
+        else:
+            account_numbers.append(arn.account_number)
+
+    def check_es_access_policy(self, es_domain):
+        policy = es_domain.config["policy"]
+
+        for statement in policy.get("Statement", []):
+            effect = statement.get("Effect")
+            # We only care about "Allows"
+            if effect.lower() == "deny":
+                continue
+
+            account_numbers = []
+            princ = statement.get("Principal", {})
+            if isinstance(princ, dict):
+                princ_aws = princ.get("AWS", "error")
+            else:
+                princ_aws = princ
+
+            if princ_aws == "*":
+                condition = statement.get('Condition', {})
+
+                # Get the IpAddress subcondition:
+                ip_addr_condition = condition.get("IpAddress")
+
+                if ip_addr_condition:
+                    source_ip_condition = ip_addr_condition.get("aws:SourceIp")
+
+                if not ip_addr_condition or not source_ip_condition:
+                    tag = "ElasticSearch Service domain open to everyone"
+                    notes = "An ElasticSearch Service domain policy where { 'Principal': { '*' } } OR"
+                    notes += " { 'Principal': { 'AWS': '*' } } must also have a"
+                    notes += " {'Condition': {'IpAddress': { 'AWS:SourceIp': '<ARN>' } } }"
+                    notes += " or it is open to the world. In this case, anyone is allowed to perform "
+                    notes += " this action(s): {}".format(statement.get("Action"))
+                    self.add_issue(20, tag, es_domain, notes=notes)
+
+                else:
+                    # Check for "aws:SourceIp" as a condition:
+                    if isinstance(source_ip_condition, list):
+                        for cidr in source_ip_condition:
+                            self._check_proper_cidr(cidr, es_domain, statement.get("Action"))
+
+                    else:
+                        self._check_proper_cidr(source_ip_condition, es_domain, statement.get("Action"))
+
+            else:
+                if isinstance(princ_aws, list):
+                    for entry in princ_aws:
+                        arn = ARN(entry)
+                        if arn.error:
+                            self.add_issue(3, 'Auditor could not parse ARN', es_domain, notes=entry)
+                            continue
+
+                        if arn.root:
+                            message = "ALL IAM Roles/users/groups in account can perform the following actions:\n"
+                            message += "{}".format(statement.get("Action"))
+                            self.add_issue(3, message, es_domain, notes="Root IAM ARN")
+
+                        account_numbers.append(arn.account_number)
+                else:
+                    arn = ARN(princ_aws)
+                    if arn.error:
+                        self.add_issue(3, 'Auditor could not parse ARN', es_domain, notes=princ_aws)
+                    else:
+                        if arn.root:
+                            message = "ALL IAM Roles/users/groups in account can perform the following actions:\n"
+                            message += "{}".format(statement.get("Action"))
+                            self.add_issue(3, message, es_domain, notes="Root IAM ARN")
+
+                        account_numbers.append(arn.account_number)
+
+            for account_number in account_numbers:
+                self._check_cross_account(account_number, es_domain, 'policy')
+
+    def _check_proper_cidr(self, cidr, es_domain, actions):
+        try:
+            any, ip_cidr = self._check_for_any_ip(cidr, es_domain, actions)
+            if any:
+                return
+
+            if not self._check_inclusion_in_network_whitelist(cidr):
+                message = "A CIDR that is not in the whitelist has access to this ElasticSearch Service domain:\n"
+                message += "CIDR: {}, Actions: {}".format(cidr, actions)
+                self.add_issue(5, message, es_domain, notes=cidr)
+
+                # Check if the CIDR is in a large subnet (and not whitelisted):
+                # Check if it's 10.0.0.0/8
+                if ip_cidr == ipaddr.IPNetwork("10.0.0.0/8"):
+                    message = "aws:SourceIp Condition contains a very large IP range: 10.0.0.0/8"
+                    self.add_issue(7, message, es_domain, notes=cidr)
+                else:
+                    mask = int(ip_cidr.exploded.split('/')[1])
+                    if 0 < mask < 24:
+                        message = "aws:SourceIp contains a large IP Range: {}".format(cidr)
+                        self.add_issue(3, message, es_domain, notes=cidr)
+
+
+        except ValueError as ve:
+            self.add_issue(3, 'Auditor could not parse CIDR', es_domain, notes=cidr)
+
+    def _check_for_any_ip(self, cidr, es_domain, actions):
+        if cidr == '*':
+            self.add_issue(20, 'Any IP can perform the following actions against this ElasticSearch Service '
+                               'domain:\n{}'.format(actions),
+                           es_domain, notes=cidr)
+            return True, None
+
+        zero = ipaddr.IPNetwork("0.0.0.0/0")
+        ip_cidr = ipaddr.IPNetwork(cidr)
+        if zero == ip_cidr:
+            self.add_issue(20, 'Any IP can perform the following actions against this ElasticSearch Service '
+                               'domain:\n{}'.format(actions),
+                           es_domain, notes=cidr)
+            return True, None
+
+        return False, ip_cidr
+
+    def _check_inclusion_in_network_whitelist(self, cidr):
+        for entry in self.network_whitelist:
+            if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork(str(entry.cidr)):
+                return True
+        return False

--- a/security_monkey/common/arn.py
+++ b/security_monkey/common/arn.py
@@ -31,10 +31,14 @@ class ARN(object):
     name = None
     partition = None
     error = False
+    root = False
 
     def __init__(self, input):
         arn_match = re.search('^arn:([^:]*):([^:]*):([^:]*):(|[\d]{12}):(.+)$', input)
         if arn_match:
+            if arn_match.group(2) == "iam" and arn_match.group(5) == "root":
+                self.root = True
+
             return self._from_arn(arn_match, input)
 
         acct_number_match = re.search('^(\d{12})+$', input)

--- a/security_monkey/common/sts_connect.py
+++ b/security_monkey/common/sts_connect.py
@@ -24,6 +24,7 @@ import botocore.session
 import boto3
 import boto
 
+
 def connect(account_name, connection_type, **args):
     """
 
@@ -74,6 +75,16 @@ def connect(account_name, connection_type, **args):
         region = args.pop('region')
         if hasattr(region, 'name'):
             region = region.name
+
+    # ElasticSearch Service:
+    if connection_type == 'es':
+        session = boto3.Session(
+            aws_access_key_id=role.credentials.access_key,
+            aws_secret_access_key=role.credentials.secret_key,
+            aws_session_token=role.credentials.session_token,
+            region_name=region
+        )
+        return session.client('es')
 
     module = __import__("boto.{}".format(connection_type))
     for subm in connection_type.split('.'):

--- a/security_monkey/monitors.py
+++ b/security_monkey/monitors.py
@@ -40,6 +40,8 @@ from security_monkey.auditors.ses import SESAuditor
 from security_monkey.watchers.vpc.vpc import VPC
 from security_monkey.watchers.vpc.subnet import Subnet
 from security_monkey.watchers.vpc.route_table import RouteTable
+from security_monkey.watchers.elasticsearch_service import ElasticSearchService
+from security_monkey.auditors.elasticsearch_service import ElasticSearchServiceAuditor
 
 
 class Monitor(object):
@@ -89,7 +91,9 @@ __MONITORS = {
     RouteTable.index:
         Monitor(RouteTable.index, RouteTable, None),
     ManagedPolicy.index:
-        Monitor(ManagedPolicy.index, ManagedPolicy, ManagedPolicyAuditor)
+        Monitor(ManagedPolicy.index, ManagedPolicy, ManagedPolicyAuditor),
+    ElasticSearchService.index:
+        Monitor(ElasticSearchService.index, ElasticSearchService, ElasticSearchServiceAuditor)
 }
 
 

--- a/security_monkey/tests/test_arn.py
+++ b/security_monkey/tests/test_arn.py
@@ -11,6 +11,14 @@
 #     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
+"""
+.. module: security_monkey.tests.test_arn
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  Mike Grima <mgrima@netflix.com>
+
+"""
 from security_monkey.common.arn import ARN
 from security_monkey.tests import SecurityMonkeyTestCase
 from security_monkey import app
@@ -39,6 +47,10 @@ class ARNTestCase(SecurityMonkeyTestCase):
             arn_obj = ARN(arn)
 
             self.assertFalse(arn_obj.error)
+            if "root" in arn:
+                self.assertTrue(arn_obj.root)
+            else:
+                self.assertFalse(arn_obj.root)
 
         bad_arns = [
             'arn:aws:iam::012345678910',

--- a/security_monkey/tests/test_elasticsearch_service.py
+++ b/security_monkey/tests/test_elasticsearch_service.py
@@ -1,0 +1,333 @@
+#     Copyright 2014 Netflix, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.tests.test_elasticsearch_service
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  Mike Grima <mgrima@netflix.com>
+
+"""
+import json
+
+from security_monkey.datastore import NetworkWhitelistEntry
+from security_monkey.tests import SecurityMonkeyTestCase
+
+# TODO: Make a ES test for spulec/moto, then make test cases that use it.
+from security_monkey.watchers.elasticsearch_service import ElasticSearchServiceItem
+
+CONFIG_ONE = {
+    "name": "es_test",
+    "policy": json.loads(b"""{
+        "Statement": [
+            {
+                "Action": "es:*",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Resource": "arn:aws:es:us-east-1:012345678910:domain/es_test/*",
+                "Sid": ""
+            }
+        ],
+        "Version": "2012-10-17"
+      }
+    """)
+}
+
+CONFIG_TWO = {
+    "name": "es_test_2",
+    "policy": json.loads(b"""{
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "es:*",
+          "Resource": "arn:aws:es:us-west-2:012345678910:domain/es_test_2/*"
+        }
+      ]
+    }
+    """)
+}
+
+CONFIG_THREE = {
+    "name": "es_test_3",
+    "policy": json.loads(b"""{
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::012345678910:root"
+          },
+          "Action": "es:*",
+          "Resource": "arn:aws:es:eu-west-1:012345678910:domain/es_test_3/*"
+        },
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "es:ESHttp*",
+          "Resource": "arn:aws:es:eu-west-1:012345678910:domain/es_test_3/*",
+          "Condition": {
+            "IpAddress": {
+              "aws:SourceIp": [
+                "192.168.1.1/32",
+                "10.0.0.1/8"
+              ]
+            }
+          }
+        }
+      ]
+    }
+    """)
+}
+
+CONFIG_FOUR = {
+    "name": "es_test_4",
+    "policy": json.loads(b"""{
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::012345678910:root"
+          },
+          "Action": "es:*",
+          "Resource": "arn:aws:es:us-east-1:012345678910:domain/es_test_4/*"
+        },
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "es:ESHttp*",
+          "Resource": "arn:aws:es:us-east-1:012345678910:domain/es_test_4/*",
+          "Condition": {
+            "IpAddress": {
+              "aws:SourceIp": [
+                "0.0.0.0/0"
+              ]
+            }
+          }
+        }
+      ]
+    }
+    """)
+}
+
+CONFIG_FIVE = {
+    "name": "es_test_5",
+    "policy": json.loads(b"""{
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::012345678910:root"
+          },
+          "Action": "es:*",
+          "Resource": "arn:aws:es:us-east-1:012345678910:domain/es_test_5/*"
+        },
+        {
+          "Sid": "",
+          "Effect": "Deny",
+          "Principal": {
+            "AWS": "arn:aws:iam::012345678910:role/not_this_role"
+          },
+          "Action": "es:*",
+          "Resource": "arn:aws:es:us-east-1:012345678910:domain/es_test_5/*"
+        }
+      ]
+    }
+    """)
+}
+
+CONFIG_SIX = {
+    "name": "es_test_6",
+    "policy": json.loads(b"""{
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::012345678910:role/a_good_role"
+          },
+          "Action": "es:*",
+          "Resource": "arn:aws:es:eu-west-1:012345678910:domain/es_test_6/*"
+        },
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "es:ESHttp*",
+          "Resource": "arn:aws:es:eu-west-1:012345678910:domain/es_test_6/*",
+          "Condition": {
+            "IpAddress": {
+              "aws:SourceIp": [
+                "192.168.1.1/32",
+                "100.0.0.1/16"
+              ]
+            }
+          }
+        }
+      ]
+    }
+    """)
+}
+
+CONFIG_SEVEN = {
+    "name": "es_test_7",
+    "policy": json.loads(b"""{
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::012345678910:role/a_good_role"
+          },
+          "Action": "es:*",
+          "Resource": "arn:aws:es:eu-west-1:012345678910:domain/es_test_7/*"
+        },
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "es:ESHttp*",
+          "Resource": "arn:aws:es:eu-west-1:012345678910:domain/es_test_7/*",
+          "Condition": {
+            "IpAddress": {
+              "aws:SourceIp": [
+                "192.168.1.200/32",
+                "10.0.0.1/8"
+              ]
+            }
+          }
+        }
+      ]
+    }
+    """)
+}
+
+CONFIG_EIGHT = {
+    "name": "es_test_8",
+    "policy": json.loads(b"""{
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "*"
+          },
+          "Action": "es:*",
+          "Resource": "arn:aws:es:eu-west-1:012345678910:domain/es_test_8/*"
+        },
+        {
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "es:ESHttp*",
+          "Resource": "arn:aws:es:eu-west-1:012345678910:domain/es_test_8/*",
+          "Condition": {
+            "IpAddress": {
+              "aws:SourceIp": [
+                "192.168.1.1/32",
+                "100.0.0.1/16"
+              ]
+            }
+          }
+        }
+      ]
+    }
+    """)
+}
+
+WHITELIST_CIDRS = [
+    ("Test one", "192.168.1.1/32"),
+    ("Test two", "100.0.0.1/16"),
+]
+
+
+class ElasticSearchServiceTestCase(SecurityMonkeyTestCase):
+    def setUp(self):
+        self.es_items = [
+            ElasticSearchServiceItem(region="us-east-1", account="012345678910", name="es_test", config=CONFIG_ONE),
+            ElasticSearchServiceItem(region="us-west-2", account="012345678910", name="es_test_2", config=CONFIG_TWO),
+            ElasticSearchServiceItem(region="eu-west-1", account="012345678910", name="es_test_3", config=CONFIG_THREE),
+            ElasticSearchServiceItem(region="us-east-1", account="012345678910", name="es_test_4", config=CONFIG_FOUR),
+            ElasticSearchServiceItem(region="us-east-1", account="012345678910", name="es_test_5", config=CONFIG_FIVE),
+            ElasticSearchServiceItem(region="eu-west-1", account="012345678910", name="es_test_6", config=CONFIG_SIX),
+            ElasticSearchServiceItem(region="eu-west-1", account="012345678910", name="es_test_7", config=CONFIG_SEVEN),
+            ElasticSearchServiceItem(region="eu-west-1", account="012345678910", name="es_test_8", config=CONFIG_EIGHT),
+        ]
+
+    def test_es_auditor(self):
+        from security_monkey.auditors.elasticsearch_service import ElasticSearchServiceAuditor
+        es_auditor = ElasticSearchServiceAuditor(accounts=["012345678910"])
+
+        # Add some test network whitelists into this:
+        es_auditor.network_whitelist = []
+        for cidr in WHITELIST_CIDRS:
+            whitelist_cidr = NetworkWhitelistEntry()
+            whitelist_cidr.cidr = cidr[1]
+            whitelist_cidr.name = cidr[0]
+
+            es_auditor.network_whitelist.append(whitelist_cidr)
+
+        for es_domain in self.es_items:
+            es_auditor.check_es_access_policy(es_domain)
+
+        # Check for correct number of issues located:
+        # CONFIG ONE:
+        self.assertEquals(len(self.es_items[0].audit_issues), 1)
+        self.assertEquals(self.es_items[0].audit_issues[0].score, 20)
+
+        # CONFIG TWO:
+        self.assertEquals(len(self.es_items[1].audit_issues), 1)
+        self.assertEquals(self.es_items[1].audit_issues[0].score, 20)
+
+        # CONFIG THREE:
+        self.assertEquals(len(self.es_items[2].audit_issues), 3)
+        self.assertEquals(self.es_items[2].audit_issues[0].score, 3)
+        self.assertEquals(self.es_items[2].audit_issues[1].score, 5)
+        self.assertEquals(self.es_items[2].audit_issues[2].score, 7)
+
+        # CONFIG FOUR:
+        self.assertEquals(len(self.es_items[3].audit_issues), 2)
+        self.assertEquals(self.es_items[3].audit_issues[0].score, 3)
+        self.assertEquals(self.es_items[3].audit_issues[1].score, 20)
+
+        # CONFIG FIVE:
+        self.assertEquals(len(self.es_items[4].audit_issues), 1)
+        self.assertEquals(self.es_items[4].audit_issues[0].score, 3)
+
+        # CONFIG SIX:
+        self.assertEquals(len(self.es_items[5].audit_issues), 0)
+
+        # CONFIG SEVEN:
+        self.assertEquals(len(self.es_items[6].audit_issues), 3)
+        self.assertEquals(self.es_items[6].audit_issues[0].score, 5)
+        self.assertEquals(self.es_items[6].audit_issues[1].score, 5)
+        self.assertEquals(self.es_items[6].audit_issues[2].score, 7)
+
+        # CONFIG EIGHT:
+        self.assertEquals(len(self.es_items[7].audit_issues), 1)
+        self.assertEquals(self.es_items[7].audit_issues[0].score, 20)

--- a/security_monkey/watchers/elasticsearch_service.py
+++ b/security_monkey/watchers/elasticsearch_service.py
@@ -1,0 +1,109 @@
+#     Copyright 2015 Netflix, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.watchers.keypair
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Mike Grima <mgrima@netflix.com>
+
+"""
+import json
+
+from security_monkey.constants import TROUBLE_REGIONS
+from security_monkey.exceptions import BotoConnectionIssue
+from security_monkey.watcher import Watcher, ChangeItem
+from security_monkey import app
+
+from boto.ec2 import regions
+
+
+class ElasticSearchService(Watcher):
+    index = 'elasticsearchservice'
+    i_am_singular = 'ElasticSearch Service Access Policy'
+    i_am_singular = 'ElasticSearch Service Access Policies'
+
+    def __init__(self, accounts=None, debug=False):
+        super(ElasticSearchService, self).__init__(accounts=accounts, debug=debug)
+
+    def slurp(self):
+        """
+        :returns: item_list - list of ElasticSearchService Items
+        :return:  exception_map - A dict where the keys are a tuple containing the
+            location of the exception and the value is the actual exception
+
+        """
+        self.prep_for_slurp()
+
+        item_list = []
+        exception_map = {}
+        for account in self.accounts:
+            for region in regions():
+                try:
+                    if region.name in TROUBLE_REGIONS:
+                        continue
+
+                    (client, domains) = self.get_all_es_domains_in_region(account, region)
+                except Exception as e:
+                    if region.name not in TROUBLE_REGIONS:
+                        exc = BotoConnectionIssue(str(e), 'es', account, region.name)
+                        self.slurp_exception((self.index, account, region.name), exc, exception_map)
+                    continue
+
+                app.logger.debug("Found {} {}".format(len(domains), ElasticSearchService.i_am_plural))
+                for domain in domains:
+                    if self.check_ignore_list(domain["DomainName"]):
+                        continue
+
+                    # Fetch the policy:
+                    item = self.build_item(domain["DomainName"], client, region.name, account, exception_map)
+                    if item:
+                        item_list.append(item)
+
+        return item_list, exception_map
+
+    def get_all_es_domains_in_region(self, account, region):
+        from security_monkey.common.sts_connect import connect
+        client = connect(account, "es", region=region)
+        app.logger.debug("Checking {}/{}/{}".format(ElasticSearchService.index, account, region.name))
+        # No need to paginate according to: client.can_paginate("list_domain_names")
+        domains = self.wrap_aws_rate_limited_call(client.list_domain_names)["DomainNames"]
+
+        return client, domains
+
+    def build_item(self, domain, client, region, account, exception_map):
+        config = {}
+
+        try:
+            domain_config = self.wrap_aws_rate_limited_call(client.describe_elasticsearch_domain_config,
+                                                            DomainName=domain)
+            config['policy'] = json.loads(domain_config["DomainConfig"]["AccessPolicies"]["Options"])
+            config['name'] = domain
+
+        except Exception as e:
+            self.slurp_exception((domain, client, region), e, exception_map)
+            return None
+
+        return ElasticSearchServiceItem(region=region, account=account, name=domain, config=config)
+
+
+class ElasticSearchServiceItem(ChangeItem):
+    def __init__(self, region=None, account=None, name=None, config={}):
+        super(ElasticSearchServiceItem, self).__init__(
+                index=ElasticSearchService.index,
+                region=region,
+                account=account,
+                name=name,
+                new_config=config
+        )


### PR DESCRIPTION
This implements and closes out #253.

Allows you to audit AWS ElasticSearch Service domains in your AWS accounts.

This also adds in a feature to the ARN class that allows it to audit IAM ARN's where a `root` account is provided. This is helpful for future audit tweaks.