### PR TITLE
Fixed cross-account root reporting for ES service

### DIFF
--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -296,3 +296,19 @@ class Auditor(object):
         elif account_name != dest_item.account and account.third_party:
             tag = "Friendly Third Party Cross Account Access"
             self.add_issue(0, tag, dest_item, notes=notes)
+
+    def _check_cross_account_root(self, source_item, dest_arn, actions):
+        if not actions:
+            return None
+
+        account = Account.query.filter(Account.name == source_item.account).first()
+        source_item_account_number = account.number
+
+        if source_item_account_number == dest_arn.account_number:
+            return None
+
+        tag = "Cross-Account Root IAM"
+        notes = "ALL IAM Roles/users/groups in account {} can perform the following actions:\n"\
+            .format(dest_arn.account_number)
+        notes += "{}".format(actions)
+        self.add_issue(6, tag, source_item, notes=notes)

--- a/security_monkey/auditors/elasticsearch_service.py
+++ b/security_monkey/auditors/elasticsearch_service.py
@@ -111,9 +111,7 @@ class ElasticSearchServiceAuditor(Auditor):
                             continue
 
                         if arn.root:
-                            message = "ALL IAM Roles/users/groups in account can perform the following actions:\n"
-                            message += "{}".format(statement.get("Action"))
-                            self.add_issue(3, message, es_domain, notes="Root IAM ARN")
+                            self._check_cross_account_root(es_domain, arn, statement.get("Action"))
 
                         account_numbers.append(arn.account_number)
                 else:
@@ -122,9 +120,7 @@ class ElasticSearchServiceAuditor(Auditor):
                         self.add_issue(3, 'Auditor could not parse ARN', es_domain, notes=princ_aws)
                     else:
                         if arn.root:
-                            message = "ALL IAM Roles/users/groups in account can perform the following actions:\n"
-                            message += "{}".format(statement.get("Action"))
-                            self.add_issue(3, message, es_domain, notes="Root IAM ARN")
+                            self._check_cross_account_root(es_domain, arn, statement.get("Action"))
 
                         account_numbers.append(arn.account_number)
 

--- a/security_monkey/watchers/elasticsearch_service.py
+++ b/security_monkey/watchers/elasticsearch_service.py
@@ -32,7 +32,7 @@ from boto.ec2 import regions
 class ElasticSearchService(Watcher):
     index = 'elasticsearchservice'
     i_am_singular = 'ElasticSearch Service Access Policy'
-    i_am_singular = 'ElasticSearch Service Access Policies'
+    i_am_plural = 'ElasticSearch Service Access Policies'
 
     def __init__(self, accounts=None, debug=False):
         super(ElasticSearchService, self).__init__(accounts=accounts, debug=debug)


### PR DESCRIPTION
- Fixed `i_am_plural` bug in the watcher.
- Added auditor check for Cross-Account Root
- Adjusted ES tests for cross-account checks.

Addresses #283 