### PR TITLE
Persist custom role names on account creation

### DIFF
--- a/security_monkey/views/account.py
+++ b/security_monkey/views/account.py
@@ -274,6 +274,7 @@ class AccountPostList(AuthenticatedService):
         account.s3_name = args.get('s3_name', args['name'])
         account.number = args['number']
         account.notes = args['notes']
+        account.role_name = args['role_name']
         account.active = args['active']
         account.third_party = args['third_party']
 


### PR DESCRIPTION
Currently, custom role names are sent but not persisted on account creation. Setting a custom role name works only when updating an account. This updates the POST handler for /api/1/account/<id> to properly save role_name on new accounts.