### PR TITLE
Tentative for a fix for #148

### DIFF
--- a/security_monkey/watchers/iam/managed_policy.py
+++ b/security_monkey/watchers/iam/managed_policy.py
@@ -64,6 +64,9 @@ class ManagedPolicy(Watcher):
                 if self.check_ignore_list(policy.policy_name):
                     continue
 
+                if self.check_ignore_list(policy.arn):
+                    continue
+
                 item_config = {
                     'name': policy.policy_name,
                     'arn': policy.arn,


### PR DESCRIPTION
By calling the filter twice, we can have the ignorelist filtering
both by name AND by arn.
To ignore AWS default policies, enter the following in 'prefix':
arn:aws:iam::aws:policy/
It can be a fix for #148 .