### PR TITLE
Tune itemrevision retrievals

### DIFF
--- a/migrations/versions/6b9d673d8e30_added_index_for_itemrevision_created.py
+++ b/migrations/versions/6b9d673d8e30_added_index_for_itemrevision_created.py
@@ -1,0 +1,22 @@
+"""Added index for itemrevision created_date
+
+Revision ID: 6b9d673d8e30
+Revises: 1727fb4309d8
+Create Date: 2016-04-01 09:39:35.148502
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '6b9d673d8e30'
+down_revision = '1727fb4309d8'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index('ix_itemrevision_date_created', 'itemrevision', ['date_created'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ix_itemrevision_date_created', table_name='itemrevision')

--- a/security_monkey/datastore.py
+++ b/security_monkey/datastore.py
@@ -152,7 +152,7 @@ class Item(db.Model):
     name = Column(String(285))  # Max AWS name = 255 chars.  Add 30 chars for ' (sg-xxxxxxxx in vpc-xxxxxxxx)'
     tech_id = Column(Integer, ForeignKey("technology.id"), nullable=False)
     account_id = Column(Integer, ForeignKey("account.id"), nullable=False)
-    revisions = relationship("ItemRevision", backref="item", cascade="all, delete, delete-orphan", order_by="desc(ItemRevision.date_created)")
+    revisions = relationship("ItemRevision", backref="item", cascade="all, delete, delete-orphan", order_by="desc(ItemRevision.date_created)", lazy="dynamic")
     issues = relationship("ItemAudit", backref="item", cascade="all, delete, delete-orphan")
     latest_revision_id = Column(Integer, nullable=True)
     comments = relationship("ItemComment", backref="revision", cascade="all, delete, delete-orphan", order_by="ItemComment.date_created")
@@ -307,7 +307,7 @@ class Datastore(object):
         self._set_latest_revision(item)
 
     def _set_latest_revision(self, item):
-        latest_revision = ItemRevision.query.filter(ItemRevision.item_id == item.id).order_by(ItemRevision.date_created.desc()).first()
+        latest_revision = item.revisions.first()
         item.latest_revision_id = latest_revision.id
         db.session.add(item)
         db.session.commit()

--- a/security_monkey/datastore.py
+++ b/security_monkey/datastore.py
@@ -152,7 +152,7 @@ class Item(db.Model):
     name = Column(String(285))  # Max AWS name = 255 chars.  Add 30 chars for ' (sg-xxxxxxxx in vpc-xxxxxxxx)'
     tech_id = Column(Integer, ForeignKey("technology.id"), nullable=False)
     account_id = Column(Integer, ForeignKey("account.id"), nullable=False)
-    revisions = relationship("ItemRevision", backref="item", cascade="all, delete, delete-orphan", order_by="desc(ItemRevision.date_created)", lazy="dynamic")
+    revisions = relationship("ItemRevision", backref="item", cascade="all, delete, delete-orphan", order_by="desc(ItemRevision.date_created)")
     issues = relationship("ItemAudit", backref="item", cascade="all, delete, delete-orphan")
     latest_revision_id = Column(Integer, nullable=True)
     comments = relationship("ItemComment", backref="revision", cascade="all, delete, delete-orphan", order_by="ItemComment.date_created")
@@ -307,7 +307,7 @@ class Datastore(object):
         self._set_latest_revision(item)
 
     def _set_latest_revision(self, item):
-        latest_revision = item.revisions.first()
+        latest_revision = ItemRevision.query.filter(ItemRevision.item_id == item.id).order_by(ItemRevision.date_created.desc()).first()
         item.latest_revision_id = latest_revision.id
         db.session.add(item)
         db.session.commit()

--- a/security_monkey/datastore.py
+++ b/security_monkey/datastore.py
@@ -178,7 +178,7 @@ class ItemRevision(db.Model):
     id = Column(Integer, primary_key=True)
     active = Column(Boolean())
     config = deferred(Column(JSON))
-    date_created = Column(DateTime(), default=datetime.datetime.utcnow, nullable=False)
+    date_created = Column(DateTime(), default=datetime.datetime.utcnow, nullable=False, index=True)
     item_id = Column(Integer, ForeignKey("item.id"), nullable=False)
     comments = relationship("ItemRevisionComment", backref="revision", cascade="all, delete, delete-orphan", order_by="ItemRevisionComment.date_created")
 


### PR DESCRIPTION
This fixes CPU utilisation issues we were having with our RDS DB. We are only running with 6 technologies and 19 rules but we have over 100 accounts being monitored and lots of changes. We had an m3.large database running at 100% CPU.

By tuning the queries/logic to only return what we need and by adding an index on the date_created field the database CPU now hovers between 2 and 4%. I think I can resize to a smaller DB instance now :)