### PR TITLE
Feature/issue 153 access keys last used

### DIFF
--- a/security_monkey/auditors/iam/iam_user.py
+++ b/security_monkey/auditors/iam/iam_user.py
@@ -71,6 +71,20 @@ class IAMUserAuditor(IAMPolicyAuditor):
                         notes = "> 90 days ago"
                         self.add_issue(1, 'Active accesskey has not been rotated.', iamuser_item, notes=notes)
 
+    def check_access_key_last_used(self, iamuser_item):
+        """
+        alert if an active access key hasn't been used in 90 days
+        """
+        akeys = iamuser_item.config.get('accesskeys', {})
+        for akey in akeys.keys():
+            if u'status' in akeys[akey]:
+                if akeys[akey][u'status'] == u'Active':
+                    last_used_str = akeys[akey][u'LastUsedDate']
+                    last_used_date = parser.parse(last_used_str)
+                    if last_used_date < self.ninety_days_ago:
+                        notes = "Key: [{}] Last Used: {}".format(akey, last_used_str)
+                        self.add_issue(1, 'Active accesskey unused in last 90 days.', iamuser_item, notes=notes)
+
     def check_star_privileges(self, iamuser_item):
         """
         alert when an IAM User has a policy allowing '*'.

--- a/security_monkey/auditors/iam/iam_user.py
+++ b/security_monkey/auditors/iam/iam_user.py
@@ -79,7 +79,9 @@ class IAMUserAuditor(IAMPolicyAuditor):
         for akey in akeys.keys():
             if u'status' in akeys[akey]:
                 if akeys[akey][u'status'] == u'Active':
-                    last_used_str = akeys[akey][u'LastUsedDate']
+                    last_used_str = akeys[akey].get(u'LastUsedDate')
+                    if not last_used_str:
+                        continue
                     last_used_date = parser.parse(last_used_str)
                     if last_used_date < self.ninety_days_ago:
                         notes = "Key: [{}] Last Used: {}".format(akey, last_used_str)

--- a/security_monkey/common/sts_connect.py
+++ b/security_monkey/common/sts_connect.py
@@ -62,29 +62,24 @@ def connect(account_name, connection_type, **args):
         )
         return botocore_session
 
-    if connection_type == 'iam_boto3':
-        session = boto3.Session(
-            aws_access_key_id=role.credentials.access_key,
-            aws_secret_access_key=role.credentials.secret_key,
-            aws_session_token=role.credentials.session_token
-        )
-        return session.resource('iam')
-
     region = 'us-east-1'
-    if args.has_key('region'):
+    if 'region' in args:
         region = args.pop('region')
         if hasattr(region, 'name'):
             region = region.name
 
-    # ElasticSearch Service:
-    if connection_type == 'es':
+    if 'boto3' in connection_type:
+        # Should be called in this format: boto3.iam.client
+        _, tech, api = connection_type.split('.')
         session = boto3.Session(
             aws_access_key_id=role.credentials.access_key,
             aws_secret_access_key=role.credentials.secret_key,
             aws_session_token=role.credentials.session_token,
             region_name=region
         )
-        return session.client('es')
+        if 'api' == 'resource':
+            return session.resource(tech)
+        return session.client(tech)
 
     module = __import__("boto.{}".format(connection_type))
     for subm in connection_type.split('.'):

--- a/security_monkey/common/sts_connect.py
+++ b/security_monkey/common/sts_connect.py
@@ -77,7 +77,7 @@ def connect(account_name, connection_type, **args):
             aws_session_token=role.credentials.session_token,
             region_name=region
         )
-        if 'api' == 'resource':
+        if api == 'resource':
             return session.resource(tech)
         return session.client(tech)
 

--- a/security_monkey/watcher.py
+++ b/security_monkey/watcher.py
@@ -324,6 +324,9 @@ class Watcher(object):
 
     def is_changed(self):
         """
+        Note: It is intentional that self.ephemeral_items is not included here
+        so that emails will not go out about those changes.
+        Those changes will still be recorded in the database and visible in the UI.
         :return: boolean whether or not we've found any changes
         """
         return self.deleted_items or self.created_items or self.changed_items

--- a/security_monkey/watchers/elasticsearch_service.py
+++ b/security_monkey/watchers/elasticsearch_service.py
@@ -57,7 +57,7 @@ class ElasticSearchService(Watcher):
                     (client, domains) = self.get_all_es_domains_in_region(account, region)
                 except Exception as e:
                     if region.name not in TROUBLE_REGIONS:
-                        exc = BotoConnectionIssue(str(e), 'es', account, region.name)
+                        exc = BotoConnectionIssue(str(e), self.index, account, region.name)
                         self.slurp_exception((self.index, account, region.name), exc, exception_map)
                     continue
 
@@ -75,7 +75,7 @@ class ElasticSearchService(Watcher):
 
     def get_all_es_domains_in_region(self, account, region):
         from security_monkey.common.sts_connect import connect
-        client = connect(account, "es", region=region)
+        client = connect(account, "boto3.es.client", region=region)
         app.logger.debug("Checking {}/{}/{}".format(ElasticSearchService.index, account, region.name))
         # No need to paginate according to: client.can_paginate("list_domain_names")
         domains = self.wrap_aws_rate_limited_call(client.list_domain_names)["DomainNames"]

--- a/security_monkey/watchers/iam/iam_group.py
+++ b/security_monkey/watchers/iam/iam_group.py
@@ -127,7 +127,7 @@ class IAMGroup(Watcher):
         for account in self.accounts:
 
             try:
-                iam_b3 = connect(account, 'iam_boto3')
+                iam_b3 = connect(account, 'boto3.iam.client')
                 managed_policies = all_managed_policies(iam_b3)
 
                 iam = connect(account, 'iam')
@@ -149,7 +149,7 @@ class IAMGroup(Watcher):
                     'users': {}
                 }
 
-                if managed_policies.has_key(group.arn):
+                if group.arn in managed_policies:
                     item_config['managed_policies'] = managed_policies.get(group.arn)
 
                 ### GROUP POLICIES ###

--- a/security_monkey/watchers/iam/iam_user.py
+++ b/security_monkey/watchers/iam/iam_user.py
@@ -76,6 +76,17 @@ class IAMUser(Watcher):
         return all_policy_names
 
     def access_keys_for_user(self, conn, user):
+        """
+        :returns: list of dicts describing each of the user's access keys.
+            [
+                {
+                  "status": "Active",
+                  "create_date": "2016-01-14T21:59:37Z",
+                  "user_name": "...",
+                  "access_key_id": "AKIA..."
+                }
+            ]
+        """
         all_access_keys = []
         marker = None
         while True:
@@ -90,6 +101,44 @@ class IAMUser(Watcher):
             else:
                 break
         return all_access_keys
+
+    def access_key_last_used(self, conn, key):
+        """
+        :conn: iam boto3 connection for the appropriate account
+        :key: dict containing access_key_id:
+            {
+              "status": "Active",
+              "create_date": "2016-01-14T21:59:37Z",
+              "user_name": "...",
+              "access_key_id": "AKIA..."
+            }
+        :returns:
+            {
+                'LastUsedDate': "2016-02-20T04:59:22",
+                'ServiceName': 'string',
+                'Region': 'string',
+                "status": "Active",
+                "create_date": "2016-01-14T21:59:37Z",
+                "user_name": "...",
+                "access_key_id": "AKIA..."
+            }
+        """
+        last_used = self.wrap_aws_rate_limited_call(
+            conn.get_access_key_last_used,
+            AccessKeyId=key.access_key_id
+        )
+
+        last_used = last_used['AccessKeyLastUsed']
+
+        # Convert datetime to string so it can be serialized to JSON.
+        if 'LastUsedDate' in last_used:
+            # TODO: Determine if this needs to be cast to/from UTC
+            last_used['LastUsedDate'] = last_used['LastUsedDate'].strftime(
+                    "%Y-%m-%dT%H:%M:%S")
+
+        # Combine with the dict returned by access_keys_for_user()
+        key.update(last_used)
+        return key
 
     def mfas_for_user(self, conn, user):
         all_mfas = []
@@ -138,8 +187,10 @@ class IAMUser(Watcher):
             all_users = []
 
             try:
-                iam_b3 = connect(account, 'iam_boto3')
-                managed_policies = all_managed_policies(iam_b3)
+                boto3_iam_resource = connect(account, 'boto3.iam.resource')
+                managed_policies = all_managed_policies(boto3_iam_resource)
+
+                boto3_iam_client = connect(account, 'boto3.iam.client')
 
                 iam = connect(account, 'iam')
                 marker = None
@@ -178,7 +229,7 @@ class IAMUser(Watcher):
                 app.logger.debug("Slurping %s (%s) from %s" % (self.i_am_singular, user.user_name, account))
                 item_config['user'] = dict(user)
 
-                if managed_policies.has_key(user.arn):
+                if user.arn in managed_policies:
                     item_config['managed_policies'] = managed_policies.get(user.arn)
 
                 ### USER POLICIES ###
@@ -204,6 +255,7 @@ class IAMUser(Watcher):
                 access_keys = self.access_keys_for_user(iam, user)
 
                 for key in access_keys:
+                    key = self.access_key_last_used(boto3_iam_client, key)
                     item_config['accesskeys'][key.access_key_id] = dict(key)
 
                 ### Multi Factor Authentication Devices ###

--- a/security_monkey/watchers/iam/iam_user.py
+++ b/security_monkey/watchers/iam/iam_user.py
@@ -57,7 +57,10 @@ class IAMUser(Watcher):
     def __init__(self, accounts=None, debug=False):
         super(IAMUser, self).__init__(accounts=accounts, debug=debug)
         self.honor_ephemerals = True
-        self.ephemeral_paths = ["user$password_last_used"]
+        self.ephemeral_paths = [
+            "user$password_last_used",
+            "accesskeys$*$LastUsedDate"
+        ]
 
     def policy_names_for_user(self, conn, user):
         all_policy_names = []
@@ -134,7 +137,7 @@ class IAMUser(Watcher):
         if 'LastUsedDate' in last_used:
             # TODO: Determine if this needs to be cast to/from UTC
             last_used['LastUsedDate'] = last_used['LastUsedDate'].strftime(
-                    "%Y-%m-%dT%H:%M:%S")
+                    "%Y-%m-%dT%H:%M:%SZ")
 
         # Combine with the dict returned by access_keys_for_user()
         key.update(last_used)

--- a/security_monkey/watchers/iam/iam_user.py
+++ b/security_monkey/watchers/iam/iam_user.py
@@ -59,7 +59,9 @@ class IAMUser(Watcher):
         self.honor_ephemerals = True
         self.ephemeral_paths = [
             "user$password_last_used",
-            "accesskeys$*$LastUsedDate"
+            "accesskeys$*$LastUsedDate",
+            "accesskeys$*$Region",
+            "accesskeys$*$ServiceName"
         ]
 
     def policy_names_for_user(self, conn, user):

--- a/security_monkey/watchers/iam/managed_policy.py
+++ b/security_monkey/watchers/iam/managed_policy.py
@@ -49,7 +49,7 @@ class ManagedPolicy(Watcher):
             all_policies = []
 
             try:
-                iam = connect(account, 'iam_boto3')
+                iam = connect(account, 'boto3.iam.client')
 
                 for policy in iam.policies.all():
                     all_policies.append(policy)


### PR DESCRIPTION
IAM Users with access keys will now have new data regarding the date the access key was last accessed, the service, and the region.

This data has been added to the ephemeral section, so these changes alone will not cause an email to go out. They will, however, cause a change to be recorded in the UI.

This PR needs to be tested to see if it produces too many noisy changes.  If so, security_monkey's ephemeral handling may need to be tuned to have a setting where it can update the last item_revision instead of creating a new revision.