### PR TITLE
Adding AlexCline's route53 watcher and auditor (See PR #334)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -41,28 +41,6 @@ SES-SendEmail
     }
 
 
-SM-Route53
-
-.. code-block:: python
-    
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Action": [
-            "route53:Get*",
-            "route53:List*",
-            "route53:ChangeResourceRecordSets"
-          ],
-          "Resource": [
-            "*"
-          ]
-        }
-      ]
-    }
-
-
 STS-AssumeRole
 
 .. code-block:: python
@@ -133,6 +111,7 @@ SM-ReadOnly
                     "iam:listusers",
                     "redshift:DescribeClusters",
                     "rds:describedbsecuritygroups",
+                    "route53:gethostedzone",
                     "route53:listhostedzones",
                     "route53:listresourcerecordsets",
                     "s3:getbucketacl",
@@ -205,7 +184,7 @@ FQDN
 ----
 
 To perform redirection security monkey needs to know the FQDN you intend to use. IF R53 is enabled this FQDN will be
-automatically added to Route53 when Security Monkey starts.
+automatically added to Route53 when Security Monkey starts, assuming the SecurityMonkeyInstanceProfile has permission to do so.
 
 
 SQLACHEMY_DATABASE_URI

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -123,6 +123,7 @@ Paste in this JSON with the name "SecurityMonkeyReadOnly":
                     "iam:listusers",
                     "redshift:DescribeClusters",
                     "rds:describedbsecuritygroups",
+                    "route53:gethostedzone",
                     "route53:listhostedzones",
                     "route53:listresourcerecordsets",
                     "s3:getbucketacl",

--- a/security_monkey/auditors/elb.py
+++ b/security_monkey/auditors/elb.py
@@ -21,7 +21,7 @@
 """
 from security_monkey.watchers.elb import ELB
 from security_monkey.auditor import Auditor
-from security_monkey.auditors.security_group import _check_rfc_1918
+from security_monkey.common.utils import check_rfc_1918
 from security_monkey.datastore import NetworkWhitelistEntry
 from security_monkey.datastore import Item
 
@@ -155,7 +155,7 @@ class ELBAuditor(Auditor):
                 for rule in config.get('rules', []):
                     cidr = rule.get('cidr_ip', '')
                     if rule.get('rule_type', None) == 'ingress' and cidr:
-                        if not _check_rfc_1918(cidr) and not self._check_inclusion_in_network_whitelist(cidr):
+                        if not check_rfc_1918(cidr) and not self._check_inclusion_in_network_whitelist(cidr):
                             sg_cidrs.append(cidr)
                 if sg_cidrs:
                     notes = 'SG [{sgname}] via [{cidr}]'.format(

--- a/security_monkey/auditors/rds_security_group.py
+++ b/security_monkey/auditors/rds_security_group.py
@@ -22,7 +22,7 @@
 from security_monkey.auditor import Auditor
 from security_monkey.watchers.rds_security_group import RDSSecurityGroup
 from security_monkey.datastore import NetworkWhitelistEntry
-from security_monkey.auditors.security_group import _check_rfc_1918
+from security_monkey.common.utils import check_rfc_1918
 
 import ipaddr
 
@@ -56,7 +56,7 @@ class RDSSecurityGroupAuditor(Auditor):
 
         for ipr in sg_item.config.get("ip_ranges", []):
             cidr = ipr.get("cidr_ip", None)
-            if cidr and _check_rfc_1918(cidr):
+            if cidr and check_rfc_1918(cidr):
                 self.add_issue(severity, tag, sg_item, notes=cidr)
 
     def check_securitygroup_large_subnet(self, sg_item):

--- a/security_monkey/auditors/route53.py
+++ b/security_monkey/auditors/route53.py
@@ -1,0 +1,50 @@
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.auditors.route53
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  Alex Cline <alex.cline@gmail.com> @alex.cline
+
+"""
+from security_monkey.auditor import Auditor
+from security_monkey.watchers.route53 import Route53
+from security_monkey.common.utils import check_rfc_1918
+import re
+
+
+class Route53Auditor(Auditor):
+    index = Route53.index
+    i_am_singular = Route53.i_am_singular
+    i_am_plural = Route53.i_am_plural
+    internal_record_regex = [
+        r"^internal-"
+    ]
+
+    def __init__(self, accounts=None, debug=False):
+        super(Route53Auditor, self).__init__(accounts=accounts, debug=debug)
+
+    def check_for_public_zone_with_private_records(self, route53_item):
+        """
+        alert when a public zone has private records.
+        """
+        if not route53_item.config.get('zoneprivate'):
+            for r in route53_item.config.get('records'):
+                for regex in self.internal_record_regex:
+                    if re.match(regex, r):
+                        notes = "{}".format(",".join(route53_item.config.get('records')))
+                        self.add_issue(1, 'Route53 public zone contains private record.', route53_item, notes=notes)
+                if check_rfc_1918(r):
+                    notes = "{}".format(",".join(route53_item.config.get('records')))
+                    self.add_issue(1, 'Route53 public zone contains private record.', route53_item, notes=notes)
+

--- a/security_monkey/common/utils.py
+++ b/security_monkey/common/utils.py
@@ -26,6 +26,7 @@ from security_monkey.datastore import Account
 from flask_mail import Message
 import boto
 import traceback
+import ipaddr
 
 prims = [int, str, unicode, bool, float, type(None)]
 
@@ -97,6 +98,7 @@ def send_email(subject=None, recipients=[], html=""):
                 app.logger.warn(m)
                 app.logger.warn(traceback.format_exc())
 
+
 def add_account(number, third_party, name, s3_name, active, notes, role_name='SecurityMonkey', edit=False):
     ''' Adds an account. If one with the same number already exists, do nothing,
     unless edit is True, in which case, override the existing account. Returns True
@@ -119,3 +121,19 @@ def add_account(number, third_party, name, s3_name, active, notes, role_name='Se
     db.session.add(account)
     db.session.commit()
     return True
+
+
+def check_rfc_1918(cidr):
+        """
+        EC2-Classic SG's should never use RFC-1918 CIDRs
+        """
+        if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork('10.0.0.0/8'):
+            return True
+
+        if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork('172.16.0.0/12'):
+            return True
+
+        if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork('192.168.0.0/16'):
+            return True
+
+        return False

--- a/security_monkey/monitors.py
+++ b/security_monkey/monitors.py
@@ -35,6 +35,8 @@ from security_monkey.auditors.elb import ELBAuditor
 from security_monkey.watchers.redshift import Redshift
 from security_monkey.auditors.redshift import RedshiftAuditor
 from security_monkey.watchers.elastic_ip import ElasticIP
+from security_monkey.watchers.route53 import Route53
+from security_monkey.auditors.route53 import Route53Auditor
 from security_monkey.watchers.ses import SES
 from security_monkey.auditors.ses import SESAuditor
 from security_monkey.watchers.vpc.vpc import VPC
@@ -80,6 +82,8 @@ __MONITORS = {
         Monitor(SNS.index, SNS, SNSAuditor),
     Redshift.index:
         Monitor(Redshift.index, Redshift, RedshiftAuditor),
+    Route53.index:
+        Monitor(Route53.index, Route53, Route53Auditor),
     ElasticIP.index:
         Monitor(ElasticIP.index, ElasticIP, None),
     SES.index:

--- a/security_monkey/watchers/route53.py
+++ b/security_monkey/watchers/route53.py
@@ -1,0 +1,117 @@
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.watchers.route53
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Alex Cline <alex.cline@gmail.com> @alex.cline
+
+"""
+
+from security_monkey.watcher import Watcher
+from security_monkey.watcher import ChangeItem
+from security_monkey.constants import TROUBLE_REGIONS
+from security_monkey.exceptions import BotoConnectionIssue
+from security_monkey import app
+
+
+class Route53(Watcher):
+    index = 'route53'
+    i_am_singular = 'Route53 Zone'
+    i_am_plural = 'Route53 Zones'
+    i_have_singular = 'Record Set'
+    i_have_plural = 'Record Sets'
+
+    def __init__(self, accounts=None, debug=False):
+        super(Route53, self).__init__(accounts=accounts, debug=debug)
+
+    def record_sets_for_zone(self, conn, zone):
+        all_record_sets = []
+        marker = None
+        while True:
+            response = self.wrap_aws_rate_limited_call(
+                conn.get_all_rrsets,
+                zone
+            )
+            all_record_sets.extend(response)
+            if response.is_truncated != u'true':
+                break
+        return all_record_sets
+
+    def slurp(self):
+        """
+        :returns: item_list - list of Route53 zones.
+        :returns: exception_map - A dict where the keys are a tuple containing the
+            location of the exception and the value is the actual exception
+
+        """
+        self.prep_for_slurp()
+        from security_monkey.common.sts_connect import connect
+        item_list = []
+        exception_map = {}
+        for account in self.accounts:
+
+            app.logger.debug("Checking {}/{}".format(self.index, account, 'universal'))
+            all_zones = []
+
+            try:
+                route53 = connect(account, 'route53')
+
+                zones = self.wrap_aws_rate_limited_call(
+                    route53.get_zones
+                )
+
+            except Exception as e:
+                exc = BotoConnectionIssue(str(e), self.index, account, None)
+                self.slurp_exception((self.index, account, 'universal'), exc, exception_map)
+                continue
+            app.logger.debug("Found {} {}.".format(len(zones), self.i_am_plural))
+
+            for zone in zones:
+                if self.check_ignore_list(zone):
+                    continue
+
+                zone_info = self.wrap_aws_rate_limited_call(
+                    route53.get_hosted_zone,
+                    zone.id
+                )
+                record_sets = self.record_sets_for_zone(route53, zone.id)
+
+                app.logger.debug("Slurped %s %s within %s %s (%s) from %s" %
+                    (len(record_sets), self.i_have_plural, self.i_am_singular, zone.name, zone.id, account))
+
+                for record in record_sets:
+                    config = {
+                        'zonename': zone.name,
+                        'zoneid':   zone.id,
+                        'zoneprivate': zone_info['GetHostedZoneResponse']['HostedZone']['Config']['PrivateZone'] == 'true',
+                        'name':     record.name.decode('unicode-escape'),
+                        'type':     record.type,
+                        'records':  record.resource_records,
+                        'ttl':      record.ttl,
+                    }
+
+                    item = Route53Record(account=account, name=record.name, config=dict(config))
+                    item_list.append(item)
+
+        return item_list, exception_map
+
+
+class Route53Record(ChangeItem):
+    def __init__(self, account=None, name=None, config={}):
+        super(Route53Record, self).__init__(
+            index=Route53.index,
+            region='universal',
+            account=account,
+            name=name,
+            new_config=config)


### PR DESCRIPTION
Adding AlexCline's route53 watcher and auditor (See PR #334) and updating docs to include route53:gethostedzone.

Initial PR (#334) was made against master.  As this change requires a new permission for the security_monkey role, I wanted to merge it into develop so the permission change can be included in the release notes of the next release.