### PR TITLE
Feature/route53 botor (PR #340 + botor)

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -111,7 +111,6 @@ SM-ReadOnly
                     "iam:listusers",
                     "redshift:DescribeClusters",
                     "rds:describedbsecuritygroups",
-                    "route53:gethostedzone",
                     "route53:listhostedzones",
                     "route53:listresourcerecordsets",
                     "s3:getbucketacl",

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -41,28 +41,6 @@ SES-SendEmail
     }
 
 
-SM-Route53
-
-.. code-block:: python
-    
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Effect": "Allow",
-          "Action": [
-            "route53:Get*",
-            "route53:List*",
-            "route53:ChangeResourceRecordSets"
-          ],
-          "Resource": [
-            "*"
-          ]
-        }
-      ]
-    }
-
-
 STS-AssumeRole
 
 .. code-block:: python
@@ -133,6 +111,7 @@ SM-ReadOnly
                     "iam:listusers",
                     "redshift:DescribeClusters",
                     "rds:describedbsecuritygroups",
+                    "route53:gethostedzone",
                     "route53:listhostedzones",
                     "route53:listresourcerecordsets",
                     "s3:getbucketacl",
@@ -205,7 +184,7 @@ FQDN
 ----
 
 To perform redirection security monkey needs to know the FQDN you intend to use. IF R53 is enabled this FQDN will be
-automatically added to Route53 when Security Monkey starts.
+automatically added to Route53 when Security Monkey starts, assuming the SecurityMonkeyInstanceProfile has permission to do so.
 
 
 SQLACHEMY_DATABASE_URI

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -123,6 +123,7 @@ Paste in this JSON with the name "SecurityMonkeyReadOnly":
                     "iam:listusers",
                     "redshift:DescribeClusters",
                     "rds:describedbsecuritygroups",
+                    "route53:gethostedzone",
                     "route53:listhostedzones",
                     "route53:listresourcerecordsets",
                     "s3:getbucketacl",

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -123,7 +123,6 @@ Paste in this JSON with the name "SecurityMonkeyReadOnly":
                     "iam:listusers",
                     "redshift:DescribeClusters",
                     "rds:describedbsecuritygroups",
-                    "route53:gethostedzone",
                     "route53:listhostedzones",
                     "route53:listresourcerecordsets",
                     "s3:getbucketacl",

--- a/security_monkey/auditors/elb.py
+++ b/security_monkey/auditors/elb.py
@@ -21,7 +21,7 @@
 """
 from security_monkey.watchers.elb import ELB
 from security_monkey.auditor import Auditor
-from security_monkey.auditors.security_group import _check_rfc_1918
+from security_monkey.common.utils import check_rfc_1918
 from security_monkey.datastore import NetworkWhitelistEntry
 from security_monkey.datastore import Item
 
@@ -155,7 +155,7 @@ class ELBAuditor(Auditor):
                 for rule in config.get('rules', []):
                     cidr = rule.get('cidr_ip', '')
                     if rule.get('rule_type', None) == 'ingress' and cidr:
-                        if not _check_rfc_1918(cidr) and not self._check_inclusion_in_network_whitelist(cidr):
+                        if not check_rfc_1918(cidr) and not self._check_inclusion_in_network_whitelist(cidr):
                             sg_cidrs.append(cidr)
                 if sg_cidrs:
                     notes = 'SG [{sgname}] via [{cidr}]'.format(

--- a/security_monkey/auditors/rds_security_group.py
+++ b/security_monkey/auditors/rds_security_group.py
@@ -22,7 +22,7 @@
 from security_monkey.auditor import Auditor
 from security_monkey.watchers.rds_security_group import RDSSecurityGroup
 from security_monkey.datastore import NetworkWhitelistEntry
-from security_monkey.auditors.security_group import _check_rfc_1918
+from security_monkey.common.utils import check_rfc_1918
 
 import ipaddr
 
@@ -56,7 +56,7 @@ class RDSSecurityGroupAuditor(Auditor):
 
         for ipr in sg_item.config.get("ip_ranges", []):
             cidr = ipr.get("cidr_ip", None)
-            if cidr and _check_rfc_1918(cidr):
+            if cidr and check_rfc_1918(cidr):
                 self.add_issue(severity, tag, sg_item, notes=cidr)
 
     def check_securitygroup_large_subnet(self, sg_item):

--- a/security_monkey/auditors/route53.py
+++ b/security_monkey/auditors/route53.py
@@ -1,0 +1,50 @@
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.auditors.route53
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  Alex Cline <alex.cline@gmail.com> @alex.cline
+
+"""
+from security_monkey.auditor import Auditor
+from security_monkey.watchers.route53 import Route53
+from security_monkey.common.utils import check_rfc_1918
+import re
+
+
+class Route53Auditor(Auditor):
+    index = Route53.index
+    i_am_singular = Route53.i_am_singular
+    i_am_plural = Route53.i_am_plural
+    internal_record_regex = [
+        r"^internal-"
+    ]
+
+    def __init__(self, accounts=None, debug=False):
+        super(Route53Auditor, self).__init__(accounts=accounts, debug=debug)
+
+    def check_for_public_zone_with_private_records(self, route53_item):
+        """
+        alert when a public zone has private records.
+        """
+        if not route53_item.config.get('zoneprivate'):
+            for r in route53_item.config.get('records'):
+                for regex in self.internal_record_regex:
+                    if re.match(regex, r):
+                        notes = "{}".format(",".join(route53_item.config.get('records')))
+                        self.add_issue(1, 'Route53 public zone contains private record.', route53_item, notes=notes)
+                if check_rfc_1918(r):
+                    notes = "{}".format(",".join(route53_item.config.get('records')))
+                    self.add_issue(1, 'Route53 public zone contains private record.', route53_item, notes=notes)
+

--- a/security_monkey/auditors/route53.py
+++ b/security_monkey/auditors/route53.py
@@ -41,10 +41,14 @@ class Route53Auditor(Auditor):
         if not route53_item.config.get('zoneprivate'):
             for r in route53_item.config.get('records'):
                 for regex in self.internal_record_regex:
-                    if re.match(regex, r):
-                        notes = "{}".format(",".join(route53_item.config.get('records')))
+                    if re.match(regex, str(r)):
+                        notes = ", ".join(route53_item.config.get('records'))
                         self.add_issue(1, 'Route53 public zone contains private record.', route53_item, notes=notes)
-                if check_rfc_1918(r):
-                    notes = "{}".format(",".join(route53_item.config.get('records')))
-                    self.add_issue(1, 'Route53 public zone contains private record.', route53_item, notes=notes)
+                try:
+                    if check_rfc_1918(r):
+                        notes = ", ".join(route53_item.config.get('records'))
+                        self.add_issue(1, 'Route53 public zone contains private record.', route53_item, notes=notes)
+                except:
+                    # non IP's will throw an exception and that's okay.
+                    pass
 

--- a/security_monkey/common/utils.py
+++ b/security_monkey/common/utils.py
@@ -26,6 +26,7 @@ from security_monkey.datastore import Account
 from flask_mail import Message
 import boto
 import traceback
+import ipaddr
 
 prims = [int, str, unicode, bool, float, type(None)]
 
@@ -97,6 +98,7 @@ def send_email(subject=None, recipients=[], html=""):
                 app.logger.warn(m)
                 app.logger.warn(traceback.format_exc())
 
+
 def add_account(number, third_party, name, s3_name, active, notes, role_name='SecurityMonkey', edit=False):
     ''' Adds an account. If one with the same number already exists, do nothing,
     unless edit is True, in which case, override the existing account. Returns True
@@ -119,3 +121,19 @@ def add_account(number, third_party, name, s3_name, active, notes, role_name='Se
     db.session.add(account)
     db.session.commit()
     return True
+
+
+def check_rfc_1918(cidr):
+        """
+        EC2-Classic SG's should never use RFC-1918 CIDRs
+        """
+        if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork('10.0.0.0/8'):
+            return True
+
+        if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork('172.16.0.0/12'):
+            return True
+
+        if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork('192.168.0.0/16'):
+            return True
+
+        return False

--- a/security_monkey/decorators.py
+++ b/security_monkey/decorators.py
@@ -105,7 +105,7 @@ def record_exception():
     return decorator
 
 
-def iter_account_region(index=None, accounts=None, regions=None):
+def iter_account_region(index=None, accounts=None, regions=None, exception_record_region=None):
     regions = regions or ['us-east-1']
 
     def decorator(f):
@@ -122,6 +122,9 @@ def iter_account_region(index=None, accounts=None, regions=None):
                 kwargs['account_number'] = account.number
                 kwargs['region'] = region
                 kwargs['assume_role'] = account.role_name or 'SecurityMonkey'
+                kwargs['exception_map'] = {}
+                if exception_record_region:
+                    kwargs['exception_record_region'] = exception_record_region
                 itm, exc = f(*args, **kwargs)
                 item_list.extend(itm)
                 exception_map.update(exc)

--- a/security_monkey/monitors.py
+++ b/security_monkey/monitors.py
@@ -35,6 +35,8 @@ from security_monkey.auditors.elb import ELBAuditor
 from security_monkey.watchers.redshift import Redshift
 from security_monkey.auditors.redshift import RedshiftAuditor
 from security_monkey.watchers.elastic_ip import ElasticIP
+from security_monkey.watchers.route53 import Route53
+from security_monkey.auditors.route53 import Route53Auditor
 from security_monkey.watchers.ses import SES
 from security_monkey.auditors.ses import SESAuditor
 from security_monkey.watchers.vpc.vpc import VPC
@@ -80,6 +82,8 @@ __MONITORS = {
         Monitor(SNS.index, SNS, SNSAuditor),
     Redshift.index:
         Monitor(Redshift.index, Redshift, RedshiftAuditor),
+    Route53.index:
+        Monitor(Route53.index, Route53, Route53Auditor),
     ElasticIP.index:
         Monitor(ElasticIP.index, ElasticIP, None),
     SES.index:

--- a/security_monkey/watchers/iam/iam_role.py
+++ b/security_monkey/watchers/iam/iam_role.py
@@ -79,12 +79,9 @@ class IAMRole(Watcher):
     def slurp(self):
         self.prep_for_slurp()
 
-        @iter_account_region(index=self.index, accounts=self.accounts, regions=['us-east-1'])
+        @iter_account_region(index=self.index, accounts=self.accounts, regions=['us-east-1'], exception_record_region='universal')
         def slurp_items(**kwargs):
             item_list = []
-            exception_map = {}
-            kwargs['exception_map'] = exception_map
-            kwargs['exception_record_region'] = 'universal'
             roles = self.list_roles(**kwargs)
 
             roles = zip(
@@ -99,7 +96,7 @@ class IAMRole(Watcher):
                 item = IAMRoleItem(account=kwargs['account_name'], name=role[0], config=role[1])
                 item_list.append(item)
 
-            return item_list, exception_map
+            return item_list, kwargs.get('exception_map', {})
         return slurp_items()
 
 

--- a/security_monkey/watchers/route53.py
+++ b/security_monkey/watchers/route53.py
@@ -1,0 +1,117 @@
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.watchers.route53
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Alex Cline <alex.cline@gmail.com> @alex.cline
+
+"""
+
+from security_monkey.watcher import Watcher
+from security_monkey.watcher import ChangeItem
+from security_monkey.constants import TROUBLE_REGIONS
+from security_monkey.exceptions import BotoConnectionIssue
+from security_monkey import app
+
+
+class Route53(Watcher):
+    index = 'route53'
+    i_am_singular = 'Route53 Zone'
+    i_am_plural = 'Route53 Zones'
+    i_have_singular = 'Record Set'
+    i_have_plural = 'Record Sets'
+
+    def __init__(self, accounts=None, debug=False):
+        super(Route53, self).__init__(accounts=accounts, debug=debug)
+
+    def record_sets_for_zone(self, conn, zone):
+        all_record_sets = []
+        marker = None
+        while True:
+            response = self.wrap_aws_rate_limited_call(
+                conn.get_all_rrsets,
+                zone
+            )
+            all_record_sets.extend(response)
+            if response.is_truncated != u'true':
+                break
+        return all_record_sets
+
+    def slurp(self):
+        """
+        :returns: item_list - list of Route53 zones.
+        :returns: exception_map - A dict where the keys are a tuple containing the
+            location of the exception and the value is the actual exception
+
+        """
+        self.prep_for_slurp()
+        from security_monkey.common.sts_connect import connect
+        item_list = []
+        exception_map = {}
+        for account in self.accounts:
+
+            app.logger.debug("Checking {}/{}".format(self.index, account, 'universal'))
+            all_zones = []
+
+            try:
+                route53 = connect(account, 'route53')
+
+                zones = self.wrap_aws_rate_limited_call(
+                    route53.get_zones
+                )
+
+            except Exception as e:
+                exc = BotoConnectionIssue(str(e), self.index, account, None)
+                self.slurp_exception((self.index, account, 'universal'), exc, exception_map)
+                continue
+            app.logger.debug("Found {} {}.".format(len(zones), self.i_am_plural))
+
+            for zone in zones:
+                if self.check_ignore_list(zone):
+                    continue
+
+                zone_info = self.wrap_aws_rate_limited_call(
+                    route53.get_hosted_zone,
+                    zone.id
+                )
+                record_sets = self.record_sets_for_zone(route53, zone.id)
+
+                app.logger.debug("Slurped %s %s within %s %s (%s) from %s" %
+                    (len(record_sets), self.i_have_plural, self.i_am_singular, zone.name, zone.id, account))
+
+                for record in record_sets:
+                    config = {
+                        'zonename': zone.name,
+                        'zoneid':   zone.id,
+                        'zoneprivate': zone_info['GetHostedZoneResponse']['HostedZone']['Config']['PrivateZone'] == 'true',
+                        'name':     record.name.decode('unicode-escape'),
+                        'type':     record.type,
+                        'records':  record.resource_records,
+                        'ttl':      record.ttl,
+                    }
+
+                    item = Route53Record(account=account, name=record.name, config=dict(config))
+                    item_list.append(item)
+
+        return item_list, exception_map
+
+
+class Route53Record(ChangeItem):
+    def __init__(self, account=None, name=None, config={}):
+        super(Route53Record, self).__init__(
+            index=Route53.index,
+            region='universal',
+            account=account,
+            name=name,
+            new_config=config)

--- a/security_monkey/watchers/route53.py
+++ b/security_monkey/watchers/route53.py
@@ -54,12 +54,11 @@ class Route53(Watcher):
         records = record.get('ResourceRecords', [])
         records = [r.get('Value') for r in records]
 
-        # TODO: determine if we need a unicode-escape on record name
         config = {
             'zonename': zone.get('Name'),
             'zoneid':   zone.get('Id'),
             'zoneprivate': zone.get('Config', {}).get('PrivateZone', 'Unknown'),
-            'name':     record.get('Name'),
+            'name':     record.get('Name', '').decode('unicode-escape'),
             'type':     record.get('Type'),
             'records':  records,
             'ttl':      record.get('TTL'),

--- a/security_monkey/watchers/route53.py
+++ b/security_monkey/watchers/route53.py
@@ -41,11 +41,12 @@ class Route53(Watcher):
     @record_exception()
     def list_hosted_zones(self, **kwargs):
         zones = list_hosted_zones(**kwargs)
-        return [zone for zone in zones if not self.check_ignore_list(zone.get('Name'))]
+        return [zone for zone in zones if not self.check_ignore_list(zone.get('Name', ''))]
 
     @record_exception()
     def list_resource_record_sets(self, **kwargs):
-        return list_resource_record_sets(**kwargs)
+        record_sets = list_resource_record_sets(**kwargs)
+        return [record for record in record_sets if not self.check_ignore_list(record.get('Name', ''))]
 
     @record_exception()
     def process_item(self, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'dpath==1.3.2',
         'pyyaml==3.11',
         'jira==0.32',
-        'botor>=0.0.1.dev3',
+        'botor>=0.0.1.dev6',
         'joblib>=0.9.4'
     ]
 )


### PR DESCRIPTION
Similar to PR #340 (which itself replaced #334).

This PR no longer requires the `route53:gethostedzone` permission.

This uses a library called botor to wrap calls to boto3 which has connection caching and will automatically grab a new connection if the old one is getting close to expiration.

Removed `route53:gethostedzone` from the docs and finished the TODO in the new watcher.