### PR TITLE
fix sqs principal parsing bug

### DIFF
--- a/security_monkey/auditors/sqs.py
+++ b/security_monkey/auditors/sqs.py
@@ -66,7 +66,10 @@ class SQSAuditor(Auditor):
         policy = sqsitem.config
         for statement in policy.get("Statement", []):
             account_numbers = []
-            princ = statement.get("Principal", "*")
+            princ = statement.get("Principal", None)
+            if not princ:
+                # It is possible not to define a principal, AWS ignores these statements and so should we!
+                continue
             if isinstance(princ, dict):
                 princ_val = princ.get("AWS") or princ.get("Service")
             else:

--- a/security_monkey/auditors/sqs.py
+++ b/security_monkey/auditors/sqs.py
@@ -66,7 +66,7 @@ class SQSAuditor(Auditor):
         policy = sqsitem.config
         for statement in policy.get("Statement", []):
             account_numbers = []
-            princ = statement.get("Principal", {})
+            princ = statement.get("Principal", "*")
             if isinstance(princ, dict):
                 princ_val = princ.get("AWS") or princ.get("Service")
             else:


### PR DESCRIPTION
In SQS, it is possible to not have a principle in a policy.
The code currently defaults to empty dict when there is no principle, which breaks the ARN parser.
I've updated it to default to everybody (*), I'm still waiting to hear back from AWS about how they interpret policies with no principle.