### PR TITLE
Add KMS watcher and auditor

### DIFF
--- a/security_monkey/auditors/kms.py
+++ b/security_monkey/auditors/kms.py
@@ -19,7 +19,6 @@
 """
 from security_monkey.auditor import Auditor
 from security_monkey.watchers.kms import KMS
-from security_monkey.common.utils import check_rfc_1918
 import json
 
 class KMSAuditor(Auditor):

--- a/security_monkey/auditors/kms.py
+++ b/security_monkey/auditors/kms.py
@@ -1,0 +1,68 @@
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.auditors.kms
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  Alex Cline <alex.cline@gmail.com> @alex.cline
+
+"""
+from security_monkey.auditor import Auditor
+from security_monkey.watchers.kms import KMS
+from security_monkey.common.utils import check_rfc_1918
+import json
+
+class KMSAuditor(Auditor):
+    index = KMS.index
+    i_am_singular = KMS.i_am_singular
+    i_am_plural = KMS.i_am_plural
+
+    def __init__(self, accounts=None, debug=False):
+        super(KMSAuditor, self).__init__(accounts=accounts, debug=debug)
+
+    def check_for_kms_policy_with_foreign_account(self, kms_item):
+        """
+        alert when a KMS master key contains a policy giving permissions
+        to a foreign account
+        """
+        tag = '{0} contains policies with foreign account permissions.'.format(self.i_am_singular)
+        key_account_id = kms_item.config.get("AWSAccountId")
+        key_policies = kms_item.config.get("Policies")
+
+        has_issue = False
+        bad_statements = []
+
+        for policy in key_policies:
+            for statement in policy.get("Statement"):
+                if statement and statement.get("Principal"):
+                    aws_principal = statement.get("Principal").get("AWS")
+                    # A principal can either be a single ARN in a string, or an array of ARNs
+                    if isinstance(aws_principal, basestring):
+                        aws_principal = [aws_principal]
+
+                    print aws_principal
+                    for arn in aws_principal:
+                        if arn == "*":
+                            has_issue = True
+                            bad_statements.append(json.dumps(statement))
+                            continue
+
+                        statement_account_id = arn.split(":")[4]
+                        if statement_account_id != key_account_id:
+                            has_issue = True
+                            bad_statements.append(json.dumps(statement))
+
+        if has_issue:
+            notes = ", ".join(bad_statements)
+            self.add_issue(5, tag, kms_item, notes=notes)
+

--- a/security_monkey/monitors.py
+++ b/security_monkey/monitors.py
@@ -44,6 +44,8 @@ from security_monkey.watchers.vpc.subnet import Subnet
 from security_monkey.watchers.vpc.route_table import RouteTable
 from security_monkey.watchers.elasticsearch_service import ElasticSearchService
 from security_monkey.auditors.elasticsearch_service import ElasticSearchServiceAuditor
+from security_monkey.watchers.kms import KMS
+from security_monkey.auditors.kms import KMSAuditor
 
 
 class Monitor(object):
@@ -97,7 +99,9 @@ __MONITORS = {
     ManagedPolicy.index:
         Monitor(ManagedPolicy.index, ManagedPolicy, ManagedPolicyAuditor),
     ElasticSearchService.index:
-        Monitor(ElasticSearchService.index, ElasticSearchService, ElasticSearchServiceAuditor)
+        Monitor(ElasticSearchService.index, ElasticSearchService, ElasticSearchServiceAuditor),
+    KMS.index:
+        Monitor(KMS.index, KMS, KMSAuditor),
 }
 
 

--- a/security_monkey/watchers/kms.py
+++ b/security_monkey/watchers/kms.py
@@ -1,0 +1,192 @@
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.watchers.kms
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Alex Cline <alex.cline@gmail.com> @alex.cline
+
+"""
+
+from security_monkey.watcher import Watcher
+from security_monkey.watcher import ChangeItem
+from security_monkey.constants import TROUBLE_REGIONS
+from security_monkey.exceptions import BotoConnectionIssue
+from security_monkey import app
+
+from dateutil.tz import tzutc
+import json
+
+class KMS(Watcher):
+    index = 'kms'
+    i_am_singular = 'KMS Master Key'
+    i_am_plural = 'KMS Master Keys'
+
+    def paged_wrap_aws_rate_limited_call(self, type, func, *args, **nargs):
+        marker = None
+        all_results = []
+        while True:
+            if marker is None:
+                response = self.wrap_aws_rate_limited_call(func, *args, **nargs)
+            else:
+                nargs["Marker"] = marker
+                response = self.wrap_aws_rate_limited_call(func, *args, **nargs)
+            all_results.extend(response.get(type))
+            marker = response.get("NextMarker")
+            if marker is None:
+                break
+        return all_results
+
+    def list_keys(self, kms):
+        all_keys = self.paged_wrap_aws_rate_limited_call(
+            "Keys",
+            kms.list_keys
+        )
+        return all_keys
+
+    def list_aliases(self, kms):
+        all_aliases = self.paged_wrap_aws_rate_limited_call(
+            "Aliases",
+            kms.list_aliases
+        )
+        return all_aliases
+
+    def list_grants(self, kms, key_id):
+        all_grants = self.paged_wrap_aws_rate_limited_call(
+            "Grants",
+            kms.list_grants,
+            KeyId=key_id
+        )
+        return all_grants
+
+    def describe_key(self, kms, key_id):
+        response = self.wrap_aws_rate_limited_call(
+            kms.describe_key,
+            KeyId=key_id
+        )
+        return response.get("KeyMetadata")
+
+    def list_key_policies(self, kms, key_id):
+        policy_names = []
+        try:
+            policy_names = self.paged_wrap_aws_rate_limited_call(
+                "PolicyNames",
+                kms.list_key_policies,
+                KeyId=key_id
+            )
+        except Exception as e:
+            if e.response.get("Error").get("Code") == "AccessDeniedException":
+                app.logger.debug("{} {} is an AWS supplied {} that has no policies".format(self.i_am_singular, key_id, self.i_am_singular))
+
+        return policy_names
+
+    def get_key_policy(self, kms, key_id, policy_name):
+        policy = self.wrap_aws_rate_limited_call(
+            kms.get_key_policy,
+            KeyId=key_id,
+            PolicyName=policy_name
+        )
+        return json.loads(policy.get("Policy"))
+
+    def __init__(self, accounts=None, debug=False):
+        super(KMS, self).__init__(accounts=accounts, debug=debug)
+
+    def slurp(self):
+        """
+        :returns: item_list - list of SES Identities.
+        :returns: exception_map - A dict where the keys are a tuple containing the
+            location of the exception and the value is the actual exception
+
+        """
+        self.prep_for_slurp()
+        from security_monkey.common.sts_connect import connect
+        item_list = []
+        exception_map = {}
+        for account in self.accounts:
+
+            try:
+                ec2 = connect(account, 'ec2')
+                regions = ec2.get_all_regions()
+            except Exception as e:  # EC2ResponseError
+                # Some Accounts don't subscribe to EC2 and will throw an exception here.
+                exc = BotoConnectionIssue(str(e), 'keypair', account, None)
+                self.slurp_exception((self.index, account), exc, exception_map)
+                continue
+
+            for region in regions:
+                keys = []
+                aliases = []
+
+                app.logger.debug("Checking {}/{}/{}".format(self.index, account, region.name))
+                try:
+                    kms = connect(account, 'boto3.kms.client', region=region.name)
+                    # First, we'll get all the keys and aliases
+                    keys = self.list_keys(kms)
+                    # If we don't have any keys, don't bother getting aliases
+                    if not(keys):
+                        app.logger.debug("Found {} {}.".format(len(keys), self.i_am_plural))
+                        continue
+                    else:
+                        aliases = self.list_aliases(kms)
+
+                except Exception as e:
+                    if region.name not in TROUBLE_REGIONS:
+                        exc = BotoConnectionIssue(str(e), self.index, account, region.name)
+                        self.slurp_exception((self.index, account, region.name), exc, exception_map)
+                    continue
+
+                app.logger.debug("Found {} {} and {} Aliases.".format(len(keys), self.i_am_plural, len(aliases)))
+                # Then, we'll get info about each key
+                for key in keys:
+                    policies = []
+                    key_id = key.get("KeyId")
+                    # get the key's config object and grants
+                    config = self.describe_key(kms, key_id)
+                    grants = self.list_grants(kms, key_id)
+                    policy_names = self.list_key_policies(kms, key_id)
+
+                    for policy_name in policy_names:
+                        policy = self.get_key_policy(kms, key_id, policy_name)
+                        policies.append(policy)
+
+                    # Convert the datetime objects into ISO formatted strings in UTC
+                    if config.get('CreationDate'):
+                        config.update({ 'CreationDate': config.get('CreationDate').astimezone(tzutc()).isoformat() })
+                    if config.get('DeletionDate'):
+                        config.update({ 'DeletionDate': config.get('DeletionDate').astimezone(tzutc()).isoformat() })
+
+                    for grant in grants:
+                        if grant.get("CreationDate"):
+                            grant.update({ 'CreationDate': grant.get('CreationDate').astimezone(tzutc()).isoformat() })
+
+                    config[u"Policies"] = policies
+                    config[u"Grants"] = grants
+                    # filter the list of all aliases and save them with the key they're for
+                    config[u"Aliases"] = [a.get("AliasName") for a in aliases if a.get("TargetKeyId") == key_id]
+
+                    config[u"Foo"] = "Bar"
+
+                    item = KMSMasterKey(region=region.name, account=account, name=key_id, config=dict(config))
+                    item_list.append(item)
+
+        return item_list, exception_map
+
+
+class KMSMasterKey(ChangeItem):
+    def __init__(self, region=None, account=None, name=None, config={}):
+        super(KMSMasterKey, self).__init__(
+            index=KMS.index,
+            region=region,
+            account=account,
+            name=name,
+            new_config=config)

--- a/security_monkey/watchers/kms.py
+++ b/security_monkey/watchers/kms.py
@@ -174,8 +174,6 @@ class KMS(Watcher):
                     # filter the list of all aliases and save them with the key they're for
                     config[u"Aliases"] = [a.get("AliasName") for a in aliases if a.get("TargetKeyId") == key_id]
 
-                    config[u"Foo"] = "Bar"
-
                     item = KMSMasterKey(region=region.name, account=account, name=key_id, config=dict(config))
                     item_list.append(item)
 


### PR DESCRIPTION
The KMS watcher and auditor will:

- Iterate over all accounts and regions
- Pull keys, aliases, grants and policies
- Store configurations for all the above
- Alert when a key has policies which include permissions for a foreign account

The following permissions need to be added to the Security Monkey Policies

```
"kms:DescribeKey"
"kms:GetKeyPolicy",
"kms:ListKeys",
"kms:ListAliases",
"kms:ListGrants",
"kms:ListKeyPolicies",
```