### PR TITLE
Shortening sessions from default value to 60 minutes. Setting Cookie…

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -449,6 +449,7 @@ Edit /usr/local/src/security_monkey/env-config/config-deploy.py:
     GOOGLE_AUTH_ENDPOINT = ''
     GOOGLE_SECRET = ''
 
+    from datetime import timedelta
     PERMANENT_SESSION_LIFETIME=timedelta(minutes=60)  # Will logout users after period of inactivity.
     SESSION_REFRESH_EACH_REQUEST=True
     SESSION_COOKIE_SECURE=True

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -449,6 +449,16 @@ Edit /usr/local/src/security_monkey/env-config/config-deploy.py:
     GOOGLE_AUTH_ENDPOINT = ''
     GOOGLE_SECRET = ''
 
+    PERMANENT_SESSION_LIFETIME=timedelta(minutes=60)  # Will logout users after period of inactivity.
+    SESSION_REFRESH_EACH_REQUEST=True
+    SESSION_COOKIE_SECURE=True
+    SESSION_COOKIE_HTTPONLY=True
+    PREFERRED_URL_SCHEME='https'
+
+    REMEMBER_COOKIE_DURATION=timedelta(minutes=60)  # Can make longer if you want remember_me to be useful
+    REMEMBER_COOKIE_SECURE=True
+    REMEMBER_COOKIE_HTTPONLY=True
+
 A few things need to be modified in this file before we move on.
 
 **SQLALCHEMY_DATABASE_URI**: The value above will be correct for the username "postgres" with the password "securitymonkeypassword" and the database name of "secmonkey".  Please edit this line if you have created a different database name or username or password.

--- a/env-config/config-deploy.py
+++ b/env-config/config-deploy.py
@@ -121,3 +121,14 @@ PING_SECRET = ''  # Provided by your administrator
 GOOGLE_CLIENT_ID = ''
 GOOGLE_AUTH_ENDPOINT = ''
 GOOGLE_SECRET = ''
+
+from datetime import timedelta
+PERMANENT_SESSION_LIFETIME=timedelta(minutes=60)
+SESSION_REFRESH_EACH_REQUEST=True
+SESSION_COOKIE_SECURE=True
+SESSION_COOKIE_HTTPONLY=True
+PREFERRED_URL_SCHEME='https'
+
+REMEMBER_COOKIE_DURATION=timedelta(minutes=60)  # Can make longer if you want remember_me to be useful.
+REMEMBER_COOKIE_SECURE=True
+REMEMBER_COOKIE_HTTPONLY=True

--- a/scripts/secmonkey_auto_install.sh
+++ b/scripts/secmonkey_auto_install.sh
@@ -462,6 +462,16 @@ GOOGLE_CLIENT_ID = ''
 GOOGLE_AUTH_ENDPOINT = ''
 GOOGLE_SECRET = ''
 
+PERMANENT_SESSION_LIFETIME=timedelta(minutes=60)   # Will logout users after period of inactivity.
+SESSION_REFRESH_EACH_REQUEST=True
+SESSION_COOKIE_SECURE=True
+SESSION_COOKIE_HTTPONLY=True
+PREFERRED_URL_SCHEME='https'
+
+REMEMBER_COOKIE_DURATION=timedelta(minutes=60)  # Can make longer if you want remember_me to be useful
+REMEMBER_COOKIE_SECURE=True
+REMEMBER_COOKIE_HTTPONLY=True
+
 EOF
 
 }

--- a/scripts/secmonkey_auto_install.sh
+++ b/scripts/secmonkey_auto_install.sh
@@ -462,6 +462,7 @@ GOOGLE_CLIENT_ID = ''
 GOOGLE_AUTH_ENDPOINT = ''
 GOOGLE_SECRET = ''
 
+from datetime import timedelta
 PERMANENT_SESSION_LIFETIME=timedelta(minutes=60)   # Will logout users after period of inactivity.
 SESSION_REFRESH_EACH_REQUEST=True
 SESSION_COOKIE_SECURE=True


### PR DESCRIPTION
Shortening sessions from default value to 60 minutes. Setting Cookie HTTPONLY and SECURE flags.

Basically add this to your deployment config file:

```
PERMANENT_SESSION_LIFETIME=timedelta(minutes=60)   # Will logout users after period of inactivity.
SESSION_REFRESH_EACH_REQUEST=True
SESSION_COOKIE_SECURE=True
SESSION_COOKIE_HTTPONLY=True
PREFERRED_URL_SCHEME='https'

REMEMBER_COOKIE_DURATION=timedelta(minutes=60)  # Can make longer if you want remember_me to be useful
REMEMBER_COOKIE_SECURE=True
REMEMBER_COOKIE_HTTPONLY=True
```

The session will then timeout after 60 minutes of inactivity.  Each interaction with the server will extend the session length.

Session and remember_me cookies will only be sent over HTTPS and client side scripts will not have access to read those values.

If Flask ever generates URLs, it will default to https.

As I don't use remember_me, I've set it's timeout to be the same period as the permanent session.  This effectively renders it useless.  Feel free to provide a longer period if you use remember_me.

