### PR TITLE
Google SSO fixes + limiting to hosted domain

### DIFF
--- a/dart/web/js/sso.js
+++ b/dart/web/js/sso.js
@@ -18,6 +18,9 @@ var create_url = function(provider) {
     url += "&redirect_uri="+provider.redirectUri;
     url += "&scope="+provider.scope.join(provider.scopeDelimiter);
     url += "&state=clientId,"+provider.clientId+",redirectUri,"+provider.redirectUri+",return_to,"+next;
+    if (provider.hd) {
+        url += "&hd="+provider.hd;
+    }
     return url;
 };
 

--- a/security_monkey/sso/service.py
+++ b/security_monkey/sso/service.py
@@ -38,9 +38,9 @@ def get_rsa_public_key(n, e):
 
 
 
-def fetch_token_header(token):
+def fetch_token_header_payload(token):
     """
-    Fetch the header out of the JWT token.
+    Fetch the header and payload out of the JWT token.
     :param token:
     :return: :raise jwt.DecodeError:
     """
@@ -52,10 +52,18 @@ def fetch_token_header(token):
         raise jwt.DecodeError('Not enough segments')
 
     try:
-        return json.loads(jwt.utils.base64url_decode(header_segment).decode('utf-8'))
+        header = json.loads(jwt.utils.base64url_decode(header_segment).decode('utf-8'))
     except TypeError as e:
         current_app.logger.exception(e)
         raise jwt.DecodeError('Invalid header padding')
+
+    try:
+        payload = json.loads(jwt.utils.base64url_decode(payload_segment).decode('utf-8'))
+    except TypeError as e:
+        current_app.logger.exception(e)
+        raise jwt.DecodeError('Invalid header padding')
+
+    return (header, payload)
 
 
 @identity_loaded.connect

--- a/security_monkey/sso/views.py
+++ b/security_monkey/sso/views.py
@@ -238,11 +238,11 @@ class Providers(Resource):
                 active_providers.append({
                     'name': 'google',
                     'clientId': current_app.config.get("GOOGLE_CLIENT_ID"),
-                    'url': api.url_for(Google),
-                    'redirectUri': api.url_for(Google),
+                    'url': api.url_for(Google, _external=True, _scheme='https'),
+                    'redirectUri': api.url_for(Google, _external=True, _scheme='https'),
                     'authorizationEndpoint': current_app.config.get("GOOGLE_AUTH_ENDPOINT"),
-                    'scope': [],
-                    'responseType': 'authorization_code'
+                    'scope': ['openid email'],
+                    'responseType': 'code'
                 })
             else:
                 raise Exception("Unknown authentication provider: {0}".format(provider))

--- a/security_monkey/sso/views.py
+++ b/security_monkey/sso/views.py
@@ -15,7 +15,7 @@ from flask.ext.restful import reqparse, Resource, Api
 from flask.ext.principal import Identity, identity_changed
 from flask_login import login_user
 
-from .service import fetch_token_header, get_rsa_public_key
+from .service import fetch_token_header_payload, get_rsa_public_key
 
 from security_monkey.datastore import User
 from security_monkey import db, rbac
@@ -84,7 +84,7 @@ class Ping(Resource):
         access_token = r.json()['access_token']
 
         # fetch token public key
-        header_data = fetch_token_header(id_token)
+        header_data = fetch_token_header_payload(id_token)[0]
         jwks_url = current_app.config.get('PING_JWKS_URL')
 
         # retrieve the key material as specified by the token header
@@ -183,6 +183,26 @@ class Google(Resource):
         r = requests.post(access_token_url, data=payload)
         token = r.json()
 
+        # Step 1bis. Validate (some information of) the id token (if necessary)
+        google_hosted_domain = current_app.config.get("GOOGLE_HOSTED_DOMAIN")
+        if google_hosted_domain is not None:
+            current_app.logger.debug('We need to verify that the token was issued for this hosted domain: %s ' % (google_hosted_domain))
+
+	    # Get the JSON Web Token
+            id_token = r.json()['id_token']
+            current_app.logger.debug('The id_token is: %s' % (id_token))
+
+            # Extract the payload
+            (header_data, payload_data) = fetch_token_header_payload(id_token)
+            current_app.logger.debug('id_token.header_data: %s' % (header_data))
+            current_app.logger.debug('id_token.payload_data: %s' % (payload_data))
+
+            token_hd = payload_data.get('hd')
+            if token_hd != google_hosted_domain:
+                current_app.logger.debug('Verification failed: %s != %s' % (token_hd, google_hosted_domain))
+                return dict(message='Token is invalid %s' % token), 403
+            current_app.logger.debug('Verification passed')
+
         # Step 2. Retrieve information about the current user
         headers = {'Authorization': 'Bearer {0}'.format(token['access_token'])}
 
@@ -235,7 +255,7 @@ class Providers(Resource):
                     'type': '2.0'
                 })
             elif provider == "google":
-                active_providers.append({
+                google_provider = {
                     'name': 'google',
                     'clientId': current_app.config.get("GOOGLE_CLIENT_ID"),
                     'url': api.url_for(Google, _external=True, _scheme='https'),
@@ -243,7 +263,11 @@ class Providers(Resource):
                     'authorizationEndpoint': current_app.config.get("GOOGLE_AUTH_ENDPOINT"),
                     'scope': ['openid email'],
                     'responseType': 'code'
-                })
+                }
+                google_hosted_domain = current_app.config.get("GOOGLE_HOSTED_DOMAIN")
+                if google_hosted_domain is not None:
+                    google_provider['hd'] = google_hosted_domain
+                active_providers.append(google_provider)
             else:
                 raise Exception("Unknown authentication provider: {0}".format(provider))
 


### PR DESCRIPTION
I couldn't make Google SSO work (on Google Apps For Work) without a few modifications that were done according to the public documentation on Google's OpenId Connect : https://developers.google.com/identity/protocols/OpenIDConnect

Tests were made using 
GOOGLE_AUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth'
I did not test it against any other Google SSO.

In addition I added the ability to limit to specific hosted domain - which is useful if you're using Google Apps For Work on your domain and want to limit access to the *only* users of your domain.
There is a new configuration option for that: 
GOOGLE_HOSTED_DOMAIN = 'mydomain.org'
