### PR TITLE
Better handle bad IAM SSL certificates

### DIFF
--- a/security_monkey/watchers/iam/iam_ssl.py
+++ b/security_monkey/watchers/iam/iam_ssl.py
@@ -239,6 +239,9 @@ class IAMSSL(Watcher):
                 except Exception as e:
                     app.logger.warn(traceback.format_exc())
                     app.logger.error("Invalid certificate {}!".format(cert.server_certificate_id))
+                    self.slurp_exception(
+                        (self.index, account, 'universal', cert.server_certificate_name),
+                        e, exception_map, source="{}-watcher".format(self.index))
 
         except Exception as e:
             app.logger.warn(traceback.format_exc())


### PR DESCRIPTION
This is an extension to #396.

@markofu added per-certificate error handling.  I've taken that and added a call to `slurp_exception`, which itself will call `store_exception`, so exceptions can be analyzed by querying the database in addition to checking the logs.