### PR TITLE
Added "route53domains:getdomaindetail" to permissions doc.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -145,6 +145,7 @@ SM-ReadOnly
                     "route53:listhostedzones",
                     "route53:listresourcerecordsets",
                     "route53domains:listdomains",
+                    "route53domains:getdomaindetail",
                     "s3:getbucketacl",
                     "s3:getbucketlocation",
                     "s3:getbucketlogging",

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -157,6 +157,7 @@ Paste in this JSON with the name "SecurityMonkeyReadOnly":
                     "route53:listhostedzones",
                     "route53:listresourcerecordsets",
                     "route53domains:listdomains",
+                    "route53domains:getdomaindetail",
                     "s3:getbucketacl",
                     "s3:getbucketlocation",
                     "s3:getbucketlogging",

--- a/scripts/secmonkey_role_setup.py
+++ b/scripts/secmonkey_role_setup.py
@@ -130,6 +130,7 @@ policy = \
            "route53:listhostedzones",
            "route53:listresourcerecordsets",
            "route53domains:listdomains",
+           "route53domains:getdomaindetail",
            "s3:getbucketacl",
            "s3:getbucketlocation",
            "s3:getbucketlogging",


### PR DESCRIPTION
- The route53 watcher requires access to the `route53domains:getdomaindetail` permission
- Added it to the Quickstart doc.