### PR TITLE
setup.py fail because of moto lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup
 
 setup(
     name='security_monkey',
-    version='0.6.0',
+    version='0.7.0',
     long_description=__doc__,
     packages=['security_monkey'],
     include_package_data=True,
@@ -54,7 +54,7 @@ setup(
         'joblib>=0.9.4',
         'pyjwt>=1.01',
         'healthcheck>=1.2.0',
-        'moto>=0.4.25',
+        'moto==0.4.25',
         'freezegun>=0.3.7',
         'python-saml>=2.2.0'
     ]


### PR DESCRIPTION
Fix for the issue : Jinja2 2.7.2 is installed but Jinja2>=2.8 is required by set(['moto'])
Moto now depends on Jinja2 2.8 - Consider updating to the latest version of Jinja2 2.9?