### PR TITLE
Adds exception logging listener for appscheduler

### DIFF
--- a/security_monkey/scheduler.py
+++ b/security_monkey/scheduler.py
@@ -9,6 +9,7 @@
 """
 
 from apscheduler.threadpool import ThreadPool
+from apscheduler import events
 from apscheduler.scheduler import Scheduler
 from sqlalchemy.exc import OperationalError, InvalidRequestError, StatementError
 
@@ -95,6 +96,10 @@ scheduler = Scheduler(
     misfire_grace_time=30
 )
 
+def exception_listener(event):
+     store_exception("scheduler-change-reporter-uncaught", None, event.exception)
+
+scheduler.add_listener(exception_listener, events.EVENT_JOB_ERROR)
 
 def setup_scheduler():
     """Sets up the APScheduler"""


### PR DESCRIPTION
Type: general-bugfix

Why is this change necessary?
With the new version of app scheduler unhandled exceptions are not
recorded unless explicitly configured to do so.

This change addresses the need by:
Adding a listener to catch and store unhandled exceptions