### PR TITLE
Fix exception logging in store_exception ✅

### DIFF
--- a/security_monkey/datastore.py
+++ b/security_monkey/datastore.py
@@ -602,14 +602,15 @@ def store_exception(source, location, exception, ttl=None):
                 if account:
                     exception_entry.account_id = account.id
 
-            technology = Technology.query.filter(Technology.name == location[0]).first()
-            if not technology:
-                technology = Technology(name=location[0])
-                db.session.add(technology)
-                db.session.commit()
-                db.session.refresh(technology)
-
-            if technology:
+            if len(location) >= 1:
+                technology = Technology.query.filter(Technology.name == location[0]).first()
+                if not technology:
+                    technology = Technology(name=location[0])
+                    db.session.add(technology)
+                    db.session.commit()
+                    db.session.refresh(technology)
+                    app.logger.info("Creating a new Technology: {} - ID: {}"
+                                    .format(technology.name, technology.id))
                 exception_entry.tech_id = technology.id
 
         db.session.add(exception_entry)


### PR DESCRIPTION
Type: Bugfix

Why:
Netflix added code to store exceptions in the database, but when the
method to store the exception is called before the associated tech
type is stored, it throws an error. The error is caught and logged
which would cause false alerts.

This change addresses the need by:
Creating the tech type if it doesn't exist

Potential Side Effects:
No known side effects