### PR TITLE
Moved test & onelogin requirements to the setup.py extras_require section.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y libxml2-dev libxmlsec1-dev
+  # - sudo apt-get install -y libxml2-dev libxmlsec1-dev
 
 before_script:
   - psql -c "CREATE DATABASE securitymonkeydb;" -U postgres
@@ -30,6 +30,7 @@ before_script:
   - psql -c "CREATE SCHEMA securitymonkeydb GRANT Usage, Create ON SCHEMA securitymonkeydb TO securitymonkeyuser;" -U postgres
   - psql -c "set timezone TO 'GMT';" -U postgres
   - python setup.py develop
+  - pip install .[tests]
   - python manage.py db upgrade
 
 script:
@@ -38,4 +39,5 @@ script:
 
 notifications:
   email:
-    mgrima@netflix.com
+    - mgrima@netflix.com
+    - pkelley@netflix.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 install:
 
 before_install:
-  - sudo apt-get -qq update
+  # - sudo apt-get -qq update
   # - sudo apt-get install -y libxml2-dev libxmlsec1-dev
 
 before_script:

--- a/security_monkey/sso/views.py
+++ b/security_monkey/sso/views.py
@@ -15,8 +15,12 @@ from flask.ext.restful import reqparse, Resource, Api
 from flask.ext.principal import Identity, identity_changed
 from flask_login import login_user
 
-from onelogin.saml2.auth import OneLogin_Saml2_Auth
-from onelogin.saml2.utils import OneLogin_Saml2_Utils
+try:
+    from onelogin.saml2.auth import OneLogin_Saml2_Auth
+    from onelogin.saml2.utils import OneLogin_Saml2_Utils
+    onelogin_import_success = True
+except ImportError:
+    onelogin_import_success = False
 
 from .service import fetch_token_header_payload, get_rsa_public_key
 
@@ -367,5 +371,7 @@ class Providers(Resource):
 
 api.add_resource(Ping, '/auth/ping', endpoint='ping')
 api.add_resource(Google, '/auth/google', endpoint='google')
-api.add_resource(OneLogin, '/auth/onelogin', endpoint='onelogin')
 api.add_resource(Providers, '/auth/providers', endpoint='providers')
+
+if onelogin_import_success:
+    api.add_resource(OneLogin, '/auth/onelogin', endpoint='onelogin')

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,6 @@ setup(
         'boto>=2.41.0',
         'ipaddr==2.1.11',
         'itsdangerous==0.23',
-        'mock==1.0.1',
-        'nose==1.3.0',
-        'pika==0.9.13',
         'psycopg2==2.5.2',
         'bcrypt==2.0.0',
         'Sphinx==1.2.2',
@@ -53,9 +50,14 @@ setup(
         'cloudaux>=1.0.0.dev0',
         'joblib>=0.9.4',
         'pyjwt>=1.01',
-        'healthcheck>=1.2.0',
-        'moto==0.4.25',
-        'freezegun>=0.3.7',
-        'python-saml>=2.2.0'
-    ]
+    ],
+    extras_require = {
+        'onelogin': ['python-saml>=2.2.0'],
+        'tests': [
+            'nose==1.3.0',
+            'mock==1.0.1',
+            'moto==0.4.25',
+            'freezegun>=0.3.7'
+        ]
+    }
 )


### PR DESCRIPTION
Moved the `python-saml` lib to an extras section.
Also, moved testing libs to their own extras section.

Now, `libxmlsec1-dev` is no longer required.

`.travis.yml` modified to install the `tests` requirements:
- `pip install .[tests]`

If you'd like to use onelogin, you simply need to run these commands:
- `sudo apt-get -qq update`
- `sudo apt-get install -y libxml2-dev libxmlsec1-dev`
- `pip install .[onelogin]`

```
    extras_require = {
        'onelogin': ['python-saml>=2.2.0'],
        'tests': [
            'nose==1.3.0',
            'mock==1.0.1',
            'moto==0.4.25',
            'freezegun>=0.3.7'
        ]
    }
```