### PR TITLE
Fixing a bug where we stopped raising an issue when we could not obtain a cert issuer

### DIFF
--- a/security_monkey/watchers/iam/iam_ssl.py
+++ b/security_monkey/watchers/iam/iam_ssl.py
@@ -61,6 +61,8 @@ def cert_get_issuer(cert):
         return issuer
     except Exception as e:
         app.logger.error("Unable to get issuer! {0}".format(e))
+        return 'ERROR_EXTRACTING_ISSUER'
+
 
 
 def cert_get_serial(cert):


### PR DESCRIPTION
The regression happened after moving from M2Crypto to Cryptography. Should fix issue #251.