### PR TITLE
Updating the way we interact with Flask-WTF. Closes Issue #494.

### DIFF
--- a/security_monkey/templates/security/forgot_password.html
+++ b/security_monkey/templates/security/forgot_password.html
@@ -52,7 +52,7 @@
         <form action="{{ url_for_security('forgot_password') }}" method="POST" name="forgot_password_form" class="form-signin">
             {% include "security/_messages.html" %}
             <h1>Send password reset instructions</h1>
-              <input id="csrf_token" name="csrf_token" type="hidden" value="{{ forgot_password_form.csrf_token }}">
+              {{ forgot_password_form.csrf_token }}
               <input type="email" class="form-control" placeholder="Email address" id="email" name="email" required autofocus>
               {{ render_errors(forgot_password_form.email) }}
               <button class="btn btn-lg btn-primary btn-block" id="submit" name="submit" type="submit" value="Recover Password">Recover Password</button>

--- a/security_monkey/templates/security/forgot_password.html
+++ b/security_monkey/templates/security/forgot_password.html
@@ -27,7 +27,7 @@
 <body role="document">
 
     <div class="container">
-    
+
         <!-- Fixed navbar -->
         <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
             <div class="container">
@@ -52,15 +52,15 @@
         <form action="{{ url_for_security('forgot_password') }}" method="POST" name="forgot_password_form" class="form-signin">
             {% include "security/_messages.html" %}
             <h1>Send password reset instructions</h1>
-              <input id="csrf_token" name="csrf_token" type="hidden" value="{{ forgot_password_form.generate_csrf_token() }}">
+              <input id="csrf_token" name="csrf_token" type="hidden" value="{{ forgot_password_form.csrf_token }}">
               <input type="email" class="form-control" placeholder="Email address" id="email" name="email" required autofocus>
               {{ render_errors(forgot_password_form.email) }}
               <button class="btn btn-lg btn-primary btn-block" id="submit" name="submit" type="submit" value="Recover Password">Recover Password</button>
             {% include "security/_menu.html" %}
         </form>
-        
+
     </div>
-    
+
     <div class="container-fluid">
     </div>
     <!-- Bootstrap core JavaScript

--- a/security_monkey/templates/security/login_user.html
+++ b/security_monkey/templates/security/login_user.html
@@ -27,7 +27,7 @@
 <body role="document">
 
     <div class="container">
-    
+
         <!-- Fixed navbar -->
         <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
             <div class="container">
@@ -47,7 +47,7 @@
                 <!--/.nav-collapse -->
             </div>
         </div>
-        
+
         {% from "security/_macros.html" import render_errors, render_field, render_generic_error %}
         <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form" class="form-signin">
         {% include "security/_messages.html" %}
@@ -58,7 +58,7 @@
 
           <br />
           <div class="login-or"><hr class="hr-or"><span class="span-or">OR</span></div>
-          <input id="csrf_token" name="csrf_token" type="hidden" value="{{ login_user_form.generate_csrf_token() }}">
+          <input id="csrf_token" name="csrf_token" type="hidden" value="{{ login_user_form.csrf_token }}">
           <input type="email" class="form-control" placeholder="Email address" id="email" name="email" required autofocus>
           <input type="password" class="form-control" placeholder="Password" id="password" name="password" required>
           {{ render_generic_error(login_user_form.email, login_user_form.password) }}
@@ -70,9 +70,9 @@
         {% include "security/_menu.html" %}
           </div>
         </form>
-    
+
     </div>
-    
+
     <div class="container-fluid">
     </div>
     <!-- Bootstrap core JavaScript

--- a/security_monkey/templates/security/login_user.html
+++ b/security_monkey/templates/security/login_user.html
@@ -58,7 +58,7 @@
 
           <br />
           <div class="login-or"><hr class="hr-or"><span class="span-or">OR</span></div>
-          <input id="csrf_token" name="csrf_token" type="hidden" value="{{ login_user_form.csrf_token }}">
+          {{ login_user_form.csrf_token }}
           <input type="email" class="form-control" placeholder="Email address" id="email" name="email" required autofocus>
           <input type="password" class="form-control" placeholder="Password" id="password" name="password" required>
           {{ render_generic_error(login_user_form.email, login_user_form.password) }}

--- a/security_monkey/templates/security/register_user.html
+++ b/security_monkey/templates/security/register_user.html
@@ -27,7 +27,7 @@
 <body role="document">
 
     <div class="container">
-    
+
         <!-- Fixed navbar -->
         <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
             <div class="container">
@@ -53,7 +53,7 @@
         <form action="{{ url_for_security('register') }}" method="POST" name="register_user_form" class="form-signin">
         {% include "security/_messages.html" %}
         <h1>Register</h1>
-          <input id="csrf_token" name="csrf_token" type="hidden" value="{{ register_user_form.generate_csrf_token() }}">
+          <input id="csrf_token" name="csrf_token" type="hidden" value="{{ register_user_form.csrf_token }}">
           <input type="email" class="form-control" placeholder="Email address" id="email" name="email" required autofocus>
           {{ render_errors(register_user_form.email) }}
           <input type="password" class="form-control" placeholder="Password" id="password" name="password" required>
@@ -67,7 +67,7 @@
         </form>
 
     </div>
-    
+
     <div class="container-fluid">
     </div>
     <!-- Bootstrap core JavaScript

--- a/security_monkey/templates/security/register_user.html
+++ b/security_monkey/templates/security/register_user.html
@@ -53,7 +53,7 @@
         <form action="{{ url_for_security('register') }}" method="POST" name="register_user_form" class="form-signin">
         {% include "security/_messages.html" %}
         <h1>Register</h1>
-          <input id="csrf_token" name="csrf_token" type="hidden" value="{{ register_user_form.csrf_token }}">
+          {{ register_user_form.csrf_token }}
           <input type="email" class="form-control" placeholder="Email address" id="email" name="email" required autofocus>
           {{ render_errors(register_user_form.email) }}
           <input type="password" class="form-control" placeholder="Password" id="password" name="password" required>

--- a/security_monkey/templates/security/reset_password.html
+++ b/security_monkey/templates/security/reset_password.html
@@ -53,7 +53,7 @@
         <form action="{{ url_for_security('reset_password', token=reset_password_token) }}" method="POST" name="reset_password_form" class="form-signin">
             {% include "security/_messages.html" %}
             <h1>Reset password</h1>
-            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ reset_password_form.csrf_token }}">
+            {{ reset_password_form.csrf_token }}
             <input type="password" class="form-control" placeholder="Password" id="password" name="password" required>
             {{ render_errors(reset_password_form.password) }}
             <input type="password" class="form-control" placeholder="Confirm Password" id="password_confirm" name="password_confirm" required>

--- a/security_monkey/templates/security/reset_password.html
+++ b/security_monkey/templates/security/reset_password.html
@@ -27,7 +27,7 @@
 <body role="document">
 
     <div class="container">
-    
+
         <!-- Fixed navbar -->
         <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
             <div class="container">
@@ -53,7 +53,7 @@
         <form action="{{ url_for_security('reset_password', token=reset_password_token) }}" method="POST" name="reset_password_form" class="form-signin">
             {% include "security/_messages.html" %}
             <h1>Reset password</h1>
-            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ reset_password_form.generate_csrf_token() }}">
+            <input id="csrf_token" name="csrf_token" type="hidden" value="{{ reset_password_form.csrf_token }}">
             <input type="password" class="form-control" placeholder="Password" id="password" name="password" required>
             {{ render_errors(reset_password_form.password) }}
             <input type="password" class="form-control" placeholder="Confirm Password" id="password_confirm" name="password_confirm" required>
@@ -63,7 +63,7 @@
         </form>
 
     </div>
-    
+
     <div class="container-fluid">
     </div>
     <!-- Bootstrap core JavaScript

--- a/security_monkey/templates/security/send_confirmation.html
+++ b/security_monkey/templates/security/send_confirmation.html
@@ -52,7 +52,7 @@
 <form action="{{ url_for_security('send_confirmation') }}" method="POST" name="send_confirmation_form" class="form-signin">
   {% include "security/_messages.html" %}
   <h1>Resend confirmation instructions</h1>
-  <input id="csrf_token" name="csrf_token" type="hidden" value="{{ send_confirmation_form.csrf_token }}">
+  {{ send_confirmation_form.csrf_token }}
   <input type="email" class="form-control" placeholder="Email address" id="email" name="email" required autofocus>
   {{ render_errors(send_confirmation_form.email) }}
   <button class="btn btn-lg btn-primary btn-block" id="submit" name="submit" type="submit" value="Resend Confirmation">Resend Confirmation</button>

--- a/security_monkey/templates/security/send_confirmation.html
+++ b/security_monkey/templates/security/send_confirmation.html
@@ -27,7 +27,7 @@
 <body role="document">
 
     <div class="container">
-    
+
         <!-- Fixed navbar -->
         <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
             <div class="container">
@@ -52,7 +52,7 @@
 <form action="{{ url_for_security('send_confirmation') }}" method="POST" name="send_confirmation_form" class="form-signin">
   {% include "security/_messages.html" %}
   <h1>Resend confirmation instructions</h1>
-  <input id="csrf_token" name="csrf_token" type="hidden" value="{{ send_confirmation_form.generate_csrf_token() }}">
+  <input id="csrf_token" name="csrf_token" type="hidden" value="{{ send_confirmation_form.csrf_token }}">
   <input type="email" class="form-control" placeholder="Email address" id="email" name="email" required autofocus>
   {{ render_errors(send_confirmation_form.email) }}
   <button class="btn btn-lg btn-primary btn-block" id="submit" name="submit" type="submit" value="Resend Confirmation">Resend Confirmation</button>
@@ -60,7 +60,7 @@
 </form>
 
     </div>
-    
+
     <div class="container-fluid">
     </div>
     <!-- Bootstrap core JavaScript

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'Flask-Script==0.6.3',
         # 'Flask-Security==1.7.4',
         'Flask-Security-Fork==1.8.2',
+        'Flask-WTF>=0.14.2',
         'Jinja2>=2.8.1',
         'SQLAlchemy==0.9.2',
         'boto>=2.41.0',


### PR DESCRIPTION
This should fix the problems in #494.

You can either pin to `Flask-WTF==0.13.1` or update the templates and use `Flask-WTF>=0.14.2` .  This PR does the latter.