### PR TITLE
Avoid double json encoding

### DIFF
--- a/dart/lib/model/Account.dart
+++ b/dart/lib/model/Account.dart
@@ -47,8 +47,8 @@ class Account {
         }
     }
 
-    String toJson() {
-        Map objmap = {
+    Map toMap() {
+        return {
             "id": id,
             "active": active,
             "third_party": third_party,
@@ -58,6 +58,5 @@ class Account {
             "account_type": account_type,
             "custom_fields": custom_field_values
         };
-        return JSON.encode(objmap);
     }
 }

--- a/dart/lib/model/Role.dart
+++ b/dart/lib/model/Role.dart
@@ -13,11 +13,10 @@ class Role implements Comparable{
     id = data['name'];
   }
 
-  String toJson() {
-    Map objmap = {
+  Map toMap() {
+    return {
         "name": id
     };
-    return JSON.encode(objmap);
   }
   
   bool operator ==(r) => r is Role && this.id == r.id;

--- a/dart/lib/model/User.dart
+++ b/dart/lib/model/User.dart
@@ -48,13 +48,12 @@ class User{
 
   get role_id => role.id;
 
-  String toJson() {
-    Map objmap = {
+  Map toMap() {
+    return {
         "id": id,
         "active": active,
         "email": email,
         "role": role.id
     };
-    return JSON.encode(objmap);
   }
 }

--- a/dart/lib/model/UserSetting.dart
+++ b/dart/lib/model/UserSetting.dart
@@ -29,13 +29,12 @@ class UserSetting {
         }
     }
 
-    String toJson() {
-        Map objmap = {
+    Map toMap() {
+        return {
             "accounts": account_ids,
             "daily_audit_email": daily_audit_email,
             "change_report_setting": change_report_setting
         };
-        return JSON.encode(objmap);
     }
 
 }

--- a/dart/lib/model/hammock_config.dart
+++ b/dart/lib/model/hammock_config.dart
@@ -26,7 +26,7 @@ import 'dart:mirrors';
 
 import 'package:security_monkey/util/constants.dart';
 
-Resource serializeAccount(Account account) => resource("accounts", account.id, account.toJson());
+Resource serializeAccount(Account account) => resource("accounts", account.id, account.toMap());
 final serializeIssue = serializer("issues", ["id", "score", "issue", "notes", "justified", "justified_user", "justification", "justified_date", "item_id"]);
 final serializeRevision = serializer("revisions", ["id", "item_id", "config", "active", "date_created", "diff_html"]);
 final serializeItem = serializer("items", ["id", "technology", "region", "account", "name"]);

--- a/dart/lib/model/network_whitelist_entry.dart
+++ b/dart/lib/model/network_whitelist_entry.dart
@@ -17,14 +17,13 @@ class NetworkWhitelistEntry {
         cidr = data["cidr"];
     }
 
-    String toJson() {
-        Map objmap = {
+    Map toMap() {
+        return {
             "id": id,
             "name": name,
             "cidr": cidr,
             "notes": notes
         };
-        return JSON.encode(objmap);
     }
 
 }

--- a/security_monkey/views/account.py
+++ b/security_monkey/views/account.py
@@ -258,7 +258,7 @@ class AccountPostList(AuthenticatedService):
             :statuscode 401: Authentication Error. Please Login.
         """
 
-        args = json.loads(request.json)
+        args = request.json
         account_type = args['account_type']
         name = args['name']
         identifier = args['identifier']


### PR DESCRIPTION
No need to call JSON.encode because browser will encode any object to json if content-type is application/json.

Fixes #498 