### PR TITLE
Updating ARN.py to look for StringEqualsIgnoreCase in policy condition blocks

### DIFF
--- a/security_monkey/common/arn.py
+++ b/security_monkey/common/arn.py
@@ -80,6 +80,7 @@ class ARN(object):
               condition.get('ForAllValues:StringLike', {}) or \
               condition.get('ForAnyValue:StringLike', {}) or \
               condition.get('StringEquals', {}) or \
+              condition.get('StringEqualsIgnoreCase', {}) or \
               condition.get('ForAllValues:StringEquals', {}) or \
               condition.get('ForAnyValue:StringEquals', {})
 


### PR DESCRIPTION
Example statement:

```
{
      "Resource": "arn:aws:sqs:<region>:<account_number>:<queue_name>",
      "Effect": "Allow",
      "Sid": "1",
      "Action": "sqs:SendMessage",
      "Condition": {
        "StringEqualsIgnoreCase": {
          "aws:SourceArn": "<some_arn>"
        }
      },
      "Principal": "*"
    }
```