### PR TITLE
Update dev_setup_osx.rst to get it up-to-date

### DIFF
--- a/docs/dev_setup_osx.rst
+++ b/docs/dev_setup_osx.rst
@@ -31,6 +31,12 @@ A tool for installing and managing Python packages::
 
     sudo easy_install pip
 
+Install Python
+==========================
+Install the latest version of Python 2.7 with Homebrew::
+
+    sudo brew install python
+
 Setup Virtualenv
 ==========================
 Virtualenv is a tool to create isolated Python environments.  You will need to install it::

--- a/docs/dev_setup_osx.rst
+++ b/docs/dev_setup_osx.rst
@@ -46,7 +46,7 @@ Virtualenv is a tool to create isolated Python environments.  You will need to i
 VirtualenvWrapper
   virtualenvwrapper is a set of extensions to Ian Bicking’s virtualenv tool. The extensions include wrappers for creating and deleting virtual environments and otherwise managing your development workflow, making it easier to work on more than one project at a time without introducing conflicts in their dependencies. ::
 
-    sudo pip install virtualenvwrapper --ignore-installed six
+    sudo pip install virtualenvwrapper
 
 Configure VirtualEnvWrapper
   Configure VirtualEnvWrapper so it knows where to store the virtualenvs and where the virtualenvwerapper script is located. ::

--- a/docs/dev_setup_osx.rst
+++ b/docs/dev_setup_osx.rst
@@ -10,12 +10,12 @@ You will need to have the proper IAM Role configuration in place.  See `Configur
   
 Additionally, see the boto documentation for more information: http://boto.readthedocs.org/en/latest/boto_config_tut.html
 
-Install XCode
+Install Xcode
 ==========================
-XCode contains a number of tools that are required to install Security Monkey dependencies.  This needs to be installed from the App Store (free download):
+Xcode contains a number of tools that are required to install Security Monkey dependencies.  This needs to be installed from the App Store (free download):
 https://itunes.apple.com/us/app/xcode/id497799835?mt=12
 
-After XCode is installed, you need to accept the XCode license agreement.  To do that, run::
+After Xcode is installed, you need to accept the Xcode license agreement.  To do that, run::
 
     sudo xcodebuild -license   # You will need to type in 'agree'
 
@@ -23,7 +23,7 @@ Install Homebrew (http://brew.sh)
 ==========================
 Requirement - Xcode Command Line Tools (Popup - Just click Install)::
 
-    ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
 Install Pip
 ==========================
@@ -40,7 +40,7 @@ Virtualenv is a tool to create isolated Python environments.  You will need to i
 VirtualenvWrapper
   virtualenvwrapper is a set of extensions to Ian Bicking’s virtualenv tool. The extensions include wrappers for creating and deleting virtual environments and otherwise managing your development workflow, making it easier to work on more than one project at a time without introducing conflicts in their dependencies. ::
 
-    sudo pip install virtualenvwrapper
+    sudo pip install virtualenvwrapper --ignore-installed six
 
 Configure VirtualEnvWrapper
   Configure VirtualEnvWrapper so it knows where to store the virtualenvs and where the virtualenvwerapper script is located. ::
@@ -82,11 +82,11 @@ Install Postgres.  Create a database for security monkey and add a role.  Set th
 
     brew install postgresql
 
-Start the DB in a new shell::
+Open a new shell, then start the DB::
 
     postgres -D /usr/local/var/postgres
 
-Create the database and users and set the timezone. ::
+Go back to your previous shell, then create the database and users and set the timezone. ::
 
     psql -d postgres -h localhost
     CREATE DATABASE "securitymonkeydb";
@@ -181,6 +181,11 @@ Next, you will create the ``securitymonkey.conf`` NGINX configuration file.  Cre
           index ui.html;
       }
     }
+
+Create the ``devlog/security_monkey.access.log`` file. ::
+
+    mkdir devlog
+    touch devlog/security_monkey.access.log
 
 NGINX can be started by running the ``nginx`` command in the Terminal.  You will need to run ``nginx`` before moving on.  This will also output any errors that are encountered when reading the configuration files.
 

--- a/docs/dev_setup_osx.rst
+++ b/docs/dev_setup_osx.rst
@@ -25,17 +25,17 @@ Requirement - Xcode Command Line Tools (Popup - Just click Install)::
 
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-Install Pip
-==========================
-A tool for installing and managing Python packages::
-
-    sudo easy_install pip
-
 Install Python
 ==========================
 Install the latest version of Python 2.7 with Homebrew::
 
     sudo brew install python
+
+Upgrade Pip
+==========================
+A tool for installing and managing Python packages. You may need to update Pip, so run::
+
+    sudo pip install --upgrade pip
 
 Setup Virtualenv
 ==========================


### PR DESCRIPTION
Update the osx dev doc to get it up-to-date.

The reasons for these changes are below:

### Homebrew
Homebrew failed to install using the old URL, returning:
curl: (22) The requested URL returned error: 404 Not Found

New URL (off their website):
ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

### virtualenvwrapper
Trying `pip install virtualenvwrapper` fails because six 1.4.1 is deprecated.
Running `sudo pip install virtualenvwrapper --ignore-installed six` fixes this

### Install PostgreSQL
"Start the DB in a new shell:" rephrased for clarity to "Open a new shell and start the DB".
When I first went through the doc, I didn't know what `postgres -D /usr/local/var/postgres` did. Based on the instructions, I thought it opened the the DB in a new shell automatically.

### Running nginx
After trying to run `nginx` after setting everything up properly, I get:
"nginx: [emerg] open() "/path/to/security_monkey/devlog/security_monkey.access.log" failed (2: No such file or directory)"

To fix this, I run:
```
mkdir devlog
touch devlog/security_monkey.access.log
```