### PR TITLE
Add ability to press enter to search in search bar component

### DIFF
--- a/dart/lib/component/search_bar_component/search_bar_component.html
+++ b/dart/lib/component/search_bar_component/search_bar_component.html
@@ -42,17 +42,20 @@
 
     <div>
       <h6>Search Config</h6>
-      <input id="searchconfig" class="form-control" ng-model="searchconfig"></input>
+      <input id="searchconfig" class="form-control" ng-model="searchconfig"
+             ng-keyup="$event.keyCode == 13 && pushFilterRoutes()"></input>
     </div>
 
     <div ng-if="result_type_binded == 'items'">
       <h6>Min Total Score</h6>
-      <input id="min_score" class="form-control" ng-model="min_score"></input>
+      <input id="min_score" class="form-control" ng-model="min_score"
+             ng-keyup="$event.keyCode == 13 && pushFilterRoutes()"></input>
     </div>
 
     <div ng-if="result_type_binded == 'items'">
       <h6>Min Unjustified Score</h6>
-      <input id="min_unjustified_score" class="form-control" ng-model="min_unjustified_score"></input>
+      <input id="min_unjustified_score" class="form-control" ng-model="min_unjustified_score"
+             ng-keyup="$event.keyCode == 13 && pushFilterRoutes()"></input>
     </div>
 
     <div>


### PR DESCRIPTION
Added the ability to search with pressing the `enter` key. This is for the second set of fields in the search component.

The previous behaviour was that you **had** to click the "Search" button. I often found myself hitting the `enter` key in a field and expecting it to search.

I've done this by using ng-keyup, checking if the key pressed was `enter` and calling the search method within the input element.