### PR TITLE
Update dev_setup_osx

### DIFF
--- a/docs/dev_setup_osx.rst
+++ b/docs/dev_setup_osx.rst
@@ -29,7 +29,7 @@ Install Python
 ==========================
 Install the latest version of Python 2.7 with Homebrew::
 
-    sudo brew install python
+    brew install python
 
 Upgrade Pip
 ==========================


### PR DESCRIPTION
Didn't realise at the time, Homebrew has now disabled the use of `sudo` with the `brew` command.

```
$ sudo brew install python
Error: Running Homebrew as root is extremely dangerous and no longer supported.
As Homebrew does not drop privileges on installation you would be giving all
build scripts full access to your system.
```

So I've updated the docs to remove `sudo`.