### PR TITLE
Optimize SQL for account delete

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -260,6 +260,12 @@ def _parse_accounts(account_str):
         return account_str.split(',')
 
 
+@manager.option('-n', '--name', dest='name', type=unicode, required=True)
+def delete_account(name):
+    from security_monkey.account_manager import delete_account_by_name
+    delete_account_by_name(name)
+
+
 class APIServer(Command):
     def __init__(self, host='127.0.0.1', port=app.config.get('API_PORT'), workers=6):
         self.address = "{}:{}".format(host, port)

--- a/security_monkey/views/account.py
+++ b/security_monkey/views/account.py
@@ -16,7 +16,7 @@ from security_monkey.views import AuthenticatedService
 from security_monkey.views import ACCOUNT_FIELDS
 from security_monkey.datastore import Account
 from security_monkey.datastore import User
-from security_monkey.account_manager import get_account_by_id
+from security_monkey.account_manager import get_account_by_id, delete_account_by_id
 from security_monkey import db, rbac
 
 from flask import request
@@ -187,19 +187,7 @@ class AccountGetPutDelete(AuthenticatedService):
             :statuscode 202: accepted
             :statuscode 401: Authentication Error. Please Login.
         """
-
-        # Need to unsubscribe any users first:
-        users = User.query.filter(User.accounts.any(Account.id == account_id)).all()
-        for user in users:
-            user.accounts = [account for account in user.accounts if not account.id == account_id]
-            db.session.add(user)
-        db.session.commit()
-
-        account = Account.query.filter(Account.id == account_id).first()
-
-        db.session.delete(account)
-        db.session.commit()
-
+        delete_account_by_id(account_id)
         return {'status': 'deleted'}, 202
 
 


### PR DESCRIPTION
Type: generic-bugfix

Why is this change necessary?
We were getting intermittent integrity errors and timeouts when
deleting accounts with many items and issues. This appears to be
caused by SQL Alchemy's method of handling cascading deletes,
which is inefficient and does not appear to handle transactional
locks well, allowing for race conditions.

This change addresses the need by:
Deleting accounts and related records with a raw sql query
