### PR TITLE
Fix reaudit issue for watchers in different intervals

### DIFF
--- a/security_monkey/reporter.py
+++ b/security_monkey/reporter.py
@@ -24,112 +24,98 @@
 
 from security_monkey.alerter import Alerter
 from security_monkey.monitors import all_monitors
+from security_monkey.account_manager import get_account_by_name
 from security_monkey import app, db
-
-import time
+from security_monkey.datastore import store_exception
 
 
 class Reporter(object):
     """Sets up all watchers and auditors and the alerters"""
 
-    def __init__(self, account=None, alert_accounts=None, debug=False):
-        self.account_watchers = {}
-        self.account_alerters = {}
-        if not alert_accounts:
-            alert_accounts = [account]
-
-        self.account_watchers[account] = []
-        for monitor in all_monitors(account, debug):
-            self.account_watchers[account].append((monitor))
-
-        if account in alert_accounts:
-            self.account_alerters[account] = Alerter(watchers_auditors=self.account_watchers[account], account=account)
+    def __init__(self, account=None, debug=False):
+        self.all_monitors = all_monitors(account, debug)
+        self.account_alerter = Alerter(watchers_auditors=self.all_monitors, account=account)
 
     def run(self, account, interval=None):
-        """Starts the process of watchers -> auditors -> alerters -> watchers.save()"""
+        """Starts the process of watchers -> auditors -> alerters """
         app.logger.info("Starting work on account {}.".format(account))
-        time1 = time.time()
-        mons = self.get_watchauditors(account, interval)
-        unique_watcher_results = self.slurp_unique_watchers(mons, account, interval)
+        mons = self.get_monitors_to_run(account, interval)
+        watchers_with_changes = set()
 
-        monitors_with_changes = set()
         for monitor in mons:
-            slurped_watcher_results = unique_watcher_results.get(monitor.watcher.index)
-            monitor.watcher.find_changes(slurped_watcher_results[0], slurped_watcher_results[1])
+            app.logger.info("Running slurp {} for {} ({} minutes interval)".format(monitor.watcher.i_am_singular, account, interval))
+            (items, exception_map) = monitor.watcher.slurp()
+            monitor.watcher.find_changes(items, exception_map)
             if (len(monitor.watcher.created_items) > 0) or (len(monitor.watcher.changed_items) > 0):
-                monitors_with_changes.add(monitor.watcher.index)
+                watchers_with_changes.add(monitor.watcher.index)
             monitor.watcher.save()
 
-        for monitor in mons:
+        db_account = get_account_by_name(account)
+
+        for monitor in self.all_monitors:
             for auditor in monitor.auditors:
-                items_to_audit = self.get_items_to_audit(monitor, auditor, unique_watcher_results.get(monitor.watcher.index), monitors_with_changes)
-                auditor.audit_these_objects(items_to_audit)
-                auditor.save_issues()
+                if auditor.applies_to_account(db_account):
+                    items_to_audit = self.get_items_to_audit(monitor.watcher, auditor, watchers_with_changes)
+                    app.logger.info("Running audit {} for {}".format(
+                                    monitor.watcher.index,
+                                    account))
 
-            app.logger.info("Account {} is done with {}".format(account, monitor.watcher.i_am_singular))
+                    try:
+                        auditor.audit_these_objects(items_to_audit)
+                        auditor.save_issues()
+                    except Exception as e:
+                        store_exception('reporter-run-auditor', (auditor.index, account), e)
+                        continue
 
-        time2 = time.time()
-        app.logger.info('Run Account %s took %0.1f s' % (account, (time2-time1)))
-
-        if account in self.account_alerters:
-            self.account_alerters[account].report()
+        self.account_alerter.report()
 
         db.session.close()
 
-    def get_watchauditors(self, account, interval=None):
+    def get_monitors_to_run(self, account, interval=None):
         """
         Return a list of (watcher, auditor) enabled for a specific account,
         optionally filtered by interval time
         """
         mons = []
         if interval:
-            for monitor in self.account_watchers[account]:
-                if interval == monitor.watcher.get_interval():
+            for monitor in self.all_monitors:
+                if monitor.watcher and interval == monitor.watcher.get_interval():
                     mons.append(monitor)
         else:
-            mons = self.account_watchers[account]
+            mons = self.all_monitors
         return mons
-
-    def slurp_unique_watchers(self, monitors, account, interval):
-        unique_watcher_results = {}
-        for monitor in monitors:
-            app.logger.info("Running {} for {} ({} minutes interval)".format(monitor.watcher.i_am_singular, account, interval))
-            (items, exception_map) = monitor.watcher.slurp()
-            unique_watcher_results[monitor.watcher.index] = [items, exception_map]
-
-        return unique_watcher_results
-
-    def get_alerters(self, account):
-        """ Return a list of alerters enabled for a specific account """
-        return self.account_alerters[account]
 
     def get_intervals(self, account):
         """ Returns current intervals for watchers """
         buckets = []
-        for monitor in self.get_watchauditors(account):
-            interval = monitor.watcher.get_interval()
-            if not interval in buckets:
-                buckets.append(interval)
+        for monitor in self.all_monitors:
+            if monitor.watcher:
+                interval = monitor.watcher.get_interval()
+                if not interval in buckets:
+                    buckets.append(interval)
         return buckets
 
-    def get_items_to_audit(self, monitor, auditor, slurped_watcher_results, monitors_with_changes):
+    def get_items_to_audit(self, watcher, auditor, watchers_with_changes):
         """
         Returns the items that have changed if there are no changes in dependencies,
         otherwise returns all slurped items for reauditing
         """
-        monitor.watcher.full_audit_list = None
+        watcher.full_audit_list = None
         if auditor.support_watcher_indexes:
             for support_watcher_index in auditor.support_watcher_indexes:
-                if support_watcher_index in monitors_with_changes:
-                    app.logger.debug("Upstream watcher changed {}. reauditing {}".format(support_watcher_index, monitor.watcher.index))
-                    monitor.watcher.full_audit_list = slurped_watcher_results[0]
+                if support_watcher_index in watchers_with_changes:
+                    app.logger.debug("Upstream watcher changed {}. reauditing {}".format(
+                                     support_watcher_index, watcher.index))
+
+                    watcher.full_audit_list = auditor.read_previous_items()
         if auditor.support_auditor_indexes:
             for support_auditor_index in auditor.support_auditor_indexes:
-                if support_auditor_index in monitors_with_changes:
-                    app.logger.debug("Upstream auditor changed {}. reauditing {}".format(support_auditor_index, monitor.watcher.index))
-                    monitor.watcher.full_audit_list = slurped_watcher_results[0]
+                if support_auditor_index in watchers_with_changes:
+                    app.logger.debug("Upstream auditor changed {}. reauditing {}".format(
+                                     support_auditor_index, watcher.index))
+                    watcher.full_audit_list = auditor.read_previous_items()
 
-        if monitor.watcher.full_audit_list:
-            return monitor.watcher.full_audit_list
+        if watcher.full_audit_list:
+            return watcher.full_audit_list
 
-        return [item for item in monitor.watcher.created_items + monitor.watcher.changed_items]
+        return [item for item in watcher.created_items + watcher.changed_items]

--- a/security_monkey/scheduler.py
+++ b/security_monkey/scheduler.py
@@ -14,7 +14,7 @@ from apscheduler.scheduler import Scheduler
 from sqlalchemy.exc import OperationalError, InvalidRequestError, StatementError
 
 from security_monkey.datastore import Account, clear_old_exceptions, store_exception
-from security_monkey.monitors import get_monitors, get_monitors_and_dependencies
+from security_monkey.monitors import get_monitors, get_monitors_and_dependencies, all_monitors
 from security_monkey.reporter import Reporter
 
 from security_monkey import app, db, jirasync
@@ -28,7 +28,7 @@ def run_change_reporter(account_names, interval=None):
     """ Runs Reporter """
     try:
         for account in account_names:
-            reporter = Reporter(account=account, alert_accounts=account_names, debug=True)
+            reporter = Reporter(account=account, debug=True)
             reporter.run(account, interval)
     except (OperationalError, InvalidRequestError, StatementError) as e:
         app.logger.exception("Database error processing accounts %s, cleaning up session.", account_names)
@@ -145,7 +145,7 @@ def setup_scheduler():
                     args=[[account], period]
                 )
             auditors = []
-            for monitor in rep.get_watchauditors(account):
+            for monitor in all_monitors(account):
                 auditors.extend(monitor.auditors)
             scheduler.add_cron_job(_audit_changes, hour=10, day_of_week="mon-fri", args=[account, auditors, True])
 

--- a/security_monkey/tests/core/monitor_mock.py
+++ b/security_monkey/tests/core/monitor_mock.py
@@ -24,7 +24,7 @@ from security_monkey.watcher import ChangeItem
 from collections import defaultdict
 
 RUNTIME_WATCHERS = defaultdict(list)
-RUNTIME_AUDITORS = defaultdict(list)
+RUNTIME_AUDIT_COUNTS = defaultdict(list)
 CURRENT_MONITORS = []
 
 
@@ -66,10 +66,12 @@ class MockRunnableAuditor(object):
         self.support_watcher_indexes = support_watcher_indexes
 
     def audit_all_objects(self):
-        RUNTIME_AUDITORS[self.index].append(self)
+        item_count = RUNTIME_AUDIT_COUNTS.get(self.index, 0)
+        RUNTIME_AUDIT_COUNTS[self.index] = item_count + 1
 
     def audit_these_objects(self, items):
-        RUNTIME_AUDITORS[self.index].append(self)
+        item_count = RUNTIME_AUDIT_COUNTS.get(self.index, 0)
+        RUNTIME_AUDIT_COUNTS[self.index] = item_count + len(items)
 
     def save_issues(self):
         pass

--- a/security_monkey/tests/core/test_reporter.py
+++ b/security_monkey/tests/core/test_reporter.py
@@ -1,0 +1,287 @@
+#     Copyright 2017 Bridgewater Associates
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.tests.test_reporter
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Bridgewater OSS <opensource@bwater.com>
+
+"""
+from security_monkey.tests import SecurityMonkeyTestCase
+from security_monkey.datastore import Account, AccountType
+from security_monkey.tests.core.monitor_mock import RUNTIME_WATCHERS, RUNTIME_AUDIT_COUNTS
+from security_monkey.tests.core.monitor_mock import build_mock_result
+from security_monkey.tests.core.monitor_mock import mock_all_monitors
+from security_monkey import db
+
+from mock import patch
+
+watcher_configs = [
+    {'index': 'index1', 'interval': 15},
+    {'index': 'index2', 'interval': 15},
+    {'index': 'index3', 'interval': 60}
+]
+
+auditor_configs_no_external_dependencies = [
+    {
+        'index': 'index1',
+        'support_auditor_indexes': [],
+        'support_watcher_indexes': ['index2']
+    },
+    {
+        'index': 'index2',
+        'support_auditor_indexes': ['index1'],
+        'support_watcher_indexes': []
+    },
+    {
+        'index': 'index3',
+        'support_auditor_indexes': [],
+        'support_watcher_indexes': []
+    }
+]
+
+auditor_configs_with_auditor_dependencies = [
+    {
+        'index': 'index1',
+        'support_auditor_indexes': [],
+        'support_watcher_indexes': ['index2']
+    },
+    {
+        'index': 'index2',
+        'support_auditor_indexes': ['index1'],
+        'support_watcher_indexes': []
+    },
+    {
+        'index': 'index3',
+        'support_auditor_indexes': ['index1'],
+        'support_watcher_indexes': []
+    }
+]
+
+auditor_configs_with_watcher_dependencies = [
+    {
+        'index': 'index1',
+        'support_auditor_indexes': [],
+        'support_watcher_indexes': ['index2']
+    },
+    {
+        'index': 'index2',
+        'support_auditor_indexes': ['index1'],
+        'support_watcher_indexes': []
+    },
+    {
+        'index': 'index3',
+        'support_auditor_indexes': [],
+        'support_watcher_indexes': ['index1']
+    }
+]
+
+
+def mock_report(self):
+    pass
+
+
+@patch('security_monkey.monitors.all_monitors', mock_all_monitors)
+class ReporterTestCase(SecurityMonkeyTestCase):
+
+    def pre_test_setup(self):
+        account_type_result = AccountType(name='AWS')
+        db.session.add(account_type_result)
+        db.session.commit()
+
+        account = Account(number="012345678910", name="TEST_ACCOUNT",
+                          s3_name="TEST_ACCOUNT", role_name="TEST_ACCOUNT",
+                          account_type_id=account_type_result.id, notes="TEST_ACCOUNT",
+                          third_party=False, active=True)
+
+        db.session.add(account)
+        db.session.commit()
+
+        RUNTIME_WATCHERS.clear()
+        RUNTIME_AUDIT_COUNTS.clear()
+
+    @patch('security_monkey.alerter.Alerter.report', new=mock_report)
+    def test_run_with_interval_no_dependencies(self):
+        """
+        If an interval is passed to reporter.run(), the reporter will run all watchers in the interval
+        along with their auditors. It will also reaudit all existing items of watchers that are not in
+        the interval but are dependent on watchers/auditors in the interval. This is done because any
+        changes to the dependencies could change the audit results even is the items have not changed.
+
+        In this case, index1 and index2 are in the interval and index3 is not dependent on either.
+        Expected result:
+        Watchers of index1 and index2 are run
+        New items of index1 and index2 are audited
+        Items of index3 are not reaudited
+        """
+        from security_monkey.reporter import Reporter
+        build_mock_result(watcher_configs, auditor_configs_no_external_dependencies)
+
+        reporter = Reporter(account="TEST_ACCOUNT")
+        reporter.run("TEST_ACCOUNT", 15)
+        watcher_keys = RUNTIME_WATCHERS.keys()
+        self.assertEqual(first=2, second=len(watcher_keys),
+                         msg="Should run 2 watchers but ran {}"
+                         .format(len(watcher_keys)))
+
+        self.assertTrue('index1' in watcher_keys,
+                        msg="Watcher index1 not run")
+        self.assertTrue('index2' in watcher_keys,
+                        msg="Watcher index2 not run")
+
+        self.assertEqual(first=1, second=len(RUNTIME_WATCHERS['index1']),
+                         msg="Watcher index1 should run once but ran {} times"
+                         .format(len(RUNTIME_WATCHERS['index1'])))
+        self.assertEqual(first=1, second=len(RUNTIME_WATCHERS['index2']),
+                         msg="Watcher index2 should run once but ran {} times"
+                         .format(len(RUNTIME_WATCHERS['index2'])))
+
+        auditor_keys = RUNTIME_AUDIT_COUNTS.keys()
+        self.assertEqual(first=3, second=len(auditor_keys),
+                         msg="Should run all 3 auditors but ran {}"
+                         .format(len(auditor_keys)))
+
+        self.assertTrue('index1' in auditor_keys,
+                        msg="Auditor index1 not run")
+        self.assertTrue('index2' in auditor_keys,
+                        msg="Auditor index2 not run")
+        self.assertTrue('index3' in auditor_keys,
+                        msg="Auditor index3 not run")
+
+        self.assertEqual(first=1, second=RUNTIME_AUDIT_COUNTS['index1'],
+                         msg="Auditor index1 should have audited 1 item but audited {}"
+                         .format(RUNTIME_AUDIT_COUNTS['index1']))
+        self.assertEqual(first=1, second=RUNTIME_AUDIT_COUNTS['index2'],
+                         msg="Auditor index2 should have audited 1 item but audited {}"
+                         .format(RUNTIME_AUDIT_COUNTS['index2']))
+        self.assertEqual(first=0, second=RUNTIME_AUDIT_COUNTS['index3'],
+                         msg="Auditor index3 should have audited no items but audited {}"
+                         .format(RUNTIME_AUDIT_COUNTS['index3']))
+
+    @patch('security_monkey.alerter.Alerter.report', new=mock_report)
+    def test_run_with_interval_auditor_dependencies(self):
+        """
+        If an interval is passed to reporter.run(), the reporter will run all watchers in the interval
+        along with their auditors. It will also reaudit all existing items of watchers that are not in
+        the interval but are dependent on watchers/auditors in the interval. This is done because any
+        changes to the dependencies could change the audit results even is the items have not changed.
+
+        In this case, index1 and index2 are in the interval and index3 is dependent on index1 auditor.
+        Expected result:
+        Watchers of index1 and index2 are run
+        New items of index1 and index2 are audited
+        Items of index3 are reaudited
+        """
+        from security_monkey.reporter import Reporter
+        build_mock_result(watcher_configs, auditor_configs_with_auditor_dependencies)
+
+        reporter = Reporter(account="TEST_ACCOUNT")
+        reporter.run("TEST_ACCOUNT", 15)
+        watcher_keys = RUNTIME_WATCHERS.keys()
+        self.assertEqual(first=2, second=len(watcher_keys),
+                         msg="Should run 2 watchers but ran {}"
+                         .format(len(watcher_keys)))
+
+        self.assertTrue('index1' in watcher_keys,
+                        msg="Watcher index1 not run")
+        self.assertTrue('index2' in watcher_keys,
+                        msg="Watcher index2 not run")
+
+        self.assertEqual(first=1, second=len(RUNTIME_WATCHERS['index1']),
+                         msg="Watcher index1 should run once but ran {} times"
+                         .format(len(RUNTIME_WATCHERS['index1'])))
+        self.assertEqual(first=1, second=len(RUNTIME_WATCHERS['index2']),
+                         msg="Watcher index2 should run once but ran {} times"
+                         .format(len(RUNTIME_WATCHERS['index2'])))
+
+        auditor_keys = RUNTIME_AUDIT_COUNTS.keys()
+        self.assertEqual(first=3, second=len(auditor_keys),
+                         msg="Should run 3 auditors but ran {}"
+                         .format(len(auditor_keys)))
+
+        self.assertTrue('index1' in auditor_keys,
+                        msg="Auditor index1 not run")
+        self.assertTrue('index2' in auditor_keys,
+                        msg="Auditor index2 not run")
+        self.assertTrue('index3' in auditor_keys,
+                        msg="Auditor index3 not run")
+
+        self.assertEqual(first=1, second=RUNTIME_AUDIT_COUNTS['index1'],
+                         msg="Auditor index1 should have audited 1 item but audited {}"
+                         .format(RUNTIME_AUDIT_COUNTS['index1']))
+        self.assertEqual(first=1, second=RUNTIME_AUDIT_COUNTS['index2'],
+                         msg="Auditor index2 should have audited 1 item but audited {}"
+                         .format(RUNTIME_AUDIT_COUNTS['index2']))
+        self.assertEqual(first=1, second=RUNTIME_AUDIT_COUNTS['index3'],
+                         msg="Auditor index3 should have audited 1 item but audited {}"
+                         .format(RUNTIME_AUDIT_COUNTS['index3']))
+
+    @patch('security_monkey.alerter.Alerter.report', new=mock_report)
+    def test_run_with_interval_watcher_dependencies(self):
+        """
+        If an interval is passed to reporter.run(), the reporter will run all watchers in the interval
+        along with their auditors. It will also reaudit all existing items of watchers that are not in
+        the interval but are dependent on watchers/auditors in the interval. This is done because any
+        changes to the dependencies could change the audit results even is the items have not changed.
+
+        In this case, index1 and index2 are in the interval and index3 is dependent on index1 watcher.
+        Expected result:
+        Watchers of index1 and index2 are run
+        New items of index1 and index2 are audited
+        Items of index3 are reaudited
+        """
+        from security_monkey.reporter import Reporter
+        build_mock_result(watcher_configs, auditor_configs_with_watcher_dependencies)
+
+        reporter = Reporter(account="TEST_ACCOUNT")
+        reporter.run("TEST_ACCOUNT", 15)
+        watcher_keys = RUNTIME_WATCHERS.keys()
+        self.assertEqual(first=2, second=len(watcher_keys),
+                         msg="Should run 2 watchers but ran {}"
+                         .format(len(watcher_keys)))
+
+        self.assertTrue('index1' in watcher_keys,
+                        msg="Watcher index1 not run")
+        self.assertTrue('index2' in watcher_keys,
+                        msg="Watcher index2 not run")
+
+        self.assertEqual(first=1, second=len(RUNTIME_WATCHERS['index1']),
+                         msg="Watcher index1 should have audited 1 item but audited {}"
+                         .format(len(RUNTIME_WATCHERS['index1'])))
+        self.assertEqual(first=1, second=len(RUNTIME_WATCHERS['index2']),
+                         msg="Watcher index2 should have audited 1 item but audited {}"
+                         .format(len(RUNTIME_WATCHERS['index2'])))
+
+        auditor_keys = RUNTIME_AUDIT_COUNTS.keys()
+        self.assertEqual(first=3, second=len(auditor_keys),
+                         msg="Should run 3 auditors but ran {}"
+                         .format(len(auditor_keys)))
+
+        self.assertTrue('index1' in auditor_keys,
+                        msg="Auditor index1 not run")
+        self.assertTrue('index2' in auditor_keys,
+                        msg="Auditor index2 not run")
+        self.assertTrue('index3' in auditor_keys,
+                        msg="Auditor index3 not run")
+
+        self.assertEqual(first=1, second=RUNTIME_AUDIT_COUNTS['index1'],
+                         msg="Auditor index1 should run once but ran {} times"
+                         .format(RUNTIME_AUDIT_COUNTS['index1']))
+        self.assertEqual(first=1, second=RUNTIME_AUDIT_COUNTS['index2'],
+                         msg="Auditor index2 should run once but ran {} times"
+                         .format(RUNTIME_AUDIT_COUNTS['index2']))
+        self.assertEqual(first=1, second=RUNTIME_AUDIT_COUNTS['index3'],
+                         msg="Auditor index3 should run once but ran {} times"
+                         .format(RUNTIME_AUDIT_COUNTS['index3']))

--- a/security_monkey/tests/core/test_scheduler.py
+++ b/security_monkey/tests/core/test_scheduler.py
@@ -21,7 +21,7 @@
 """
 from security_monkey.tests import SecurityMonkeyTestCase
 from security_monkey.datastore import Account, AccountType
-from security_monkey.tests.core.monitor_mock import RUNTIME_WATCHERS, RUNTIME_AUDITORS
+from security_monkey.tests.core.monitor_mock import RUNTIME_WATCHERS, RUNTIME_AUDIT_COUNTS
 from security_monkey.tests.core.monitor_mock import build_mock_result
 from security_monkey.tests.core.monitor_mock import mock_get_monitors, mock_all_monitors
 from security_monkey import db
@@ -95,7 +95,7 @@ class SchedulerTestCase(SecurityMonkeyTestCase):
         db.session.commit()
 
         RUNTIME_WATCHERS.clear()
-        RUNTIME_AUDITORS.clear()
+        RUNTIME_AUDIT_COUNTS.clear()
 
     def test_find_all_changes(self):
         from security_monkey.scheduler import find_changes
@@ -126,7 +126,7 @@ class SchedulerTestCase(SecurityMonkeyTestCase):
                          msg="Watcher index2 should run twice but ran {} times"
                          .format(len(RUNTIME_WATCHERS['index3'])))
 
-        auditor_keys = RUNTIME_AUDITORS.keys()
+        auditor_keys = RUNTIME_AUDIT_COUNTS.keys()
         self.assertEqual(first=3, second=len(auditor_keys),
                          msg="Should run 3 auditors but ran {}"
                          .format(len(auditor_keys)))
@@ -138,15 +138,15 @@ class SchedulerTestCase(SecurityMonkeyTestCase):
         self.assertTrue('index3' in auditor_keys,
                         msg="Auditor index3 not run")
 
-        self.assertEqual(first=2, second=len(RUNTIME_AUDITORS['index1']),
-                         msg="Auditor index1 should run twice but ran {} times"
-                         .format(len(RUNTIME_AUDITORS['index1'])))
-        self.assertEqual(first=2, second=len(RUNTIME_AUDITORS['index2']),
-                         msg="Auditor index2 should run twice but ran {} times"
-                         .format(len(RUNTIME_AUDITORS['index2'])))
-        self.assertEqual(first=2, second=len(RUNTIME_AUDITORS['index3']),
-                         msg="Auditor index3 should run twice but ran {} times"
-                         .format(len(RUNTIME_AUDITORS['index3'])))
+        self.assertEqual(first=2, second=RUNTIME_AUDIT_COUNTS['index1'],
+                         msg="Auditor index1 should have audited 2 items but audited {}"
+                         .format(RUNTIME_AUDIT_COUNTS['index1']))
+        self.assertEqual(first=2, second=RUNTIME_AUDIT_COUNTS['index2'],
+                         msg="Auditor index2 should have audited 2 items but audited {}"
+                         .format(RUNTIME_AUDIT_COUNTS['index2']))
+        self.assertEqual(first=2, second=RUNTIME_AUDIT_COUNTS['index3'],
+                         msg="Auditor index3 should have audited 2 items but audited {}"
+                         .format(RUNTIME_AUDIT_COUNTS['index3']))
 
     def test_find_account_changes(self):
         from security_monkey.scheduler import find_changes
@@ -177,7 +177,7 @@ class SchedulerTestCase(SecurityMonkeyTestCase):
                          msg="Watcher index2 should run once but ran {} times"
                          .format(len(RUNTIME_WATCHERS['index3'])))
 
-        auditor_keys = RUNTIME_AUDITORS.keys()
+        auditor_keys = RUNTIME_AUDIT_COUNTS.keys()
         self.assertEqual(first=3, second=len(auditor_keys),
                          msg="Should run 3 auditors but ran {}"
                          .format(len(auditor_keys)))
@@ -189,15 +189,15 @@ class SchedulerTestCase(SecurityMonkeyTestCase):
         self.assertTrue('index3' in auditor_keys,
                         msg="Auditor index3 not run")
 
-        self.assertEqual(first=1, second=len(RUNTIME_AUDITORS['index1']),
-                         msg="Auditor index1 should run once but ran {} times"
-                         .format(len(RUNTIME_AUDITORS['index1'])))
-        self.assertEqual(first=1, second=len(RUNTIME_AUDITORS['index2']),
-                         msg="Auditor index2 should run once but ran {} times"
-                         .format(len(RUNTIME_AUDITORS['index2'])))
-        self.assertEqual(first=1, second=len(RUNTIME_AUDITORS['index3']),
-                         msg="Auditor index3 should run once but ran {} times"
-                         .format(len(RUNTIME_AUDITORS['index3'])))
+        self.assertEqual(first=1, second=RUNTIME_AUDIT_COUNTS['index1'],
+                         msg="Auditor index1 should have audited 1 item but audited {}"
+                         .format(RUNTIME_AUDIT_COUNTS['index1']))
+        self.assertEqual(first=1, second=RUNTIME_AUDIT_COUNTS['index2'],
+                         msg="Auditor index2 should have audited 1 item but audited {}"
+                         .format(RUNTIME_AUDIT_COUNTS['index2']))
+        self.assertEqual(first=1, second=RUNTIME_AUDIT_COUNTS['index3'],
+                         msg="Auditor index3 should have audited 1 item but audited {}"
+                         .format(RUNTIME_AUDIT_COUNTS['index3']))
 
     def test_disable_all_accounts(self):
         from security_monkey.scheduler import disable_accounts


### PR DESCRIPTION
Type: bugfix

Why is this change necessary?
The reporter functionality that looks for auditors that are dependent
on watchers that have changes does not currently apply when watchers
are run in different intervals. This can lead to technology types
not being reaudited when dependencies change

This change addresses the need by:
Looking at all monitors when determining which auditors to rerun

Potential Side Effects:
Watcher results are now saved as watchers are run, not when all
watchers are complete