### PR TITLE
Add bulk enable and disable account service

### DIFF
--- a/dart/lib/component/settings_component/settings_component.dart
+++ b/dart/lib/component/settings_component/settings_component.dart
@@ -13,6 +13,8 @@ class SettingsComponent extends PaginatedTable {
     List<AuditorSetting> auditorlist;
     ObjectStore store;
     UserSetting user_setting;
+    bool active_edit_mode = false;
+
 
     SettingsComponent(this.router, this.store, this.us) {
         accounts = new List<Account>();
@@ -93,6 +95,22 @@ class SettingsComponent extends PaginatedTable {
 
     void createAccount() {
         router.go('createaccount', {});
+    }
+
+    void toggleActiveEditMode() {
+        super.is_loaded = false;
+        this.active_edit_mode = true;
+        super.is_loaded = true;
+    }
+
+    void storeActive() {
+        super.is_loaded = false;
+        AccountBulkUpdate bulkUpdate = new AccountBulkUpdate.fromAccountList(this.accounts);
+
+        this.store.update(bulkUpdate).then((_) {
+            this.active_edit_mode = false;
+            super.is_loaded = true;
+        });
     }
 
     void disableAuditor(auditor) {

--- a/dart/lib/component/settings_component/settings_component.html
+++ b/dart/lib/component/settings_component/settings_component.html
@@ -48,7 +48,11 @@
                     <table class="table table-striped">
                         <tr>
                             <th>Notify</th>
-                            <th>Active</th>
+                            <th ng-if="!us.hasRole('Admin')">Active</th>
+                            <td ng-if="us.hasRole('Admin')">
+                                <button ng-if="!active_edit_mode" class="btn btn-xs" ng-click="toggleActiveEditMode()">Active</button>
+                                <button ng-if="active_edit_mode" class="btn btn-xs btn-danger" ng-click="storeActive()">Submit</button>
+                            </td>
                             <th ng-click="sort_column('third_party')">
                                 Third Party
                                 <span ng-class="class_for_column('third_party')"></span>
@@ -77,10 +81,15 @@
                               <input ng-if="enabledValueForAccount(account.active, account.third_party) && notificationValueForAccount(account.id)" type='checkbox' checked ng-click="toggleNotificationForAccount(account.id)">
                               <input ng-if="enabledValueForAccount(account.active, account.third_party) && !notificationValueForAccount(account.id)" type='checkbox' ng-click="toggleNotificationForAccount(account.id)">
                             </td>
-                            <td ng-if="account.active"><div class="text-center"><i class="glyphicon glyphicon-ok"></i></div></td>
-                            <td ng-if="!account.active"><div class="text-center"><i class="glyphicon glyphicon-remove"></i></div></td>
-                            <td ng-if="account.third_party"><div class="text-center"><i class="glyphicon glyphicon-ok"></i></div></td>
-                            <td ng-if="!account.third_party"><div class="text-center"><i class="glyphicon glyphicon-remove"></i></div></td>
+                            <td ng-if="!active_edit_mode">
+                              <div ng-if="account.active" class="text-left"><i class="glyphicon glyphicon-ok"></i></div>
+                              <div ng-if="!account.active" class="text-left"><i class="glyphicon glyphicon-remove"></i></div>
+                            </td>
+                            <td ng-if="active_edit_mode">
+                              <input type='checkbox' ng-model="account.active">
+                            </td>
+                            <td ng-if="account.third_party"><div class="text-left"><i class="glyphicon glyphicon-ok"></i></div></td>
+                            <td ng-if="!account.third_party"><div class="text-left"><i class="glyphicon glyphicon-remove"></i></div></td>
                             <td ng-if="us.hasRole('Admin')"><a href="#/viewaccount/{{account.id}}">{{account.name}}</a></td>
                             <td ng-if="!us.hasRole('Admin')">{{account.name}}</td>
                             <td>{{account.account_type}}</td>

--- a/dart/lib/model/AccountBulkUpdate.dart
+++ b/dart/lib/model/AccountBulkUpdate.dart
@@ -1,0 +1,20 @@
+library security_monkey.account_bulk_update;
+
+import 'Account.dart';
+import 'dart:convert';
+
+class AccountBulkUpdate {
+    Map<List> accounts_map = new Map<List>();
+
+    AccountBulkUpdate();
+
+    AccountBulkUpdate.fromAccountList(List<Account> accounts) {
+        for (var account in accounts) {
+            this.accounts_map[account.name] = account.active;
+        }
+    }
+
+    String toJson() {
+        return JSON.encode(this.accounts_map);
+    }
+}

--- a/dart/lib/model/hammock_config.dart
+++ b/dart/lib/model/hammock_config.dart
@@ -14,19 +14,21 @@ import 'ignore_entry.dart';
 import 'User.dart';
 import 'Role.dart';
 import 'account_config.dart';
+import 'AccountBulkUpdate.dart';
 
 @MirrorsUsed(
         targets: const[
             Account, IgnoreEntry, Issue, AuditorSetting,
             Item, ItemComment, NetworkWhitelistEntry,
             Revision, RevisionComment, UserSetting, User, Role,
-            AccountConfig],
+            AccountConfig, AccountBulkUpdate],
         override: '*')
 import 'dart:mirrors';
 
 import 'package:security_monkey/util/constants.dart';
 
 Resource serializeAccount(Account account) => resource("accounts", account.id, account.toJson());
+Resource serializeAccountBulkUpdate(AccountBulkUpdate bulk_update) => resource("accounts_bulk", "batch", bulk_update.toJson());
 final serializeIssue = serializer("issues", ["id", "score", "issue", "notes", "justified", "justified_user", "justification", "justified_date", "item_id"]);
 final serializeRevision = serializer("revisions", ["id", "item_id", "config", "active", "date_created", "diff_html"]);
 final serializeItem = serializer("items", ["id", "technology", "region", "account", "name"]);
@@ -131,6 +133,10 @@ createHammockConfig(Injector inj) {
                     "deserializer": {
                         "query": deserializeRole
                     }
+                },
+                "account_bulk_update": {
+                    "type": AccountBulkUpdate,
+                    "serializer": serializeAccountBulkUpdate
                 }
             })
             ..urlRewriter.baseUrl = '$API_HOST'

--- a/dart/lib/security_monkey.dart
+++ b/dart/lib/security_monkey.dart
@@ -37,6 +37,7 @@ import 'model/Role.dart';
 import 'model/ItemLink.dart';
 import 'model/account_config.dart';
 import 'model/custom_field_config.dart';
+import 'model/AccountBulkUpdate.dart';
 
 // Routing
 import 'routing/securitymonkey_router.dart';

--- a/security_monkey/__init__.py
+++ b/security_monkey/__init__.py
@@ -163,6 +163,10 @@ api.add_resource(AuditorSettingsPut, '/api/1/auditorsettings/<int:as_id>')
 from security_monkey.views.account_config import AccountConfigGet
 api.add_resource(AccountConfigGet, '/api/1/account_config/<string:account_type>')
 
+from security_monkey.views.account_bulk_update import AccountListPut
+api.add_resource(AccountListPut, '/api/1/accounts_bulk/batch')
+
+
 ## Jira Sync
 import os
 from security_monkey.jirasync import JiraSync
@@ -204,7 +208,7 @@ def setup_logging():
         LOG_LEVEL = "DEBUG"
         LOG_FILE = "/var/log/security_monkey/securitymonkey.log"
 
-    2) Set LOG_CFG in your config to a PEP-0391 compatible 
+    2) Set LOG_CFG in your config to a PEP-0391 compatible
     logging configuration.
 
         LOG_CFG = {

--- a/security_monkey/scheduler.py
+++ b/security_monkey/scheduler.py
@@ -59,6 +59,30 @@ def audit_changes(accounts, monitor_names, send_report, debug=True):
             _audit_changes(account, monitor.auditors, send_report, debug)
 
 
+def disable_accounts(account_names):
+    for account_name in account_names:
+        account = Account.query.filter(Account.name == account_name).first()
+        if account:
+            app.logger.debug("Disabling account %s", account.name)
+            account.active = False
+            db.session.add(account)
+
+    db.session.commit()
+    db.session.close()
+
+
+def enable_accounts(account_names):
+    for account_name in account_names:
+        account = Account.query.filter(Account.name == account_name).first()
+        if account:
+            app.logger.debug("Enabling account %s", account.name)
+            account.active = True
+            db.session.add(account)
+
+    db.session.commit()
+    db.session.close()
+
+
 def _audit_changes(account, auditors, send_report, debug=True):
     """ Runs auditors on all items """
     try:

--- a/security_monkey/tests/core/test_scheduler.py
+++ b/security_monkey/tests/core/test_scheduler.py
@@ -198,3 +198,57 @@ class SchedulerTestCase(SecurityMonkeyTestCase):
         self.assertEqual(first=1, second=len(RUNTIME_AUDITORS['index3']),
                          msg="Auditor index3 should run once but ran {} times"
                          .format(len(RUNTIME_AUDITORS['index3'])))
+
+    def test_disable_all_accounts(self):
+        from security_monkey.scheduler import disable_accounts
+        disable_accounts(['TEST_ACCOUNT1', 'TEST_ACCOUNT2', 'TEST_ACCOUNT3', 'TEST_ACCOUNT4'])
+        accounts = Account.query.all()
+        for account in accounts:
+            self.assertFalse(account.active)
+
+    def test_disable_one_accounts(self):
+        from security_monkey.scheduler import disable_accounts
+        disable_accounts(['TEST_ACCOUNT1'])
+        accounts = Account.query.all()
+        for account in accounts:
+            if account.name == 'TEST_ACCOUNT2':
+                self.assertTrue(account.active)
+            else:
+                self.assertFalse(account.active)
+
+    def test_enable_all_accounts(self):
+        from security_monkey.scheduler import enable_accounts
+        enable_accounts(['TEST_ACCOUNT1', 'TEST_ACCOUNT2', 'TEST_ACCOUNT3', 'TEST_ACCOUNT4'])
+        accounts = Account.query.all()
+        for account in accounts:
+            self.assertTrue(account.active)
+
+    def test_enable_one_accounts(self):
+        from security_monkey.scheduler import enable_accounts
+        enable_accounts(['TEST_ACCOUNT3'])
+        accounts = Account.query.all()
+        for account in accounts:
+            if account.name != 'TEST_ACCOUNT4':
+                self.assertTrue(account.active)
+            else:
+                self.assertFalse(account.active)
+
+    def test_enable_bad_accounts(self):
+        from security_monkey.scheduler import enable_accounts
+        enable_accounts(['BAD_ACCOUNT'])
+        accounts = Account.query.all()
+        for account in accounts:
+            if account.name == 'TEST_ACCOUNT1' or account.name == 'TEST_ACCOUNT2':
+                self.assertTrue(account.active)
+            else:
+                self.assertFalse(account.active)
+
+    def test_disable_bad_accounts(self):
+        from security_monkey.scheduler import disable_accounts
+        disable_accounts(['BAD_ACCOUNT'])
+        accounts = Account.query.all()
+        for account in accounts:
+            if account.name == 'TEST_ACCOUNT1' or account.name == 'TEST_ACCOUNT2':
+                self.assertTrue(account.active)
+            else:
+                self.assertFalse(account.active)

--- a/security_monkey/views/account_bulk_update.py
+++ b/security_monkey/views/account_bulk_update.py
@@ -1,0 +1,57 @@
+#     Copyright 2017 Bridgewater Associates, LP
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.views.account_bulk_update
+    :platform: Unix
+    :synopsis: Updates the active flag for a list of accounts.
+
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Bridgewater OSS <opensource@bwater.com>
+
+
+"""
+
+
+from security_monkey.views import AuthenticatedService
+from security_monkey.datastore import Account
+from security_monkey import app, db, rbac
+
+from flask import request
+from flask_restful import reqparse
+import json
+
+
+class AccountListPut(AuthenticatedService):
+    decorators = [
+        rbac.allow(["Admin"], ["PUT"])
+    ]
+
+    def __init__(self):
+        super(AccountListPut, self).__init__()
+        self.reqparse = reqparse.RequestParser()
+
+    def put(self):
+        values = json.loads(request.json)
+        app.logger.debug("Account bulk update {}".format(values))
+        for account_name in values.keys():
+            account = Account.query.filter(Account.name == account_name).first()
+            if account:
+                account.active = values[account_name]
+                db.session.add(account)
+
+        db.session.commit()
+        db.session.close()
+
+        return {'status': 'updated'}, 200

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'itsdangerous==0.23',
         'psycopg2==2.6.2',
         'bcrypt==3.1.2',
-        'Sphinx==1.2.2',
+        'Sphinx==1.5.1',
         'gunicorn==18.0',
         'cryptography==1.7.1',
         'boto3>=1.4.2',


### PR DESCRIPTION
Replaces #534  (Fixes merge conflict.)

from @kalpatel01:

Type: generic-large-feature

Why is this change necessary?
We've run into instances where we have wanted to reconfigure watcher run
intervals to improve performance or even remove watchers that were
causing problems. Currently this requires logging into the server and
physically changing the code

This change addresses the need by:
Provides a Watcher Config page in Settings and an api where a user can
configure the run interval and the active flag

Potential Side Effects:
No known side effects