### PR TITLE
Handle unicode name tags

### DIFF
--- a/security_monkey/watchers/vpc/peering.py
+++ b/security_monkey/watchers/vpc/peering.py
@@ -77,7 +77,7 @@ class Peering(Watcher):
 
                     if not (peering_name is None):
                         peering_name = "{0} ({1})".format(
-                            peering_name, connection_id)
+                            peering_name.encode('utf-8', 'ignore'), connection_id)
                     else:
                         peering_name = connection_id
 


### PR DESCRIPTION
Type: generic-bugfix

Why is this change necessary?
The peering watcher was throwing an exception when the name tag
contained unicode characters.

This change addresses the need by:
Encoding the name tag before processing

Potential Side Effects:
No known side effects