### PR TITLE
Reduce AWS managed policy audit noise

### DIFF
--- a/security_monkey/auditors/iam/managed_policy.py
+++ b/security_monkey/auditors/iam/managed_policy.py
@@ -22,6 +22,21 @@
 from security_monkey.watchers.iam.managed_policy import ManagedPolicy
 from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
 
+def is_aws_managed_policy(iam_obj):
+    if 'arn:aws:iam::aws:policy/' in iam_obj.config['arn']:
+        return True
+    else:
+        return False
+
+def has_attached_resources(iam_obj):
+    if iam_obj.config['attached_users'] and len(iam_obj.config['attached_users']) > 0:
+        return True
+    elif iam_obj.config['attached_roles'] and len(iam_obj.config['attached_roles']) > 0:
+        return True
+    elif iam_obj.config['attached_groups'] and len(iam_obj.config['attached_groups']) > 0:
+        return True
+    else:
+        return False
 
 class ManagedPolicyAuditor(IAMPolicyAuditor):
     index = ManagedPolicy.index
@@ -41,42 +56,46 @@ class ManagedPolicyAuditor(IAMPolicyAuditor):
         """
         alert when an IAM Object has a policy allowing '*'.
         """
-        self.library_check_iamobj_has_star_privileges(
-            iam_object,
-            policies_key='policy',
-            multiple_policies=False
-        )
+        if not is_aws_managed_policy(iam_object) or (is_aws_managed_policy(iam_object) and has_attached_resources(iam_object)):
+            self.library_check_iamobj_has_star_privileges(
+                iam_object,
+                policies_key='policy',
+                multiple_policies=False
+            )
 
     def check_iam_star_privileges(self, iam_object):
         """
         alert when an IAM Object has a policy allowing 'iam:*'.
         """
-        self.library_check_iamobj_has_iam_star_privileges(
-            iam_object,
-            policies_key='policy',
-            multiple_policies=False
-        )
+        if not is_aws_managed_policy(iam_object) or (is_aws_managed_policy(iam_object) and has_attached_resources(iam_object)):
+            self.library_check_iamobj_has_iam_star_privileges(
+                iam_object,
+                policies_key='policy',
+                multiple_policies=False
+            )
 
     def check_iam_privileges(self, iam_object):
         """
         alert when an IAM Object has a policy allowing 'iam:XxxxxXxxx'.
         """
-        self.library_check_iamobj_has_iam_privileges(
-            iam_object,
-            policies_key='policy',
-            multiple_policies=False
-        )
+        if not is_aws_managed_policy(iam_object) or (is_aws_managed_policy(iam_object) and has_attached_resources(iam_object)):
+            self.library_check_iamobj_has_iam_privileges(
+                iam_object,
+                policies_key='policy',
+                multiple_policies=False
+            )
 
     def check_iam_passrole(self, iam_object):
         """
         alert when an IAM Object has a policy allowing 'iam:PassRole'.
         This allows the object to pass any role specified in the resource block to an ec2 instance.
         """
-        self.library_check_iamobj_has_iam_passrole(
-            iam_object,
-            policies_key='policy',
-            multiple_policies=False
-        )
+        if not is_aws_managed_policy(iam_object) or (is_aws_managed_policy(iam_object) and has_attached_resources(iam_object)):
+            self.library_check_iamobj_has_iam_passrole(
+                iam_object,
+                policies_key='policy',
+                multiple_policies=False
+            )
 
     def check_notaction(self, iam_object):
         """
@@ -84,19 +103,20 @@ class ManagedPolicyAuditor(IAMPolicyAuditor):
         NotAction combined with an "Effect": "Allow" often provides more privilege
         than is desired.
         """
-        self.library_check_iamobj_has_notaction(
-            iam_object,
-            policies_key='policy',
-            multiple_policies=False
-        )
+        if not is_aws_managed_policy(iam_object) or (is_aws_managed_policy(iam_object) and has_attached_resources(iam_object)):
+            self.library_check_iamobj_has_notaction(
+                iam_object,
+                policies_key='policy',
+                multiple_policies=False
+            )
 
     def check_security_group_permissions(self, iam_object):
         """
         alert when an IAM Object has ec2:AuthorizeSecurityGroupEgress or ec2:AuthorizeSecurityGroupIngress.
         """
-        self.library_check_iamobj_has_security_group_permissions(
-            iam_object,
-            policies_key='policy',
-            multiple_policies=False
-        )
-
+        if not is_aws_managed_policy(iam_object) or (is_aws_managed_policy(iam_object) and has_attached_resources(iam_object)):
+            self.library_check_iamobj_has_security_group_permissions(
+                iam_object,
+                policies_key='policy',
+                multiple_policies=False
+            )

--- a/security_monkey/tests/auditors/test_managed_policy.py
+++ b/security_monkey/tests/auditors/test_managed_policy.py
@@ -1,0 +1,100 @@
+#     Copyright 2017 Bridgewater Associates
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.tests.auditors.test_managed_policy
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Bridgewater OSS <opensource@bwater.com>
+
+"""
+from security_monkey.tests import SecurityMonkeyTestCase
+from security_monkey.auditors.iam.managed_policy import ManagedPolicyAuditor
+from security_monkey.watchers.iam.managed_policy import ManagedPolicyItem
+
+
+FULL_ADMIN_POLICY_BARE = """
+{
+    "Statement":    {
+        "Effect": "Allow",
+        "Action": "*"
+    }
+}
+"""
+
+
+class ManagedPolicyAuditorTestCase(SecurityMonkeyTestCase):
+
+    def test_issue_on_non_aws_policy(self):
+        import json
+
+        config = {
+            'policy': json.loads(FULL_ADMIN_POLICY_BARE),
+            'arn': 'arn:aws:iam::123456789:policy/TEST',
+            'attached_users': [],
+            'attached_roles': [],
+            'attached_groups': []
+        }
+
+        auditor = ManagedPolicyAuditor(accounts=['unittest'])
+        policyobj = ManagedPolicyItem(account="TEST_ACCOUNT", name="policy_test", config=config)
+
+        self.assertIs(len(policyobj.audit_issues), 0,
+                      "Managed Policy should have 0 alert but has {}".format(len(policyobj.audit_issues)))
+
+        auditor.check_star_privileges(policyobj)
+        self.assertIs(len(policyobj.audit_issues), 1,
+                      "Managed Policy should have 1 alert but has {}".format(len(policyobj.audit_issues)))
+
+    def test_issue_on_aws_policy_no_attachments(self):
+        import json
+
+        config = {
+            'policy': json.loads(FULL_ADMIN_POLICY_BARE),
+            'arn': 'arn:aws:iam::aws:policy/TEST',
+            'attached_users': [],
+            'attached_roles': [],
+            'attached_groups': []
+        }
+
+        auditor = ManagedPolicyAuditor(accounts=['unittest'])
+        policyobj = ManagedPolicyItem(account="TEST_ACCOUNT", name="policy_test", config=config)
+
+        self.assertIs(len(policyobj.audit_issues), 0,
+                      "Managed Policy should have 0 alert but has {}".format(len(policyobj.audit_issues)))
+
+        auditor.check_star_privileges(policyobj)
+        self.assertIs(len(policyobj.audit_issues), 0,
+                      "Managed Policy should have 0 alerts but has {}".format(len(policyobj.audit_issues)))
+
+    def test_issue_on_aws_policy_with_attachment(self):
+        import json
+
+        config = {
+            'policy': json.loads(FULL_ADMIN_POLICY_BARE),
+            'arn': 'arn:aws:iam::aws:policy/TEST',
+            'attached_users': [],
+            'attached_roles': ['arn:aws:iam::123456789:role/TEST'],
+            'attached_groups': []
+        }
+
+        auditor = ManagedPolicyAuditor(accounts=['unittest'])
+        policyobj = ManagedPolicyItem(account="TEST_ACCOUNT", name="policy_test", config=config)
+
+        self.assertIs(len(policyobj.audit_issues), 0,
+                      "Managed Policy should have 0 alert but has {}".format(len(policyobj.audit_issues)))
+
+        auditor.check_star_privileges(policyobj)
+        self.assertIs(len(policyobj.audit_issues), 1,
+                      "Managed Policy should have 1 alert but has {}".format(len(policyobj.audit_issues)))


### PR DESCRIPTION
Why is this change necessary?
Currently, audits are performed against AWS created managed policies.
These checks are not meaningful unless another resource is using the
policy

This change addresses the need by:
Only performing policy auditor checks on AWS policies if there is
a resource attached

Potential Side Effects:
No known side effects