### PR TITLE
Add support for custom watcher and auditor alerters

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -47,6 +47,7 @@ manager = Manager(app)
 migrate = Migrate(app, db)
 manager.add_command('db', MigrateCommand)
 
+find_modules('alerters')
 find_modules('watchers')
 find_modules('auditors')
 load_plugins('security_monkey.plugins')

--- a/security_monkey/alerters/__init__.py
+++ b/security_monkey/alerters/__init__.py
@@ -1,0 +1,13 @@
+#     Copyright 2016 Bridgewater Associates
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.

--- a/security_monkey/alerters/custom_alerter.py
+++ b/security_monkey/alerters/custom_alerter.py
@@ -1,0 +1,45 @@
+#     Copyright 2016 Bridgewater Associates
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.alerters.custom_alerter
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Bridgewater OSS <opensource@bwater.com>
+
+
+"""
+from security_monkey import app
+
+alerter_registry = []
+
+
+class AlerterType(type):
+
+    def __init__(cls, name, bases, attrs):
+        if getattr(cls, "report_auditor_changes", None) and getattr(cls, "report_watcher_changes", None):
+            app.logger.debug("Registering alerter %s", cls.__name__)
+            alerter_registry.append(cls)
+
+
+def report_auditor_changes(items):
+    for alerter_class in alerter_registry:
+        alerter = alerter_class()
+        alerter.report_auditor_changes(items)
+
+
+def report_watcher_changes(watcher):
+    for alerter_class in alerter_registry:
+        alerter = alerter_class()
+        alerter.report_watcher_changes(watcher)

--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -29,6 +29,7 @@ from security_monkey.common.jinja import get_jinja_env
 from security_monkey.datastore import User, AuditorSettings, Item, ItemAudit, Technology, Account, ItemAuditScore, AccountPatternAuditScore
 from security_monkey.common.utils import send_email
 from security_monkey.account_manager import get_account_by_name
+from security_monkey.alerters.custom_alerter import report_auditor_changes
 
 from sqlalchemy import and_
 from collections import defaultdict
@@ -294,6 +295,7 @@ class Auditor(object):
 
         db.session.commit()
         self._create_auditor_settings()
+        report_auditor_changes(self)
 
     def email_report(self, report):
         """

--- a/security_monkey/datastore.py
+++ b/security_monkey/datastore.py
@@ -236,7 +236,7 @@ class Item(db.Model):
     cloudtrail_entries = relationship("CloudTrailEntry", backref="item", cascade="all, delete, delete-orphan", order_by="CloudTrailEntry.event_time")
     issues = relationship("ItemAudit", backref="item", cascade="all, delete, delete-orphan", foreign_keys="ItemAudit.item_id")
     exceptions = relationship("ExceptionLogs", backref="item", cascade="all, delete, delete-orphan")
-    
+
     @hybrid_property
     def score(self):
         return db.session.query(
@@ -627,6 +627,7 @@ class Datastore(object):
         db.session.commit()
 
         self._set_latest_revision(item)
+        return item
 
     def _set_latest_revision(self, item):
         latest_revision = item.revisions.first()

--- a/security_monkey/watcher.py
+++ b/security_monkey/watcher.py
@@ -16,6 +16,8 @@ from security_monkey import app
 from security_monkey.datastore import Account, IgnoreListEntry
 from security_monkey.datastore import Technology, WatcherConfig, store_exception
 from security_monkey.common.jinja import get_jinja_env
+from security_monkey.common.utils import find_modules
+from security_monkey.alerters.custom_alerter import report_watcher_changes
 
 from boto.exception import BotoServerError
 import time
@@ -380,6 +382,7 @@ class Watcher(object):
             app.logger.info("{} changed {} in {}".format(len(self.changed_items), self.i_am_plural, self.accounts))
             for item in self.changed_items:
                 item.save(self.datastore)
+        report_watcher_changes(self)
 
     def plural_name(self):
         """
@@ -500,7 +503,7 @@ class ChangeItem(object):
         Save the item
         """
         app.logger.debug("Saving {}/{}/{}/{}\n\t{}".format(self.index, self.account, self.region, self.name, self.new_config))
-        datastore.store(
+        self.db_item = datastore.store(
             self.index,
             self.region,
             self.account,


### PR DESCRIPTION
This change allows users to customize how they report auditor and
watcher changes during both reporter runs and forced runs of
`audit_changes` and `find_changes`.