### PR TITLE
Explicitly set export filename

### DIFF
--- a/security_monkey/export/__init__.py
+++ b/security_monkey/export/__init__.py
@@ -84,7 +84,8 @@ def export_items():
             values.append('"{val}"'.format(val=val))
 
         out += ",".join(values) + "\n"
-    return Response(out, mimetype='text/csv')
+    return Response(out, mimetype='text/csv',
+                    headers={"Content-disposition": "attachment; filename=security-monkey-items.csv"})
 
 
 @export_blueprint.route("/export/issues")
@@ -166,4 +167,5 @@ def export_issues():
             values.append('"{val}"'.format(val=val))
 
         out += ",".join(values) + "\n"
-    return Response(out, mimetype='text/csv')
+    return Response(out, mimetype='text/csv',
+                    headers={"Content-disposition": "attachment; filename=security-monkey-items.csv"})


### PR DESCRIPTION
Type: generic-bugfix

Why is this change necessary?
Some browsers/environments download export file as plaintext, without
.csv file extension.

This change addresses the need by:
Explicitly setting the exported filename to 'security-monkey-items.csv'
as part of the response header.

Potential Side Effects:
No known side effects