### PR TITLE
fixing issue duplicate ARN issue…

### DIFF
--- a/security_monkey/datastore.py
+++ b/security_monkey/datastore.py
@@ -592,6 +592,7 @@ class Datastore(object):
                         item=item.name
                     ))
                     db.session.add(duplicate_item)
+                    db.session.commit()
 
         if arn:
             item.arn = arn


### PR DESCRIPTION
When an item is renamed the ARN must float from the old item in security_monkey to the new item.

In `datastore::store()` there is code to handle the case of duplicate ARNs because the database has a unique constraint on ARN.  This code was not sufficient.  Adding a commit after setting the ARN to None on the old item.