### PR TITLE
Add functionality to clean up stale issues

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -197,6 +197,9 @@ def add_account(number, third_party, name, s3_name, active, notes, account_type,
     account_manager = account_registry.get(account_type)()
     account = account_manager.lookup_account_by_identifier(number)
     if account:
+        from security_monkey.common.audit_issue_cleanup import clean_account_issues
+        clean_account_issues(account)
+
         if force:
             account_manager.update(account.id, account_type, name, active,
                     third_party, notes, number,
@@ -522,6 +525,15 @@ def add_watcher_config(tech_name, disabled, interval):
     db.session.add(entry)
     db.session.commit()
     db.session.close()
+
+
+@manager.command
+def clean_stale_issues():
+    """
+    Cleans up issues for auditors that have been removed
+    """
+    from security_monkey.common.audit_issue_cleanup import clean_stale_issues
+    clean_stale_issues()
 
 
 class APIServer(Command):

--- a/security_monkey/account_manager.py
+++ b/security_monkey/account_manager.py
@@ -89,6 +89,7 @@ class AccountManager(object):
         db.session.commit()
         db.session.refresh(account)
         account = self._load(account)
+        db.session.expunge(account)
         return account
 
     def create(self, account_type, name, active, third_party, notes, identifier,

--- a/security_monkey/common/audit_issue_cleanup.py
+++ b/security_monkey/common/audit_issue_cleanup.py
@@ -1,0 +1,80 @@
+#     Copyright 2017 Bridgewater Associates
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.common.audit_issue_cleanup
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Bridgewater OSS <opensource@bwater.com>
+
+
+"""
+
+from security_monkey.auditor import auditor_registry
+from security_monkey.datastore import AuditorSettings, Account, Technology, Datastore
+from security_monkey.watcher import ChangeItem
+from security_monkey import app, db
+
+
+existing_auditor_classes = {}
+for key in auditor_registry:
+    for auditor in auditor_registry[key]:
+        existing_auditor_classes[auditor.__name__] = auditor
+
+
+def clean_stale_issues():
+    results = AuditorSettings.query.filter().all()
+    for settings in results:
+        if settings.auditor_class is None or settings.auditor_class not in existing_auditor_classes:
+            app.logger.info("Cleaning up issues for removed auditor %s", settings.auditor_class)
+            _delete_issues(settings)
+
+    db.session.commit()
+
+
+def clean_account_issues(account):
+    results = AuditorSettings.query.filter(AuditorSettings.account_id == account.id).all()
+    for settings in results:
+        auditor_class = existing_auditor_classes.get(settings.auditor_class)
+        if auditor_class:
+            if not auditor_class([account.name]).applies_to_account(account):
+                app.logger.info("Cleaning up %s issues for %s", settings.auditor_class, account.name)
+                _delete_issues(settings)
+
+    db.session.commit()
+
+
+def _delete_issues(settings):
+    account = Account.query.filter(Account.id == settings.account_id).first()
+    tech = Technology.query.filter(Technology.id == settings.tech_id).first()
+    if account and tech:
+        # Report issues as fixed
+        db_items = Datastore().get_all_ctype_filtered(tech=tech.name, account=account.name, include_inactive=False)
+        items = []
+        for item in db_items:
+            new_item = ChangeItem(index=tech.name,
+                                  region=item.region,
+                                  account=account.name,
+                                  name=item.name,
+                                  arn=item.arn)
+            new_item.audit_issues = []
+            new_item.db_item = item
+            items.append(new_item)
+
+        for item in items:
+            for issue in item.db_item.issues:
+                if issue.auditor_setting_id == settings.id:
+                    item.confirmed_fixed_issues.append(issue)
+
+    db.session.delete(settings)

--- a/security_monkey/datastore.py
+++ b/security_monkey/datastore.py
@@ -210,7 +210,7 @@ class AuditorSettings(db.Model):
     disabled = Column(Boolean(), nullable=False)
     issue_text = Column(String(512), nullable=True)
     auditor_class = Column(String(128))
-    issues = relationship("ItemAudit", backref="auditor_setting")
+    issues = relationship("ItemAudit", backref="auditor_setting", cascade="all, delete, delete-orphan")
     tech_id = Column(Integer, ForeignKey("technology.id"), index=True)
     account_id = Column(Integer, ForeignKey("account.id"), index=True)
     unique_const = UniqueConstraint('account_id', 'issue_text', 'tech_id')

--- a/security_monkey/tests/core/test_audit_issue_cleanup.py
+++ b/security_monkey/tests/core/test_audit_issue_cleanup.py
@@ -1,0 +1,146 @@
+#     Copyright 2017 Bridgewater Associates
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.tests.core.test_audit_issue_cleanup
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Bridgewater OSS <opensource@bwater.com>
+
+
+"""
+from security_monkey.tests import SecurityMonkeyTestCase
+from security_monkey.auditor import Auditor
+from security_monkey.datastore import Account, AccountType, Technology
+from security_monkey.datastore import Item, ItemAudit, AuditorSettings
+from security_monkey.auditor import auditor_registry
+from security_monkey import db, app
+
+from mock import patch
+from collections import defaultdict
+
+
+class MockAuditor(Auditor):
+    def __init__(self, accounts=None, debug=False):
+        super(MockAuditor, self).__init__(accounts=accounts, debug=debug)
+
+    def applies_to_account(self, account):
+        return self.applies
+
+
+test_auditor_registry = defaultdict(list)
+
+
+auditor_configs = [
+    {
+        'type': 'MockAuditor1',
+        'index': 'index1',
+        'applies': True
+    },
+    {
+        'type': 'MockAuditor2',
+        'index': 'index2',
+        'applies': False
+    },
+]
+
+for config in auditor_configs:
+    auditor = type(
+                config['type'], (MockAuditor,),
+                {
+                    'applies': config['applies']
+                }
+            )
+    app.logger.debug(auditor.__name__)
+
+    test_auditor_registry[config['index']].append(auditor)
+
+
+class AuditIssueCleanupTestCase(SecurityMonkeyTestCase):
+    def pre_test_setup(self):
+        account_type_result = AccountType.query.filter(AccountType.name == 'AWS').first()
+        if not account_type_result:
+            account_type_result = AccountType(name='AWS')
+            db.session.add(account_type_result)
+            db.session.commit()
+
+        self.account = Account(identifier="012345678910", name="testing",
+                               account_type_id=account_type_result.id)
+
+        self.technology = Technology(name="iamrole")
+        item = Item(region="us-west-2", name="testrole",
+                    arn="arn:aws:iam::012345678910:role/testrole", technology=self.technology,
+                    account=self.account)
+
+        db.session.add(self.account)
+        db.session.add(self.technology)
+        db.session.add(item)
+        db.session.commit()
+
+    @patch.dict(auditor_registry, test_auditor_registry, clear=True)
+    def test_clean_stale_issues(self):
+        from security_monkey.common.audit_issue_cleanup import clean_stale_issues
+
+        items = Item.query.all()
+        assert len(items) == 1
+        item = items[0]
+        item.issues.append(ItemAudit(score=1, issue='Test Issue',
+                                     auditor_setting=AuditorSettings(disabled=False,
+                                                                     technology=self.technology,
+                                                                     account=self.account,
+                                                                     auditor_class='MockAuditor1')))
+
+        item.issues.append(ItemAudit(score=1, issue='Issue with missing auditor',
+                                     auditor_setting=AuditorSettings(disabled=False,
+                                                                     technology=self.technology,
+                                                                     account=self.account,
+                                                                     auditor_class='MissingAuditor')))
+
+        db.session.commit()
+
+        clean_stale_issues()
+        items = Item.query.all()
+        assert len(items) == 1
+        item = items[0]
+        assert len(item.issues) == 1
+        assert item.issues[0].issue == 'Test Issue'
+
+    @patch.dict(auditor_registry, test_auditor_registry, clear=True)
+    def test_clean_account_issues(self):
+        from security_monkey.common.audit_issue_cleanup import clean_account_issues
+
+        items = Item.query.all()
+        assert len(items) == 1
+        item = items[0]
+
+        item.issues.append(ItemAudit(score=1, issue='Test Issue 1',
+                                     auditor_setting=AuditorSettings(disabled=False,
+                                                                     technology=self.technology,
+                                                                     account=self.account,
+                                                                     auditor_class='MockAuditor1')))
+
+        item.issues.append(ItemAudit(score=1, issue='Test Issue 2',
+                                     auditor_setting=AuditorSettings(disabled=False,
+                                                                     technology=self.technology,
+                                                                     account=self.account,
+                                                                     auditor_class='MockAuditor2')))
+
+        db.session.commit()
+
+        clean_account_issues(self.account)
+        items = Item.query.all()
+        assert len(items) == 1
+        item = items[0]
+        assert len(item.issues) == 1
+        assert item.issues[0].issue == 'Test Issue 1'

--- a/security_monkey/views/account.py
+++ b/security_monkey/views/account.py
@@ -153,6 +153,9 @@ class AccountGetPutDelete(AuthenticatedService):
         if not account:
             return {'status': 'error. Account ID not found.'}, 404
 
+        from security_monkey.common.audit_issue_cleanup import clean_account_issues
+        clean_account_issues(account)
+
         marshaled_account = marshal(account.__dict__, ACCOUNT_FIELDS)
         marshaled_account['auth'] = self.auth_dict
 


### PR DESCRIPTION
Type: generic-feature

Why is this change necessary?
In some instances such an an account pattern change or removal
of an auditor, issues are never cleared because the auditor that
created them never gets run against the account.

This change addresses the need by:
Adding cleanup methods to be run at build time

Potential Side Effects:
No known side effects

Change-Id: I2dc4b24d2a898acb9beb85ba0cd91ad112b0a253