### PR TITLE
Set user role via SSO profile

### DIFF
--- a/env-config/config-deploy.py
+++ b/env-config/config-deploy.py
@@ -117,11 +117,13 @@ PING_ACCESS_TOKEN_URL = ''  # Often something ending in token.oauth2
 PING_USER_API_URL = ''  # Often something ending in idp/userinfo.openid
 PING_JWKS_URL = ''  # Often something ending in JWKS
 PING_SECRET = ''  # Provided by your administrator
+PING_DEFAULT_ROLE = 'View'
 
 GOOGLE_CLIENT_ID = ''
 GOOGLE_AUTH_ENDPOINT = ''
 GOOGLE_SECRET = ''
 # GOOGLE_HOSTED_DOMAIN = 'example.com' # Verify that token issued by comes from domain
+GOOGLE_DEFAULT_ROLE = 'View'
 
 ONELOGIN_APP_ID = '<APP_ID>'  # OneLogin App ID provider by your administrator
 ONELOGIN_EMAIL_FIELD = 'User.email'  # SAML attribute used to provide email address

--- a/security_monkey/sso/service.py
+++ b/security_monkey/sso/service.py
@@ -86,3 +86,41 @@ def on_identity_loaded(sender, identity):
             identity.provides.add(RoleNeed(role.name))
 
     g.user = user
+
+
+def setup_user(email, groups=[], default_role='View'):
+    from security_monkey import app, db
+
+    user = User.query.filter(User.email == email).first()
+
+    if default_role:
+        role = default_role
+    else:
+        role = 'View'
+
+    if groups:
+        if app.config.get('ADMIN_GROUP') and app.config.get('ADMIN_GROUP') in groups:
+            role = 'Admin'
+        elif app.config.get('JUSTIFY_GROUP') and app.config.get('JUSTIFY_GROUP') in groups:
+            role = 'Justify'
+        elif app.config.get('VIEW_GROUP') and app.config.get('VIEW_GROUP') in groups:
+            role = 'View'
+
+    # if we get an sso user create them an account
+    if not user:
+        user = User(
+            email=email,
+            active=True,
+            role=role
+        )
+        db.session.add(user)
+        db.session.commit()
+        db.session.refresh(user)
+
+    if user.role != role:
+        user.role = role
+        db.session.add(user)
+        db.session.commit()
+        db.session.refresh(user)
+
+    return user

--- a/security_monkey/tests/core/test_sso_service.py
+++ b/security_monkey/tests/core/test_sso_service.py
@@ -1,0 +1,59 @@
+#     Copyright 2017 Bridgewater Associates
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.tests.core.test_sso_service
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Bridgewater OSS <opensource@bwater.com>
+
+
+"""
+from security_monkey.tests import SecurityMonkeyTestCase
+from security_monkey.sso.service import setup_user
+from security_monkey.datastore import User
+from security_monkey import db
+
+
+class SSOServiceTestCase(SecurityMonkeyTestCase):
+    def test_create_user(self):
+        existing_user = User(
+            email='test@test.com',
+            active=True,
+            role='View'
+        )
+        db.session.add(existing_user)
+        db.session.commit()
+        db.session.refresh(existing_user)
+
+        user1 = setup_user('test@test.com')
+        self.assertEqual(existing_user.id, user1.id)
+        self.assertEqual(existing_user.role, user1.role)
+
+        user2 = setup_user('test2@test.com')
+        self.assertEqual(user2.email, 'test2@test.com')
+        self.assertEqual(user2.role, 'View')
+
+        self.app.config.update(
+            ADMIN_GROUP='test_admin_group',
+            JUSTIFY_GROUP='test_justify_group',
+            VIEW_GROUP='test_view_group'
+        )
+        admin_user = setup_user('admin@test.com', ['test_admin_group'])
+        justify_user = setup_user('justifier@test.com', ['test_justify_group'])
+        view_user = setup_user('viewer@test.com', ['test_view_group'])
+
+        self.assertEqual(admin_user.role, 'Admin')
+        self.assertEqual(justify_user.role, 'Justify')
+        self.assertEqual(view_user.role, 'View')


### PR DESCRIPTION
Type: generic-feature

Why is this change necessary?
Current SSO implementation adds all SSO users with View role.

This change addresses the need by:
Supporting group app configurations that will check SSO user profile for
'groups' setting to determine initial role for user, if it's the first
time they're logging in.

Potential Side Effects:
No known side effects