### PR TITLE
SSO Role modifications

### DIFF
--- a/security_monkey/sso/service.py
+++ b/security_monkey/sso/service.py
@@ -88,14 +88,14 @@ def on_identity_loaded(sender, identity):
     g.user = user
 
 
-def setup_user(email, groups, default_role):
+def setup_user(email, groups=None, default_role='View'):
     from security_monkey import app, db
 
     user = User.query.filter(User.email == email).first()
     if user:
         return user
 
-    role = default_role or 'View'
+    role = default_role
     groups = groups or []
     if groups:
         if app.config.get('ADMIN_GROUP') and app.config.get('ADMIN_GROUP') in groups:

--- a/security_monkey/sso/service.py
+++ b/security_monkey/sso/service.py
@@ -88,16 +88,15 @@ def on_identity_loaded(sender, identity):
     g.user = user
 
 
-def setup_user(email, groups=[], default_role='View'):
+def setup_user(email, groups, default_role):
     from security_monkey import app, db
 
     user = User.query.filter(User.email == email).first()
+    if user:
+        return user
 
-    if default_role:
-        role = default_role
-    else:
-        role = 'View'
-
+    role = default_role or 'View'
+    groups = groups or []
     if groups:
         if app.config.get('ADMIN_GROUP') and app.config.get('ADMIN_GROUP') in groups:
             role = 'Admin'
@@ -107,20 +106,14 @@ def setup_user(email, groups=[], default_role='View'):
             role = 'View'
 
     # if we get an sso user create them an account
-    if not user:
-        user = User(
-            email=email,
-            active=True,
-            role=role
-        )
-        db.session.add(user)
-        db.session.commit()
-        db.session.refresh(user)
+    user = User(
+        email=email,
+        active=True,
+        role=role
+    )
 
-    if user.role != role:
-        user.role = role
-        db.session.add(user)
-        db.session.commit()
-        db.session.refresh(user)
+    db.session.add(user)
+    db.session.commit()
+    db.session.refresh(user)
 
     return user

--- a/security_monkey/sso/views.py
+++ b/security_monkey/sso/views.py
@@ -107,9 +107,6 @@ class Ping(Resource):
 
         # validate your token based on the key it was signed with
         try:
-            current_app.logger.debug(id_token)
-            current_app.logger.debug(secret)
-            current_app.logger.debug(algo)
             jwt.decode(id_token, secret.decode('utf-8'), algorithms=[algo], audience=client_id)
         except jwt.DecodeError:
             return dict(message='Token is invalid'), 403
@@ -124,7 +121,10 @@ class Ping(Resource):
         r = requests.get(user_api_url, params=user_params)
         profile = r.json()
 
-        user = setup_user(profile.get('email'), profile.get('groups', []), current_app.config.get('PING_DEFAULT_ROLE'))
+        user = setup_user(
+            profile.get('email'),
+            profile.get('groups', profile.get('googleGroups', [])),
+            current_app.config.get('PING_DEFAULT_ROLE'))
 
         # Tell Flask-Principal the identity changed
         identity_changed.send(current_app._get_current_object(), identity=Identity(user.id))

--- a/security_monkey/sso/views.py
+++ b/security_monkey/sso/views.py
@@ -124,7 +124,7 @@ class Ping(Resource):
         user = setup_user(
             profile.get('email'),
             profile.get('groups', profile.get('googleGroups', [])),
-            current_app.config.get('PING_DEFAULT_ROLE'))
+            current_app.config.get('PING_DEFAULT_ROLE', 'View'))
 
         # Tell Flask-Principal the identity changed
         identity_changed.send(current_app._get_current_object(), identity=Identity(user.id))
@@ -205,7 +205,7 @@ class Google(Resource):
         r = requests.get(people_api_url, headers=headers)
         profile = r.json()
 
-        user = setup_user(profile.get('email'), profile.get('groups', []), current_app.config.get('GOOGLE_DEFAULT_ROLE'))
+        user = setup_user(profile.get('email'), profile.get('groups', []), current_app.config.get('GOOGLE_DEFAULT_ROLE', 'View'))
 
         # Tell Flask-Principal the identity changed
         identity_changed.send(current_app._get_current_object(), identity=Identity(user.id))


### PR DESCRIPTION
PR #576 allowed for automatically setting user roles based on group membership.

This had an unanticipated impact on our install where user roles were being downgraded to `View` on login.  The reason is that the PR modified existing users as well as new users.  Also, the PR required a new config value `ADMIN_GROUP` / `JUSTIFY_GROUP` be placed into the config file.  Also, the PR checked the SSO response for the keyword `groups`, whereas our SSO returns `googleGroups`.

- I've modified the SSO code to check the profile for both `groups` and for `googleGroups` when using PING.
- I also modified the SSO code to only assign a role for new user creation.  Existing users will not be impacted.  This means the current security_monkey installs won't be required to modify their config file to maintain current functionality.

