### PR TITLE
GCP: fixed issue where client wasn't receiving user-specified creds

### DIFF
--- a/security_monkey/common/gcp/util.py
+++ b/security_monkey/common/gcp/util.py
@@ -12,7 +12,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 """
-.. module: security_monkey.watchers.gcp.util
+.. module: security_monkey.common.gcp.util
     :platform: Unix
 
 .. version:: $$VERSION$$
@@ -21,16 +21,42 @@
 from security_monkey.datastore import Account
 from cloudaux.orchestration import modify as cloudaux_modify
 
+def get_gcp_project_creds(account_names):
+    """
+    Build list of dicts with project credentials.
 
-def identifiers_from_account_names(account_names):
+    Takes a list of account names and fetches all of those accounts.
+    If the custom_field 'credentials_file' (custom field) is set, the list
+    item will be in the format of: {'project': 'my-project', 'key_file': 'my-key'}
+    Otherwise, it will be simply the project string.
+
+    Returns a list containing strings or dictionaries with necessary credentials
+    for connecting to GCP.
+
+    :param account_names: list of account names
+    :type account_names: ``list``
+
+    :return: list of dictionaries with project credentials
+    :rtype: ``list``
+    """
+    # The name of the field as defined in the GCP Account Manager.
+    creds_field = 'creds_file'
+    project_creds = []
+
     accounts = Account.query.filter(Account.name.in_(account_names)).all()
-    return [account.identifier for account in accounts]
 
+    for account in accounts:
+        key_file = account.getCustom(creds_field)
+        if key_file:
+            project_creds.append({'project': account.identifier, 'key_file': key_file})
+        else:
+            project_creds.append(account.identifier)
+
+    return project_creds
 
 def gcp_resource_id_builder(service, identifier, region=''):
     resource = 'gcp:%s:%s:%s' % (region, service, identifier)
     return resource.replace('/', ':').replace('.', ':')
-
 
 def modify(d, format='camelized'):
     return cloudaux_modify(d, format=format)

--- a/security_monkey/watchers/gcp/gce/firewall.py
+++ b/security_monkey/watchers/gcp/gce/firewall.py
@@ -18,7 +18,7 @@
 .. version:: $$VERSION$$
 .. moduleauthor:: Tom Melendez <supertom@google.com> @supertom
 """
-from security_monkey.common.gcp.util import gcp_resource_id_builder, identifiers_from_account_names, modify
+from security_monkey.common.gcp.util import get_gcp_project_creds, gcp_resource_id_builder, modify
 from security_monkey.watcher import Watcher
 from security_monkey.watcher import ChangeItem
 
@@ -47,9 +47,9 @@ class GCEFirewallRule(Watcher):
         location of the exception and the value is the actual exception
         """
         self.prep_for_slurp()
-        account_identifiers = identifiers_from_account_names(self.accounts)
+        project_creds = get_gcp_project_creds(self.accounts)
 
-        @iter_project(projects=account_identifiers)
+        @iter_project(projects=project_creds)
         def slurp_items(**kwargs):
             item_list = []
             rules = list_firewall_rules(**kwargs)

--- a/security_monkey/watchers/gcp/gce/network.py
+++ b/security_monkey/watchers/gcp/gce/network.py
@@ -19,7 +19,7 @@
 .. moduleauthor:: Tom Melendez <supertom@google.com> @supertom
 
 """
-from security_monkey.common.gcp.util import gcp_resource_id_builder, identifiers_from_account_names
+from security_monkey.common.gcp.util import get_gcp_project_creds, gcp_resource_id_builder
 from security_monkey.watcher import Watcher
 from security_monkey.watcher import ChangeItem
 
@@ -48,9 +48,9 @@ class GCENetwork(Watcher):
         location of the exception and the value is the actual exception
         """
         self.prep_for_slurp()
-        account_identifiers = identifiers_from_account_names(self.accounts)
+        project_creds = get_gcp_project_creds(self.accounts)
 
-        @iter_project(projects=account_identifiers)
+        @iter_project(projects=project_creds)
         def slurp_items(**kwargs):
             item_list = []
             networks = list_networks(**kwargs)

--- a/security_monkey/watchers/gcp/gcs/bucket.py
+++ b/security_monkey/watchers/gcp/gcs/bucket.py
@@ -19,7 +19,7 @@
 .. moduleauthor:: Tom Melendez <supertom@google.com> @supertom
 
 """
-from security_monkey.common.gcp.util import gcp_resource_id_builder, identifiers_from_account_names
+from security_monkey.common.gcp.util import get_gcp_project_creds, gcp_resource_id_builder
 from security_monkey.watcher import Watcher
 from security_monkey.watcher import ChangeItem
 
@@ -48,9 +48,9 @@ class GCSBucket(Watcher):
         location of the exception and the value is the actual exception
         """
         self.prep_for_slurp()
-        account_identifiers = identifiers_from_account_names(self.accounts)
+        project_creds = get_gcp_project_creds(self.accounts)
 
-        @iter_project(projects=account_identifiers)
+        @iter_project(projects=project_creds)
         def slurp_items(**kwargs):
             item_list = []
             buckets = list_buckets()

--- a/security_monkey/watchers/gcp/iam/serviceaccount.py
+++ b/security_monkey/watchers/gcp/iam/serviceaccount.py
@@ -19,7 +19,7 @@
 .. moduleauthor:: Tom Melendez <supertom@google.com> @supertom
 
 """
-from security_monkey.common.gcp.util import gcp_resource_id_builder, identifiers_from_account_names
+from security_monkey.common.gcp.util import get_gcp_project_creds, gcp_resource_id_builder
 from security_monkey.watcher import Watcher
 from security_monkey.watcher import ChangeItem
 
@@ -48,9 +48,9 @@ class IAMServiceAccount(Watcher):
         location of the exception and the value is the actual exception
         """
         self.prep_for_slurp()
-        account_identifiers = identifiers_from_account_names(self.accounts)
+        project_creds = get_gcp_project_creds(self.accounts)
 
-        @iter_project(projects=account_identifiers)
+        @iter_project(projects=project_creds)
         def slurp_items(**kwargs):
             item_list = []
             service_accounts = list_serviceaccounts(**kwargs)


### PR DESCRIPTION
When the user specified the path to the credentials file, the path wasn't making it's way to the client.  This bug isn't visible unless: 
* one is monitoring GCP from AWS
* one is monitoring GCP using a serviceaccount other than the one used by the instance

Changes made:
* Created new function get_gcp_project_creds utility function build list of creds.
* Updated existing GCP watchers.
* Removed name_to_identifier utility function as it's no longer needed