### PR TITLE
Added permission for DescribeVpnGateways missing for #406

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -98,6 +98,7 @@ SM-ReadOnly
                     "ec2:describevpcendpoints",
                     "ec2:describevpcpeeringconnections",
                     "ec2:describevpcs",
+                    "ec2:describevpngateways",
                     "elasticloadbalancing:describeloadbalancerattributes",
                     "elasticloadbalancing:describeloadbalancerpolicies",
                     "elasticloadbalancing:describeloadbalancers",

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -122,6 +122,7 @@ Paste in this JSON with the name "SecurityMonkeyReadOnly":
                     "ec2:describevpcendpoints",
                     "ec2:describevpcpeeringconnections",
                     "ec2:describevpcs",
+                    "ec2:describevpngateways",
                     "elasticloadbalancing:describeloadbalancerattributes",
                     "elasticloadbalancing:describeloadbalancerpolicies",
                     "elasticloadbalancing:describeloadbalancers",

--- a/scripts/secmonkey_role_setup.py
+++ b/scripts/secmonkey_role_setup.py
@@ -83,6 +83,7 @@ policy = \
            "ec2:describevpcendpoints",
            "ec2:describevpcpeeringconnections",
            "ec2:describevpcs",
+           "ec2:describevpngateways",
            "elasticloadbalancing:describeloadbalancerattributes",
            "elasticloadbalancing:describeloadbalancerpolicies",
            "elasticloadbalancing:describeloadbalancers",


### PR DESCRIPTION
ec2 describe_vpn_gateways seen here:
https://github.com/Netflix/security_monkey/pull/406/files#diff-f7287dd9026a529b5d1a3932687f2cfaR57