### PR TITLE
Fixing reference to check_rfc_1918

### DIFF
--- a/security_monkey/auditors/elb.py
+++ b/security_monkey/auditors/elb.py
@@ -162,7 +162,7 @@ class ELBAuditor(Auditor):
                         for rule in sg.config.get('rules', []):
                             cidr = rule.get('cidr_ip', '')
                             if rule.get('rule_type', None) == 'ingress' and cidr:
-                                if not _check_rfc_1918(cidr) and not self._check_inclusion_in_network_whitelist(cidr):
+                                if not check_rfc_1918(cidr) and not self._check_inclusion_in_network_whitelist(cidr):
                                     sg_cidrs.append(cidr)
 
                         if sg_cidrs:


### PR DESCRIPTION
Using the correct name for the imported method:

`from security_monkey.common.utils import check_rfc_1918`

Fixes #604 