### PR TITLE
GCP: set User Agent

### DIFF
--- a/security_monkey/common/gcp/config.py
+++ b/security_monkey/common/gcp/config.py
@@ -12,7 +12,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 """
-.. module: security_monkey.auditors.gcp.config
+.. module: security_monkey.common.gcp.config
     :platform: Unix
 
 .. version:: $$VERSION$$
@@ -20,6 +20,12 @@
 
 """
 
+class ApplicationConfig(object):
+    SECURITY_MONKEY_VERSION = '0.8.0'
+
+    @staticmethod
+    def get_version():
+        return ApplicationConfig.SECURITY_MONKEY_VERSION
 
 class AuditorConfig(object):
     """

--- a/security_monkey/common/gcp/util.py
+++ b/security_monkey/common/gcp/util.py
@@ -60,3 +60,7 @@ def gcp_resource_id_builder(service, identifier, region=''):
 
 def modify(d, format='camelized'):
     return cloudaux_modify(d, format=format)
+
+def get_user_agent(**kwargs):
+    from security_monkey.common.gcp.config import ApplicationConfig as appconfig
+    return 'security-monkey/%s' % appconfig.get_version()

--- a/security_monkey/watchers/gcp/gce/firewall.py
+++ b/security_monkey/watchers/gcp/gce/firewall.py
@@ -18,7 +18,7 @@
 .. version:: $$VERSION$$
 .. moduleauthor:: Tom Melendez <supertom@google.com> @supertom
 """
-from security_monkey.common.gcp.util import get_gcp_project_creds, gcp_resource_id_builder, modify
+from security_monkey.common.gcp.util import get_gcp_project_creds, get_user_agent, gcp_resource_id_builder, modify
 from security_monkey.watcher import Watcher
 from security_monkey.watcher import ChangeItem
 
@@ -39,6 +39,7 @@ class GCEFirewallRule(Watcher):
         self.ephemeral_paths = [
             "Etag",
         ]
+        self.user_agent = get_user_agent()
 
     def slurp(self):
         """
@@ -52,6 +53,7 @@ class GCEFirewallRule(Watcher):
         @iter_project(projects=project_creds)
         def slurp_items(**kwargs):
             item_list = []
+            kwargs['user_agent'] = self.user_agent
             rules = list_firewall_rules(**kwargs)
 
             for rule in rules:

--- a/security_monkey/watchers/gcp/gce/network.py
+++ b/security_monkey/watchers/gcp/gce/network.py
@@ -19,7 +19,7 @@
 .. moduleauthor:: Tom Melendez <supertom@google.com> @supertom
 
 """
-from security_monkey.common.gcp.util import get_gcp_project_creds, gcp_resource_id_builder
+from security_monkey.common.gcp.util import get_gcp_project_creds, get_user_agent, gcp_resource_id_builder
 from security_monkey.watcher import Watcher
 from security_monkey.watcher import ChangeItem
 
@@ -40,6 +40,7 @@ class GCENetwork(Watcher):
         self.ephemeral_paths = [
             "Etag",
         ]
+        self.user_agent = get_user_agent()
 
     def slurp(self):
         """
@@ -54,6 +55,7 @@ class GCENetwork(Watcher):
         @iter_project(projects=project_creds)
         def slurp_items(**kwargs):
             item_list = []
+            kwargs['user_agent'] = self.user_agent
             networks = list_networks(**kwargs)
 
             for network in networks:

--- a/security_monkey/watchers/gcp/gce/network.py
+++ b/security_monkey/watchers/gcp/gce/network.py
@@ -48,6 +48,7 @@ class GCENetwork(Watcher):
         location of the exception and the value is the actual exception
         """
         self.prep_for_slurp()
+
         project_creds = get_gcp_project_creds(self.accounts)
 
         @iter_project(projects=project_creds)

--- a/security_monkey/watchers/gcp/gcs/bucket.py
+++ b/security_monkey/watchers/gcp/gcs/bucket.py
@@ -48,6 +48,7 @@ class GCSBucket(Watcher):
         location of the exception and the value is the actual exception
         """
         self.prep_for_slurp()
+
         project_creds = get_gcp_project_creds(self.accounts)
 
         @iter_project(projects=project_creds)

--- a/security_monkey/watchers/gcp/gcs/bucket.py
+++ b/security_monkey/watchers/gcp/gcs/bucket.py
@@ -19,7 +19,7 @@
 .. moduleauthor:: Tom Melendez <supertom@google.com> @supertom
 
 """
-from security_monkey.common.gcp.util import get_gcp_project_creds, gcp_resource_id_builder
+from security_monkey.common.gcp.util import get_gcp_project_creds, get_user_agent, gcp_resource_id_builder
 from security_monkey.watcher import Watcher
 from security_monkey.watcher import ChangeItem
 
@@ -40,6 +40,7 @@ class GCSBucket(Watcher):
         self.ephemeral_paths = [
             "Etag",
         ]
+        self.user_agent = get_user_agent()
 
     def slurp(self):
         """
@@ -54,6 +55,7 @@ class GCSBucket(Watcher):
         @iter_project(projects=project_creds)
         def slurp_items(**kwargs):
             item_list = []
+            kwargs['user_agent'] = self.user_agent
             buckets = list_buckets(**kwargs)
 
             for bucket in buckets:

--- a/security_monkey/watchers/gcp/iam/serviceaccount.py
+++ b/security_monkey/watchers/gcp/iam/serviceaccount.py
@@ -48,6 +48,7 @@ class IAMServiceAccount(Watcher):
         location of the exception and the value is the actual exception
         """
         self.prep_for_slurp()
+
         project_creds = get_gcp_project_creds(self.accounts)
 
         @iter_project(projects=project_creds)

--- a/security_monkey/watchers/gcp/iam/serviceaccount.py
+++ b/security_monkey/watchers/gcp/iam/serviceaccount.py
@@ -19,7 +19,7 @@
 .. moduleauthor:: Tom Melendez <supertom@google.com> @supertom
 
 """
-from security_monkey.common.gcp.util import get_gcp_project_creds, gcp_resource_id_builder
+from security_monkey.common.gcp.util import get_gcp_project_creds, get_user_agent, gcp_resource_id_builder
 from security_monkey.watcher import Watcher
 from security_monkey.watcher import ChangeItem
 
@@ -40,6 +40,7 @@ class IAMServiceAccount(Watcher):
         self.ephemeral_paths = [
             "Etag",
         ]
+        self.user_agent = get_user_agent()
 
     def slurp(self):
         """
@@ -54,6 +55,7 @@ class IAMServiceAccount(Watcher):
         @iter_project(projects=project_creds)
         def slurp_items(**kwargs):
             item_list = []
+            kwargs['user_agent'] = self.user_agent
             service_accounts = list_serviceaccounts(**kwargs)
 
             for service_account in service_accounts:


### PR DESCRIPTION
Set the user_agent.  The version of Security Monkey is currently hard-coded, but hidden by a function call, so it can be abstracted later on.

This PR requires Netflix-Skunkworks/cloudaux#25 to be installed.