### PR TITLE
Setting Item.issue_count to deferred.  Only joining tables in distinct if necessary.

### DIFF
--- a/security_monkey/datastore.py
+++ b/security_monkey/datastore.py
@@ -281,7 +281,8 @@ class Item(db.Model):
         select([func.count(ItemAudit.id)])
         .where(ItemAudit.item_id == id)
         .where(ItemAudit.auditor_setting_id == AuditorSettings.id)
-        .where(AuditorSettings.disabled == False)
+        .where(AuditorSettings.disabled == False),
+        deferred=True
     )
 
 

--- a/security_monkey/views/distinct.py
+++ b/security_monkey/views/distinct.py
@@ -87,20 +87,20 @@ class Distinct(AuthenticatedService):
             select2 = False
 
         query = Item.query
-        query = query.join((Account, Account.id == Item.account_id)).join(
-            (AccountType, AccountType.id == Account.account_type_id))
-        query = query.join((Technology, Technology.id == Item.tech_id))
-        query = query.join((ItemRevision, Item.latest_revision_id == ItemRevision.id))
         if 'regions' in args and key_id != 'region':
             regions = args['regions'].split(',')
             query = query.filter(Item.region.in_(regions))
         if 'accounts' in args and key_id != 'account':
+            query = query.join((Account, Account.id == Item.account_id))
             accounts = args['accounts'].split(',')
             query = query.filter(Account.name.in_(accounts))
         if 'accounttypes' in args and key_id != 'accounttype':
+            query = query.join((Account, Account.id == Item.account_id)).join(
+                (AccountType, AccountType.id == Account.account_type_id))
             accounttypes = args['accounttypes'].split(',')
             query = query.filter(AccountType.name.in_(accounttypes))
         if 'technologies' in args and key_id != 'tech':
+            query = query.join((Technology, Technology.id == Item.tech_id))
             technologies = args['technologies'].split(',')
             query = query.filter(Technology.name.in_(technologies))
         if 'names' in args and key_id != 'name':
@@ -110,20 +110,25 @@ class Distinct(AuthenticatedService):
             names = args['arns'].split(',')
             query = query.filter(Item.arn.in_(names))
         if 'active' in args:
+            query = query.join((ItemRevision, Item.latest_revision_id == ItemRevision.id))
             active = args['active'].lower() == "true"
             query = query.filter(ItemRevision.active == active)
 
         if key_id == 'tech':
+            query = query.join((Technology, Technology.id == Item.tech_id))
             if select2:
                 query = query.distinct(Technology.name).filter(func.lower(Technology.name).like('%' + q + '%'))
             else:
                 query = query.distinct(Technology.name)
         elif key_id == 'accounttype':
+            query = query.join((Account, Account.id == Item.account_id)).join(
+                (AccountType, AccountType.id == Account.account_type_id))
             if select2:
                 query = query.distinct(AccountType.name).filter(func.lower(AccountType.name).like('%' + q + '%'))
             else:
                 query = query.distinct(AccountType.name)
         elif key_id == 'account':
+            query = query.join((Account, Account.id == Item.account_id))
             if select2:
                 query = query.filter(Account.third_party == False)
                 query = query.distinct(Account.name).filter(func.lower(Account.name).like('%' + q + '%'))


### PR DESCRIPTION
This solves #548.

The search dropdowns have gotten pretty slow.

I had SQLAlchemy print out the actual SQL it was sending to the DB and determined the `Item.issue_count` column_property was causing a significant delay.  I've modified that column property to be deferred.

The many joins were also having a big impact.  I've moved the joins to occur only when they are actually needed.  We've seen between a 10x and a 30x improvement with these modifications.

(Adding an index to Technology.name in #610 may have also helped, though I'm not sure by how much.)