### PR TITLE
Fix docs and variable names related to custom alerters

### DIFF
--- a/docs/misc.rst
+++ b/docs/misc.rst
@@ -111,8 +111,11 @@ A sample customer alerter would be a `SplunkAlerter` module that logs watcher an
 
 .. code-block:: python
 
+    from security_monkey.alerters import custom_alerter
+
+
     class SplunkAlerter(object):
-        __metaclass__ = AlerterType
+        __metaclass__ = custom_alerter.AlerterType
 
         def report_watcher_changes(self, watcher):
             """
@@ -164,8 +167,8 @@ A sample customer alerter would be a `SplunkAlerter` module that logs watcher an
                         item.region,
                         item.name))
 
-        def report_auditor_changes(self, items):
-            for item in items:
+        def report_auditor_changes(self, auditor):
+            for item in auditor.items:
                 for issue in item.confirmed_new_issues:
                     app.splunk_logger.info(
                         "action=\"Issue created\" "

--- a/security_monkey/alerters/custom_alerter.py
+++ b/security_monkey/alerters/custom_alerter.py
@@ -33,10 +33,10 @@ class AlerterType(type):
             alerter_registry.append(cls)
 
 
-def report_auditor_changes(items):
+def report_auditor_changes(auditor):
     for alerter_class in alerter_registry:
         alerter = alerter_class()
-        alerter.report_auditor_changes(items)
+        alerter.report_auditor_changes(auditor)
 
 
 def report_watcher_changes(watcher):


### PR DESCRIPTION
There little typo in docs and signature. Method report_auditor_changes receive auditor instance, not items list.