### PR TITLE
Fix for plaintext passwords in DB if using CLI for user creation 😱

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -15,7 +15,7 @@ from datetime import datetime
 import sys
 
 from flask.ext.script import Manager, Command, Option, prompt_pass
-from security_monkey.datastore import ExceptionLogs, clear_old_exceptions, store_exception
+from security_monkey.datastore import clear_old_exceptions, store_exception
 
 from security_monkey import app, db
 from security_monkey.common.route53 import Route53Service
@@ -221,6 +221,8 @@ def create_user(email, role):
     from flask_security import SQLAlchemyUserDatastore
     from security_monkey.datastore import User
     from security_monkey.datastore import Role
+    from flask_security.utils import encrypt_password
+
     user_datastore = SQLAlchemyUserDatastore(db, User, Role)
 
     ROLES = ['View', 'Comment', 'Justify', 'Admin']
@@ -238,7 +240,9 @@ def create_user(email, role):
             sys.stderr.write("[!] Passwords do not match\n")
             sys.exit(1)
 
-        user = user_datastore.create_user(email=email, password=password1, confirmed_at=datetime.now())
+        user = user_datastore.create_user(email=email,
+                                          password=encrypt_password(password1),
+                                          confirmed_at=datetime.now())
     else:
         sys.stdout.write("[+] Updating existing user\n")
         user = users.first()

--- a/migrations/versions/908b0085d28d_.py
+++ b/migrations/versions/908b0085d28d_.py
@@ -1,0 +1,75 @@
+"""Find unencrypted passwords in the database and delete them
+
+Revision ID: 908b0085d28d
+Revises: 1583a48cb978
+Create Date: 2017-03-17 13:16:19.539970
+Author: Mike Grima <mgrima@netflix.com>
+
+"""
+import re
+import sqlalchemy as sa
+
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+from alembic import op
+
+
+revision = '908b0085d28d'
+down_revision = '1583a48cb978'
+
+
+Session = sessionmaker()
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "user"
+    id = sa.Column(sa.Integer, primary_key=True)
+    email = sa.Column(sa.String(255), unique=True)
+    password = sa.Column(sa.String(255))
+    active = sa.Column(sa.Boolean())
+    confirmed_at = sa.Column(sa.DateTime())
+    daily_audit_email = sa.Column(sa.Boolean())
+    change_reports = sa.Column(sa.String(32))
+    last_login_at = sa.Column(sa.DateTime())
+    current_login_at = sa.Column(sa.DateTime())
+    login_count = sa.Column(sa.Integer)
+    last_login_ip = sa.Column(sa.String(45))
+    current_login_ip = sa.Column(sa.String(45))
+    role = sa.Column(sa.String(30))
+
+    def __str__(self):
+        return '<User id=%s email=%s>' % (self.id, self.email)
+
+
+def upgrade():
+    print("[@] Checking for users that have non-bcrypted/plaintext passwords in the database.")
+
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    # Need to get a list of all users in the DB that don't have bcrypted passwords.
+    users = session.query(User).all()
+
+    for user in users:
+        # If the password isn't bcrypted, then delete it -- Also output that it was deleted!
+        if user.password:
+            if not re.match("^\$2[ayb]\$.{56}$", user.password):
+                print("[!] User: {} has a plaintext password! Deleting the password!".format(user.email))
+                user.password = ""
+                session.add(user)
+                session.commit()
+                print("[-] Deleted plaintext password from user: {}'s account".format(user.email))
+
+            else:
+                print("[:D] User: {} has bcrypted password -- so all good!.".format(user.email))
+
+        else:
+            print("[:D] User: {} does not appear to be using username/password login, so all good!".format(user.email))
+
+    print("[@] Completed check.")
+
+
+def downgrade():
+    # There is no going back!
+    pass

--- a/security_monkey/tests/views/__init__.py
+++ b/security_monkey/tests/views/__init__.py
@@ -25,6 +25,7 @@ from flask_security import SQLAlchemyUserDatastore
 from security_monkey.datastore import User
 from security_monkey.datastore import Role
 from datetime import datetime
+from flask_security.utils import encrypt_password
 
 
 class SecurityMonkeyApiTestCase(SecurityMonkeyTestCase):
@@ -38,7 +39,7 @@ class SecurityMonkeyApiTestCase(SecurityMonkeyTestCase):
 
     def create_test_user(self, email, password):
         user_datastore = SQLAlchemyUserDatastore(db, User, Role)
-        user = user_datastore.create_user(email=email, password=password, confirmed_at=datetime.now())
+        user = user_datastore.create_user(email=email, password=encrypt_password(password), confirmed_at=datetime.now())
         user.role = 'Admin'
         user.active = True
 


### PR DESCRIPTION
**Note:** This has an alembic DB script that will find all unencrypted DB passwords, and **DELETE THE PASSWORDS FOR THE USER**.

_**The user must use the recover password feature if affected**._