### PR TITLE
Log Warning when S3 ACL can't be retrieved.

### DIFF
--- a/security_monkey/watchers/s3.py
+++ b/security_monkey/watchers/s3.py
@@ -69,8 +69,11 @@ class S3(Watcher):
                 bucket = self.process_bucket(bucket_name, name=bucket_name, **kwargs)
 
                 if bucket:
-                    item = S3Item.from_slurp(bucket_name, bucket, **kwargs)
-                    item_list.append(item)
+                    if bucket.has_key('Error'):
+                        app.logger.warn("Couldn't obtain ACL for S3 bucket {}. Error: {}".format(bucket_name, bucket['Error']))
+                    else:
+                        item = S3Item.from_slurp(bucket_name, bucket, **kwargs)
+                        item_list.append(item)
 
             return item_list, kwargs.get('exception_map', {})
         return slurp_items()


### PR DESCRIPTION
If MFA is enabled on the bucket we can't retrieve the ACL. This just logs a warning and carries on. It should also fix issue #579 when an ACL doesn't actually exist or has been deleted.