### PR TITLE
GCP: fixed UI Account Type filtering

### DIFF
--- a/dart/lib/component/issue_table_component/issue_table_component.dart
+++ b/dart/lib/component/issue_table_component/issue_table_component.dart
@@ -18,6 +18,7 @@ class IssueTableComponent extends PaginatedTable implements ScopeAware {
         'regions': '',
         'technologies': '',
         'accounts': '',
+        'accounttypes': '',
         'names': '',
         'arns': '',
         'active': null,

--- a/dart/lib/component/issue_table_component/issue_table_component.html
+++ b/dart/lib/component/issue_table_component/issue_table_component.html
@@ -31,6 +31,7 @@
             <th>Item Name</th>
             <th>Technology</th>
             <th>Account</th>
+            <th>Account Type</th>
             <th>Region</th>
             <th>Issue</th>
             <th>Notes</th>
@@ -44,6 +45,7 @@
             <td><a href="#/viewitem/{{issue.item_id}}">{{issue.item.name}}</a></td>
             <td>{{issue.item.technology}}</td>
             <td>{{issue.item.account}}</td>
+            <td>{{issue.item.account_type}}</td>
             <td>{{issue.item.region}}</td>
             <td>{{issue.issue}}</td>
             <td>{{issue.notes}}</td>

--- a/dart/lib/component/item_table_component/item_table_component.dart
+++ b/dart/lib/component/item_table_component/item_table_component.dart
@@ -27,6 +27,7 @@ class ItemTableComponent extends PaginatedTable implements DetachAware {
         'regions': '',
         'technologies': '',
         'accounts': '',
+        'accounttypes': '',
         'names': '',
         'arns': '',
         'active': null,

--- a/dart/lib/component/justified_table_component/justified_table_component.dart
+++ b/dart/lib/component/justified_table_component/justified_table_component.dart
@@ -17,6 +17,7 @@ class JustifiedTableComponent extends PaginatedTable implements ScopeAware {
         'regions': '',
         'technologies': '',
         'accounts': '',
+        'accounttypes': '',
         'names': '',
         'arns': '',
         'active': null,

--- a/dart/lib/component/justified_table_component/justified_table_component.html
+++ b/dart/lib/component/justified_table_component/justified_table_component.html
@@ -22,6 +22,7 @@
             <th>Item Name</th>
             <th>Technology</th>
             <th>Account</th>
+            <th>Account Type</th>
             <th>Region</th>
             <th>Issue</th>
             <th>Notes</th>
@@ -34,6 +35,7 @@
             <td><a href="#/viewitem/{{issue.item_id}}">{{issue.item.name}}</a></td>
             <td>{{issue.item.technology}}</td>
             <td>{{issue.item.account}}</td>
+            <td>{{issue.item.account_type}}</td>
             <td>{{issue.item.region}}</td>
             <td>{{issue.issue}}</td>
             <td>{{issue.notes}}</td>

--- a/dart/lib/component/revision_table_component/revision_table_component.dart
+++ b/dart/lib/component/revision_table_component/revision_table_component.dart
@@ -27,6 +27,7 @@ class RevisionTableComponent extends PaginatedTable implements DetachAware {
         'regions': '',
         'technologies': '',
         'accounts': '',
+        'accounttypes': '',
         'names': '',
         'arns': '',
         'active': null,

--- a/dart/lib/component/revision_table_component/revision_table_component.html
+++ b/dart/lib/component/revision_table_component/revision_table_component.html
@@ -46,6 +46,7 @@
             <th>Active</th>
             <th>Technology</th>
             <th>Account</th>
+            <th>Account Type</th>
             <th>Region</th>
             <th>Name</th>
             <th>Date</th>
@@ -58,6 +59,7 @@
             <td ng-switch-when="false"><div class="text-center"><i class="glyphicon glyphicon-remove"></i></div></td>
             <td>{{rev.item.technology}}</td>
             <td>{{rev.item.account}}</td>
+            <td>{{rev.item.account_type}}</td>
             <td>{{rev.item.region}}</td>
             <td><a href="#/viewitem/{{rev.item_id}}/{{rev.id}}">{{rev.item.name}}</a></td>
             <td>{{rev.date_created | date:'medium'}}</td>

--- a/security_monkey/views/item.py
+++ b/security_monkey/views/item.py
@@ -20,6 +20,7 @@ from security_monkey.views import REVISION_FIELDS
 from security_monkey.views import ITEM_LINK_FIELDS
 from security_monkey.datastore import Item
 from security_monkey.datastore import Account
+from security_monkey.datastore import AccountType
 from security_monkey.datastore import Technology
 from security_monkey.datastore import ItemRevision
 from security_monkey import rbac
@@ -138,7 +139,7 @@ class ItemGet(AuthenticatedService):
 
 
 # Returns a list of items optionally filtered by
-#  account, region, name, ctype or id.
+#  account, account_type, region, name, ctype or id.
 class ItemList(AuthenticatedService):
     decorators = [rbac.allow(['View'], ["GET"])]
 
@@ -197,6 +198,7 @@ class ItemList(AuthenticatedService):
         self.reqparse.add_argument('page', type=int, default=1, location='args')
         self.reqparse.add_argument('regions', type=str, default=None, location='args')
         self.reqparse.add_argument('accounts', type=str, default=None, location='args')
+        self.reqparse.add_argument('accounttypes', type=str, default=None, location='args')
         self.reqparse.add_argument('active', type=str, default=None, location='args')
         self.reqparse.add_argument('names', type=str, default=None, location='args')
         self.reqparse.add_argument('arns', type=str, default=None, location='args')
@@ -224,6 +226,11 @@ class ItemList(AuthenticatedService):
             accounts = args['accounts'].split(',')
             query = query.join((Account, Account.id == Item.account_id))
             query = query.filter(Account.name.in_(accounts))
+        if 'accounttypes' in args:
+            accounttypes = args['accounttypes'].split(',')
+            query = query.join((Account, Account.id == Item.account_id))
+            query = query.join((AccountType, AccountType.id == Account.account_type_id))
+            query = query.filter(AccountType.name.in_(accounttypes))
         if 'technologies' in args:
             technologies = args['technologies'].split(',')
             query = query.join((Technology, Technology.id == Item.tech_id))


### PR DESCRIPTION
Filtering on Account Type wasn't working correctly and had not been added to several screens.  By extension, I believe this should resolve #577.

Filtering added to:

* Audit Issues
* Justified Issues
* Items plus Historical Changes