### PR TITLE
Removing s3_name from exporter and renaming Account.number to identifier

### DIFF
--- a/security_monkey/export/__init__.py
+++ b/security_monkey/export/__init__.py
@@ -62,8 +62,7 @@ def export_items():
     attributes = [
         ["technology", "name"],
         ["account", "name"],
-        ["account", "s3_name"],
-        ["account", "number"],
+        ["account", "identifier"],
         ["region"],
         ["name"],
         ["issues"],
@@ -140,8 +139,7 @@ def export_issues():
     attributes = [
         ["item", "technology", "name"],
         ["item", "account", "name"],
-        ["item", "account", "s3_name"],
-        ["item", "account", "number"],
+        ["item", "account", "identifier"],
         ["item", "region"],
         ["item", "name"],
         ["item", "comments"],


### PR DESCRIPTION
Fixes #645 by removing Account.s3_name from the exported CSV and renaming Account.number to Account.identifier.