### PR TITLE
Add reference_policies for TLS transitional ELB security policies

### DIFF
--- a/security_monkey/auditors/elb.py
+++ b/security_monkey/auditors/elb.py
@@ -258,6 +258,11 @@ class ELBAuditor(Auditor):
             # https://forums.aws.amazon.com/ann.jspa?annID=3996
             return
 
+        if reference_policy == 'ELBSecurityPolicy-TLS-1-1-2017-01' or reference_policy == 'ELBSecurityPolicy-TLS-1-2-2017-01':
+            # Transitional policies for early TLS deprecation
+            # https://forums.aws.amazon.com/ann.jspa?annID=4475
+            return
+
         notes = reference_policy
         self.add_issue(10, "Unknown reference policy.", elb_item, notes=notes)
 


### PR DESCRIPTION
This resolves the 'Unknown reference policy' ELB auditor issue for these AWS-provided ELB policies.