### PR TITLE
No-opping DB migration b8ccf5b8089b

### DIFF
--- a/migrations/versions/b8ccf5b8089b_.py
+++ b/migrations/versions/b8ccf5b8089b_.py
@@ -1,9 +1,9 @@
-"""Fetch the S3 Canonical IDs for all active AWS accounts.
+"""Please run "monkey fetch_aws_canonical_ids"
 
 Revision ID: b8ccf5b8089b
 Revises: 908b0085d28d
 Create Date: 2017-03-23 11:00:43.792538
-Author: Mike Grima <mgrima@netflix.com>
+Author: Mike Grima <mgrima@netflix.com>, No-op'ed by Patrick
 
 """
 
@@ -14,40 +14,15 @@ from alembic import op
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-from security_monkey.manage import fetch_aws_canonical_ids
-
-Session = sessionmaker()
-Base = declarative_base()
-
 revision = 'b8ccf5b8089b'
 down_revision = '908b0085d28d'
 
-class Account(Base):
-    """
-    Meant to model AWS accounts.
-    """
-    __tablename__ = "account"
-    id = sa.Column(sa.Integer, primary_key=True)
-    active = sa.Column(sa.Boolean())
-    third_party = sa.Column(sa.Boolean())
-    name = sa.Column(sa.String(32), index=True, unique=True)
-    notes = sa.Column(sa.String(256))
-    identifier = sa.Column(sa.String(256))  # Unique id of the account, the number for AWS.
-    account_type_id = sa.Column(sa.Integer, sa.ForeignKey("account_type.id"), nullable=False)
-    unique_const = sa.UniqueConstraint('account_type_id', 'identifier')
-
 
 def upgrade():
-    print("[-->] Adding canonical IDs to all AWS accounts that are active...")
-    bind = op.get_bind()
-    session = Session(bind=bind)
-
-    # If there are currently no accounts, then skip... (avoids alembic issues...)
-    accounts = session.query(Account).all()
-    if len(accounts) > 0:
-        fetch_aws_canonical_ids(True)
-
-    print("[@] Completed adding canonical IDs to all active AWS accounts...")
+    # This revision has been replaced with a no-op after numerous reports of db upgrade problems.
+    # We recommend you run:
+    #   monkey fetch_aws_canonical_ids
+    pass
 
 
 def downgrade():


### PR DESCRIPTION
I'm unsure why this DB migration has caused reports of `monkey db upgrade` stalling.

I've no-op'd this DB migration.  It wasn't modifying the data structure, just the content.

Instead, we recommend calling `monkey fetch_aws_canonical_ids`.