### PR TITLE
Changed DisplayName to Email in ServiceAccount watcher

### DIFF
--- a/security_monkey/watchers/gcp/iam/serviceaccount.py
+++ b/security_monkey/watchers/gcp/iam/serviceaccount.py
@@ -72,7 +72,7 @@ class IAMServiceAccount(Watcher):
                     IAMServiceAccountItem(
                         region='global',
                         account=sa['ProjectId'],
-                        name=sa['DisplayName'],
+                        name=sa['Email'],
                         arn=resource_id,
                         config={
                             'policy': sa.get('Policy', None),


### PR DESCRIPTION
DisplayName is an optional field.  Changed to Email for consistency.  This was raised in Gitter chat, but I don't think it was officially reported.