### PR TITLE
do not add an issue when "Effect" is "Deny"

### DIFF
--- a/security_monkey/auditors/kms.py
+++ b/security_monkey/auditors/kms.py
@@ -85,7 +85,7 @@ class KMSAuditor(Auditor):
 
                     principal_account_ids = set()
                     for arn in aws_principal:
-                        if arn == "*" and not condition_accounts:
+                        if arn == "*" and not condition_accounts and "allow" == statement.get('Effect').lower():
                             notes = "An KMS policy where { 'Principal': { 'AWS': '*' } } must also have"
                             notes += " a {'Condition': {'StringEquals': { 'kms:CallerAccount': '<AccountNumber>' } } }"
                             notes += " or it is open to the world."


### PR DESCRIPTION
The default aws/acm KMS policy raises an issue with a score of 5 even though it's fine as-is.

Specifically, it raises this issue:

> An KMS policy where { 'Principal': { 'AWS': '*' } } must also have a {'Condition': {'StringEquals': { 'kms:CallerAccount': '' } } } or it is open to the world.

The policy looks like the following:
```
        {
          "Resource": "*",
          "Effect": "Deny",
          "Sid": "Deny encryption or decryption",
          "Action": [
            "kms:Decrypt*",
            "kms:Encrypt*"
          ],
          "Condition": {
            "StringEquals": {
              "kms:CallerAccount": "[...]"
            }
          },
          "Principal": {
            "AWS": "*"
          }
        },
        {
          "Resource": "*",
          "Effect": "Allow",
          "Sid": "Allowed operations for the key owner",
          "Action": [
            "kms:DescribeKey",
            "kms:GetKeyPolicy",
            "kms:ListGrants",
            "kms:RevokeGrant"
          ],
          "Condition": {
            "StringEquals": {
              "kms:CallerAccount": "[...]"
            }
          },
          "Principal": {
            "AWS": "*"
          }
        },
        {
          "Resource": "*",
          "Effect": "Allow",
          "Sid": "Allow creation of encryption grant",
          "Action": "kms:CreateGrant",
          "Condition": {
            "Bool": {
              "kms:GrantIsForAWSResource": "true"
            },
            "StringEquals": {
              "kms:ViaService": "acm.us-east-1.amazonaws.com",
              "kms:CallerAccount": "[...]"
            },
            "ForAllValues:StringEquals": {
              "kms:GrantOperations": [
                "Encrypt",
                "ReEncryptFrom",
                "ReEncryptTo"
              ]
            }
          },
          "Principal": {
            "AWS": "*"
          }
        },
        {
          "Resource": "*",
          "Effect": "Allow",
          "Sid": "Allow creation of decryption grants",
          "Action": "kms:CreateGrant",
          "Condition": {
            "Bool": {
              "kms:GrantIsForAWSResource": "true"
            },
            "StringEquals": {
              "kms:ViaService": "acm.us-east-1.amazonaws.com",
              "kms:CallerAccount": "[...]"
            },
            "ForAllValues:StringEquals": {
              "kms:GrantOperations": "Decrypt"
            }
          },
          "Principal": {
            "AWS": "*"
          }
        },
        {
          "Resource": "*",
          "Effect": "Deny",
          "Sid": "Deny re-encryption to any other key",
          "Action": "kms:ReEncrypt*",
          "Condition": {
            "Bool": {
              "kms:ReEncryptOnSameKey": "false"
            }
          },
          "Principal": {
            "AWS": "*"
          }
```
In this case, the final statement is the one triggering the alert. 

https://github.com/Netflix/security_monkey/blob/4ff55b217d6de625c5ef489baca5e115c67fb951/security_monkey/auditors/kms.py#L86-L93