### PR TITLE
Changing batch watchers to set created_items,changed_items,deleted_items so the Alerter fires properly.

### DIFF
--- a/security_monkey/datastore_utils.py
+++ b/security_monkey/datastore_utils.py
@@ -101,25 +101,25 @@ def detect_change(item, account, technology, complete_hash, durable_hash):
         app.logger.debug("Couldn't find item: {tech}/{account}/{region}/{item} in DB.".format(
             tech=item.index, account=item.account, region=item.region, item=item.name
         ))
-        return True, 'durable', result
+        return True, 'durable', result, 'created'
 
     if result.latest_revision_durable_hash != durable_hash:
         app.logger.debug("Item: {tech}/{account}/{region}/{item} in DB has a DURABLE CHANGE.".format(
             tech=item.index, account=item.account, region=item.region, item=item.name
         ))
-        return True, 'durable', result
+        return True, 'durable', result, 'changed'
 
     elif result.latest_revision_complete_hash != complete_hash:
         app.logger.debug("Item: {tech}/{account}/{region}/{item} in DB has an EPHEMERAL CHANGE.".format(
             tech=item.index, account=item.account, region=item.region, item=item.name
         ))
-        return True, 'ephemeral', result
+        return True, 'ephemeral', result, None
 
     else:
         app.logger.debug("Item: {tech}/{account}/{region}/{item} in DB has NO CHANGE.".format(
             tech=item.index, account=item.account, region=item.region, item=item.name
         ))
-        return False, None, result
+        return False, None, result, None
 
 
 def result_from_item(item, account, technology):

--- a/security_monkey/tests/core/test_datastore_utils.py
+++ b/security_monkey/tests/core/test_datastore_utils.py
@@ -213,7 +213,7 @@ class DatabaseUtilsTestCase(SecurityMonkeyTestCase):
         complete_hash, durable_hash = hash_item(sti.config, [])
 
         # Item does not exist in the DB yet:
-        assert (True, 'durable', None) == detect_change(sti, self.account, self.technology, complete_hash,
+        assert (True, 'durable', None, 'created') == detect_change(sti, self.account, self.technology, complete_hash,
                                                         durable_hash)
 
         # Add the item to the DB:
@@ -221,7 +221,7 @@ class DatabaseUtilsTestCase(SecurityMonkeyTestCase):
         db.session.commit()
 
         # Durable change (nothing hashed in DB yet)
-        assert (True, 'durable', item) == detect_change(sti, self.account, self.technology, complete_hash,
+        assert (True, 'durable', item, 'changed') == detect_change(sti, self.account, self.technology, complete_hash,
                                                         durable_hash)
 
         # No change:
@@ -230,7 +230,7 @@ class DatabaseUtilsTestCase(SecurityMonkeyTestCase):
         db.session.add(item)
         db.session.commit()
 
-        assert (False, None, item) == detect_change(sti, self.account, self.technology, complete_hash,
+        assert (False, None, item, None) == detect_change(sti, self.account, self.technology, complete_hash,
                                                     durable_hash)
 
         # Ephemeral change:
@@ -238,7 +238,7 @@ class DatabaseUtilsTestCase(SecurityMonkeyTestCase):
         mod_conf["IGNORE_ME"] = "I am ephemeral!"
         complete_hash, durable_hash = hash_item(mod_conf, ["IGNORE_ME"])
 
-        assert (True, 'ephemeral', item) == detect_change(sti, self.account, self.technology, complete_hash,
+        assert (True, 'ephemeral', item, None) == detect_change(sti, self.account, self.technology, complete_hash,
                                                           durable_hash)
 
     def test_persist_item(self):

--- a/security_monkey/tests/core/test_watcher.py
+++ b/security_monkey/tests/core/test_watcher.py
@@ -396,9 +396,19 @@ class WatcherTestCase(SecurityMonkeyTestCase):
             items.append(SomeTestItem().from_slurp(mod_conf, account_name=self.account.name))
 
         assert len(watcher.find_changes(items)) == 5
+        assert len(watcher.deleted_items) == 0
+        assert len(watcher.changed_items) == 0
+        assert len(watcher.created_items) == 5
+
+        watcher_2 = IAMRole(accounts=[self.account.name])
+        watcher_2.current_account = (self.account, 0)
+        watcher_2.technology = self.technology
 
         # Try again -- audit_items should be 0 since nothing was changed:
-        assert len(watcher.find_changes(items)) == 0
+        assert len(watcher_2.find_changes(items)) == 0
+        assert len(watcher_2.deleted_items) == 0
+        assert len(watcher_2.changed_items) == 0
+        assert len(watcher_2.created_items) == 0
 
     def test_find_deleted_batch(self):
         """
@@ -430,6 +440,7 @@ class WatcherTestCase(SecurityMonkeyTestCase):
 
         # Check for deleted items:
         watcher.find_deleted_batch({})
+        assert len(watcher.deleted_items) == 0
 
         # Check that nothing was deleted:
         for x in range(0, 5):
@@ -456,6 +467,7 @@ class WatcherTestCase(SecurityMonkeyTestCase):
 
         # Check for deleted items again:
         watcher.find_deleted_batch({})
+        assert len(watcher.deleted_items) == 2
 
         # Check that the last two items were deleted:
         for arn in removed_arns:

--- a/security_monkey/watcher.py
+++ b/security_monkey/watcher.py
@@ -377,7 +377,7 @@ class Watcher(object):
             complete_hash, durable_hash = hash_item(item.config, self.ephemeral_paths)
 
             # Detect if a change occurred:
-            is_change, change_type, db_item = detect_change(item, self.current_account[0], self.technology,
+            is_change, change_type, db_item, created_changed = detect_change(item, self.current_account[0], self.technology,
                                                             complete_hash, durable_hash)
 
             # As Officer Barbrady says: "Move along... Nothing to see here..."
@@ -393,13 +393,19 @@ class Watcher(object):
             if is_durable:
                 durable_items.append(item)
 
+            if created_changed == 'created':
+                self.created_items.append(item)
+
+            if created_changed == 'changed':
+                self.changed_items.append(item)
+
         return durable_items
 
     def find_deleted_batch(self, exception_map):
         arns = [item["Arn"] for item in self.total_list]
 
         from datastore_utils import inactivate_old_revisions
-        return inactivate_old_revisions(self, arns, self.current_account[0], self.technology)
+        self.deleted_items.extend(inactivate_old_revisions(self, arns, self.current_account[0], self.technology))
 
     def read_previous_items(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         'itsdangerous==0.23',
         'psycopg2==2.6.2',
         'bcrypt==3.1.2',
-        'Sphinx==1.5.1',
         'gunicorn==18.0',
         'cryptography==1.7.1',
         'boto3>=1.4.2',
@@ -74,8 +73,7 @@ setup(
             'mixer==5.5.7',
             'mock==1.0.1',
             'moto==0.4.30',
-            'freezegun>=0.3.7',
-            'mixer==5.5.7'
+            'freezegun>=0.3.7'
         ]
     },
     entry_points={


### PR DESCRIPTION
Changing batch watchers to set created_items,changed_items,deleted_items so the Alerter fires properly.

Fixes #705 