### PR TITLE
Fix type of postgresql port in env-config/config-docker.py

### DIFF
--- a/env-config/config-docker.py
+++ b/env-config/config-docker.py
@@ -70,7 +70,7 @@ LOG_CFG = {
     }
 }
 
-SQLALCHEMY_DATABASE_URI = 'postgresql://%s:%s@%s:%d/%s' % (
+SQLALCHEMY_DATABASE_URI = 'postgresql://%s:%s@%s:%s/%s' % (
     os.getenv('SECURITY_MONKEY_POSTGRES_USER', 'postgres'),
     os.getenv('SECURITY_MONKEY_POSTGRES_PASSWORD', 'securitymonkeypassword'),
     os.getenv('SECURITY_MONKEY_POSTGRES_HOST', 'localhost'),


### PR DESCRIPTION
Format string is failing with TypeError when environment variable
SECURITY_MONKEY_POSTGRES_PORT is set.