### PR TITLE
[GCP] fix modify parameter, remove unused import, upgrade cloudaux version

### DIFF
--- a/security_monkey/common/gcp/util.py
+++ b/security_monkey/common/gcp/util.py
@@ -59,7 +59,7 @@ def gcp_resource_id_builder(service, identifier, region=''):
     return resource.replace('/', ':').replace('.', ':')
 
 def modify(d, format='camelized'):
-    return cloudaux_modify(d, format=format)
+    return cloudaux_modify(d, output=format)
 
 def get_user_agent(**kwargs):
     from security_monkey.common.gcp.config import ApplicationConfig as appconfig

--- a/security_monkey/watchers/gcp/gce/firewall.py
+++ b/security_monkey/watchers/gcp/gce/firewall.py
@@ -24,7 +24,6 @@ from security_monkey.watcher import ChangeItem
 
 from cloudaux.gcp.decorators import iter_project
 from cloudaux.gcp.gce.firewall import list_firewall_rules
-from cloudaux.orchestration import modify
 
 
 class GCEFirewallRule(Watcher):

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'dpath==1.3.2',
         'pyyaml==3.11',
         'jira==0.32',
-        'cloudaux>=1.1.5',
+        'cloudaux>=1.2.2',
         'joblib>=0.9.4',
         'pyjwt>=1.01'
     ],


### PR DESCRIPTION
#### Summary
Version 1.2.2 of Cloudaux changes the modify argument from 'format', to output, which is used by GCP, specifically in firewall.py via our own wrapper.  We removed an unused import to cloudaux.orchestration.modify and updated our modify wrapper to use the new 'output' parameter.

We also set the cloudaux version in setup.py to 1.2.2 to ensure users receive the cloudaux version with this parameter update.

Fixes #720 