### PR TITLE
Basic auditor tests for GCP

### DIFF
--- a/security_monkey/tests/auditors/gcp/gce/test_firewall.py
+++ b/security_monkey/tests/auditors/gcp/gce/test_firewall.py
@@ -1,0 +1,105 @@
+#     Copyright 2017 Google, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import unittest
+"""
+.. module: security_monkey.tests.auditors.gcp.gce.test_firewall
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  Tom Melendez <supertom@google.com> @supertom
+"""
+
+ALLOWED_LIST_WITH_PORTRANGE = [
+    {
+     "IPProtocol": "tcp",
+     "ports": [
+      "0-65535"
+     ]
+    },
+    {
+     "IPProtocol": "udp",
+     "ports": [
+      "0-65535"
+     ]
+    },
+    {
+     "IPProtocol": "icmp"
+    }
+   ]
+
+ALLOWED_LIST_NO_PORTRANGE = [
+    {
+     "IPProtocol": "tcp",
+     "ports": [
+      "80"
+     ]
+    },
+    {
+     "IPProtocol": "icmp"
+    }
+   ]
+
+SOURCERANGES_PRESENT = [
+    '0.0.0.0/0',
+    '192.168.1.0/24'
+    ]
+
+SOURCERANGES_ABSENT = [
+    '10.0.0.0/0',
+    '192.168.1.0/24'
+    ]
+
+TARGETTAGS_PRESENT = [
+    'http-server',
+    'https-server'
+    ]
+
+TARGETTAGS_ABSENT = [
+    'http-server',
+    'https-server'
+    ]
+
+class FirewallTestCase(unittest.TestCase):
+
+    def test___port_range_exists(self):
+        from security_monkey.auditors.gcp.gce.firewall import GCEFirewallRuleAuditor
+        auditor = GCEFirewallRuleAuditor(accounts=['unittest'])
+        actual = auditor._port_range_exists(ALLOWED_LIST_WITH_PORTRANGE)
+        self.assertTrue(isinstance(actual, list))
+
+        actual = auditor._port_range_exists(ALLOWED_LIST_NO_PORTRANGE)
+        self.assertFalse(actual)
+
+    def test__target_tags_valid(self):
+        from security_monkey.auditors.gcp.gce.firewall import GCEFirewallRuleAuditor
+        auditor = GCEFirewallRuleAuditor(accounts=['unittest'])
+
+        actual = auditor._target_tags_valid(TARGETTAGS_PRESENT)
+        self.assertTrue(isinstance(actual, list))
+
+        actual = auditor._target_tags_valid(TARGETTAGS_ABSENT)
+        self.assertFalse(actual)
+
+    def test__source_ranges_open(self):
+        from security_monkey.auditors.gcp.gce.firewall import GCEFirewallRuleAuditor
+        auditor = GCEFirewallRuleAuditor(accounts=['unittest'])
+        
+        actual = auditor._source_ranges_open(SOURCERANGES_PRESENT)
+        self.assertTrue(isinstance(actual, list))
+
+        actual = auditor._source_ranges_open(SOURCERANGES_ABSENT)
+        self.assertFalse(actual)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/security_monkey/tests/auditors/gcp/gce/test_network.py
+++ b/security_monkey/tests/auditors/gcp/gce/test_network.py
@@ -1,0 +1,71 @@
+#     Copyright 2017 Google, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import unittest
+"""
+.. module: security_monkey.tests.auditors.gcp.gce.test_network
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  Tom Melendez <supertom@google.com> @supertom
+"""
+
+AUTO_NETWORK_DICT = {
+    "AutoCreateSubnetworks": True,
+    "CreationTimestamp": "2016-05-09T11:15:47.434-07:00",
+    "Description": "Default network for the project",
+    "Id": "5748637682906434876",
+    "Kind": "compute#network",
+    "Name": "default",
+    "SelfLink": "https://www.googleapis.com/compute/v1/projects/my-project-one/global/networks/default",
+    "Subnetworks": [
+        {
+            "CreationTimestamp": "2016-10-25T09:53:00.777-07:00",
+            "GatewayAddress": "10.146.0.1",
+            "Id": "1852214226435846915",
+            "IpCidrRange": "10.146.0.0/20",
+            "Kind": "compute#subnetwork",
+            "Name": "default",
+            "Network": "https://www.googleapis.com/compute/v1/projects/my-project-one/global/networks/default",
+            "Region": "https://www.googleapis.com/compute/v1/projects/my-project-one/regions/asia-northeast1",
+            "SelfLink": "https://www.googleapis.com/compute/v1/projects/my-project-one/regions/asia-northeast1/subnetworks/default"
+        }
+        
+    ]
+}
+
+LEGACY_NETWORK = {
+    "kind": "compute#network",
+    "id": "6570954185952335682",
+    "creationTimestamp": "2016-08-04T13:46:37.261-07:00",
+    "name": "network-b",
+    "IPv4Range": "10.0.0.0/8",
+    "gatewayIPv4": "10.0.0.1",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/supertom-graphite/global/networks/network-b"
+}
+    
+
+
+class NetworkTestCase(unittest.TestCase):
+
+    def test__legacy_exists(self):
+        from security_monkey.auditors.gcp.gce.network import GCENetworkAuditor
+        auditor = GCENetworkAuditor(accounts=['unittest'])
+
+        actual = auditor._legacy_exists(AUTO_NETWORK_DICT)
+        self.assertFalse(actual)
+        actual = auditor._legacy_exists(LEGACY_NETWORK)
+        self.assertTrue(isinstance(actual, list))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/security_monkey/tests/auditors/gcp/gcs/test_bucket.py
+++ b/security_monkey/tests/auditors/gcp/gcs/test_bucket.py
@@ -1,0 +1,66 @@
+#     Copyright 2017 Google, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import unittest
+"""
+.. module: security_monkey.tests.auditors.gcp.gcs.test_bucket
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  Tom Melendez <supertom@google.com> @supertom
+"""
+
+ACL_LIST = [
+    {u'role': u'OWNER', u'entity': u'project-editors-2094195755359'},
+    {u'role': u'READER', u'entity': u'project-viewers-2094195755359'},
+    {u'role': u'WRITER', u'entity': u'project-writer-2094195755359'}
+]
+
+ACL_LIST_TWO_OWNERS = [
+    {u'role': u'OWNER', u'entity': u'project-editors-2094195755359'},
+    {u'role': u'READER', u'entity': u'project-viewers-2094195755359'},
+    {u'role': u'OWNER', u'entity': u'project-editors-2094195755359'}
+]
+
+ACL_LIST_ALLUSERS = [
+    {u'role': u'OWNER', u'entity': u'project-editors-2094195755359'},
+    {u'role': u'READER', u'entity': u'allUsers'},
+    {u'role': u'OWNER', u'entity': u'project-editors-2094195755359'}
+]
+
+
+class BucketTestCase(unittest.TestCase):
+
+    def test__acl_allusers_exists(self):
+        from security_monkey.auditors.gcp.gcs.bucket import GCSBucketAuditor
+        auditor = GCSBucketAuditor(accounts=['unittest'])
+
+        actual = auditor._acl_allusers_exists(ACL_LIST)
+        self.assertFalse(actual)
+        actual = auditor._acl_allusers_exists(ACL_LIST_ALLUSERS)
+        self.assertTrue(actual)
+        
+    def test__acl_max_owners(self):
+        from security_monkey.auditors.gcp.gcs.bucket import GCSBucketAuditor
+        auditor = GCSBucketAuditor(accounts=['unittest'])
+
+        # NOTE: the config value below actually controls this so ensure
+        # it is set to 1
+        auditor.gcp_config.MAX_OWNERS_PER_BUCKET = 1
+        actual = auditor._acl_max_owners(ACL_LIST)
+        self.assertFalse(actual)
+        actual = auditor._acl_max_owners(ACL_LIST_TWO_OWNERS)
+        self.assertTrue(actual)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/security_monkey/tests/auditors/gcp/iam/test_serviceaccount.py
+++ b/security_monkey/tests/auditors/gcp/iam/test_serviceaccount.py
@@ -1,0 +1,70 @@
+#     Copyright 2017 Google, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+import unittest
+"""
+.. module: security_monkey.tests.auditors.gcp.iam.test_serviceaccount
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  Tom Melendez <supertom@google.com> @supertom
+"""
+
+POLICY_WITH_ACTOR_LIST = [
+    {
+        "Members": [
+            "user:test-user@gmail.com"
+        ],
+        "Role": "roles/iam.serviceAccountActor"
+    }
+]
+
+
+POLICY_NO_ACTOR_LIST = [
+    {
+        "Members": [
+            "user:test-user@gmail.com"
+        ],
+        "Role": "roles/viewer"
+    }
+]
+
+
+class IAMServiceAccountTestCase(unittest.TestCase):
+
+    def test__max_keys(self):
+        from security_monkey.auditors.gcp.iam.serviceaccount import IAMServiceAccountAuditor
+        auditor = IAMServiceAccountAuditor(accounts=['unittest'])
+        # NOTE: the config value below actually controls this so ensure
+        # it is set to 1
+        auditor.gcp_config.MAX_SERVICEACCOUNT_KEYS = 1
+        actual = auditor._max_keys(2)
+        self.assertTrue(isinstance(actual, list))
+
+        actual = auditor._max_keys(1)
+        self.assertFalse(actual)
+
+    def test__actor_role(self):
+        from security_monkey.auditors.gcp.iam.serviceaccount import IAMServiceAccountAuditor
+        auditor = IAMServiceAccountAuditor(accounts=['unittest'])
+        # NOTE: the config value below actually controls this so ensure
+        # it is set to 1
+        auditor.gcp_config.MAX_SERVICEACCOUNT_KEYS = 1
+        actual = auditor._actor_role(POLICY_WITH_ACTOR_LIST)
+        self.assertTrue(isinstance(actual, list))
+
+        actual = auditor._actor_role(POLICY_NO_ACTOR_LIST)
+        self.assertFalse(actual)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Some auditor tests for GCP.  These run with pytest like so:

`PYTHONPATH=. pytest security_monkey/tests/auditors/gcp/iam/test_serviceaccount.py`

`PYTHONPATH=. pytest security_monkey/tests/auditors/gcp/gce/test_firewall.py`

`PYTHONPATH=. pytest security_monkey/tests/auditors/gcp/gcs/test_bucket.py`

`PYTHONPATH=. pytest security_monkey/tests/auditors/gcp/gce/test_network.py`

