### PR TITLE
Add a KMS key rotation watcher and auditor

### DIFF
--- a/security_monkey/auditors/kms.py
+++ b/security_monkey/auditors/kms.py
@@ -49,6 +49,15 @@ class KMSAuditor(Auditor):
     def __init__(self, accounts=None, debug=False):
         super(KMSAuditor, self).__init__(accounts=accounts, debug=debug)
 
+    def check_for_kms_key_rotation(self, kms_item):
+        """
+        Alert when a KMS key is not configured for rotation
+        This is a AWS CIS Foundations Benchmark audit item (2.8)
+        """
+        rotation_status = kms_item.config.get('KeyRotationEnabled')
+        if not rotation_status:
+            self.add_issue(1, 'KMS key is not configured for rotation.', kms_item)
+
     def check_for_kms_policy_with_foreign_account(self, kms_item):
         """
         alert when a KMS master key contains a policy giving permissions

--- a/security_monkey/watchers/kms.py
+++ b/security_monkey/watchers/kms.py
@@ -139,7 +139,7 @@ class KMS(Watcher):
     @record_exception()
     def get_key_rotation_status(self, kms, key_id, alias, **kwargs):
         rotation_status = None
-        if bool('aws/' in alias):
+        if alias.startswith('alias/aws/'):
             # AWS-owned KMS keys don't have a rotation status we can see. Setting a default here saves an API request.
             app.logger.debug("{} {}({}) is an AWS supplied KMS key, overriding to True for rotation state".format(self.i_am_singular, alias, key_id))
             rotation_status = True

--- a/security_monkey/watchers/kms.py
+++ b/security_monkey/watchers/kms.py
@@ -136,6 +136,21 @@ class KMS(Watcher):
 
         return json.loads(policy.get("Policy"))
 
+    @record_exception()
+    def get_key_rotation_status(self, kms, key_id, alias, **kwargs):
+        rotation_status = None
+        if bool('aws/' in alias):
+            # AWS-owned KMS keys don't have a rotation status we can see. Setting a default here saves an API request.
+            app.logger.debug("{} {}({}) is an AWS supplied KMS key, overriding to True for rotation state".format(self.i_am_singular, alias, key_id))
+            rotation_status = True
+        else:
+            rotation_status = self.wrap_aws_rate_limited_call(
+                kms.get_key_rotation_status,
+                KeyId=key_id
+            ).get("KeyRotationEnabled")
+
+        return rotation_status
+
     def __init__(self, accounts=None, debug=False):
         super(KMS, self).__init__(accounts=accounts, debug=debug)
 
@@ -190,6 +205,7 @@ class KMS(Watcher):
                             if config.get('Error') is None:
                                 grants = self.list_grants(kms, key_id, **kwargs)
                                 policy_names = self.list_key_policies(kms, key_id, alias, **kwargs)
+                                rotation_status = self.get_key_rotation_status(kms, key_id, alias, **kwargs)
 
                                 if policy_names:
                                     for policy_name in policy_names:
@@ -207,9 +223,9 @@ class KMS(Watcher):
                                         if grant.get("CreationDate"):
                                             grant.update({ 'CreationDate': grant.get('CreationDate').astimezone(tzutc()).isoformat() })
 
-
                                 config[u"Policies"] = policies
                                 config[u"Grants"] = grants
+                                config[u"KeyRotationEnabled"] = rotation_status
 
                             item = KMSMasterKey(region=kwargs['region'], account=kwargs['account_name'], name=name, arn=config.get('Arn'), config=dict(config))
                             item_list.append(item)


### PR DESCRIPTION
The AWS CIS Benchmark recommends that all AWS KMS keys are rotated annually.
This change tracks the rotation state of all KMS keys and create a 1 point
issue when a key is not configured to rotate.

This change requires new permissions in the Security Monkey policy document:

`kms:GetKeyRotationStatus`