### PR TITLE
Fixing S3 Region

### DIFF
--- a/security_monkey/tests/core/test_scheduler.py
+++ b/security_monkey/tests/core/test_scheduler.py
@@ -377,7 +377,7 @@ class SchedulerTestCase(SecurityMonkeyTestCase):
             role_policy = dict(ROLE_CONF)
             role_policy["Arn"] = "arn:aws:iam::012345678910:role/roleNumber{}".format(x)
             role_policy["RoleName"] = "roleNumber{}".format(x)
-            role = CloudAuxChangeItem.from_item(name=role_policy['RoleName'], item=role_policy, override_region='universal', account_name=test_account.name, index='iamrole')
+            role = CloudAuxChangeItem.from_item(name=role_policy['RoleName'], item=role_policy, record_region='universal', account_name=test_account.name, index='iamrole')
             items.append(role)
 
         audit_items = watcher.find_changes_batch(items, {})


### PR DESCRIPTION
Fixing bug where All S3 buckets were recorded in us-east-1.  The bug was introduced by a recent refactor.  The JSON still contained the correct region, but the table and filters would display an incorrect region.

Allowing S3 to record in the buckets region instead of the region where the initial boto connection takes place (us-east-1).