### PR TITLE
Allow specifying accounts by id in manage.py

### DIFF
--- a/security_monkey/manage.py
+++ b/security_monkey/manage.py
@@ -468,7 +468,11 @@ def _parse_accounts(account_str, active=True):
         accounts = [account.name for account in accounts]
         return accounts
     else:
-        return account_str.split(',')
+        names_or_ids = account_str.split(',')
+        accounts = Account.query.all()
+        accounts = {account.identifier: account.name for account in accounts}
+        names = map(lambda n: accounts.get(n, n), names_or_ids)
+        return names
 
 
 @manager.option('-n', '--name', dest='name', type=unicode, required=True)


### PR DESCRIPTION
The `manage.py`/`monkey` script currently only supports specifying accounts by their security_monkey-managed name when running tasks such as `find_changes`. This PR adds support for specifying accounts by their id (`acccount.identifier`) and allows for easier integrations with external manual or automated workflows for running tasks that only are aware of the identifier.

```console
$ python manage.py find_changes -a 1234567890 -m s3
```