### PR TITLE
fix docs inconsistency in default db/schema name and password

### DIFF
--- a/docs/dev_setup_osx.md
+++ b/docs/dev_setup_osx.md
@@ -102,10 +102,10 @@ Open a new shell, then start the DB:
 Go back to your previous shell, then create the database and users and set the timezone. :
 
     psql -d postgres -h localhost
-    CREATE DATABASE "securitymonkeydb";
-    CREATE ROLE "securitymonkeyuser" LOGIN PASSWORD 'securitymonkeypass';
-    CREATE SCHEMA securitymonkeydb
-    GRANT Usage, Create ON SCHEMA "securitymonkeydb" TO "securitymonkeyuser";
+    CREATE DATABASE "secmonkey";
+    CREATE ROLE "securitymonkeyuser" LOGIN PASSWORD 'securitymonkeypassword';
+    CREATE SCHEMA secmonkey
+    GRANT Usage, Create ON SCHEMA "secmonkey" TO "securitymonkeyuser";
     set timezone to 'GMT';
     select now();
 

--- a/docs/dev_setup_ubuntu.md
+++ b/docs/dev_setup_ubuntu.md
@@ -68,10 +68,10 @@ Configure PostgreSQL
 Create a PostgreSQL database for security monkey and add a role. Set the timezone to GMT. :
 
     sudo -u postgres psql
-    CREATE DATABASE "securitymonkeydb";
-    CREATE ROLE "securitymonkeyuser" LOGIN PASSWORD 'securitymonkeypass';
-    CREATE SCHEMA securitymonkeydb
-    GRANT Usage, Create ON SCHEMA "securitymonkeydb" TO "securitymonkeyuser";
+    CREATE DATABASE "secmonkey";
+    CREATE ROLE "securitymonkeyuser" LOGIN PASSWORD 'securitymonkeypassword';
+    CREATE SCHEMA secmonkey
+    GRANT Usage, Create ON SCHEMA "secmonkey" TO "securitymonkeyuser";
     set timezone TO 'GMT';
     select now();
     \q


### PR DESCRIPTION
Updated osx/ubuntu guides to match quickstart guide and scripts
* `securitymonkeydb` -> `secmonkey`
* `securitymonkeypass` -> `securitymonkeypassword`