### PR TITLE
Fix unjustified issues deletion

### DIFF
--- a/security_monkey/manage.py
+++ b/security_monkey/manage.py
@@ -94,7 +94,7 @@ def delete_unjustified_issues(accounts, monitors):
     monitor_names = _parse_tech_names(monitors)
     account_names = _parse_accounts(accounts)
     from security_monkey.datastore import ItemAudit
-    issues = ItemAudit.query.filter_by(ItemAudit.justified == False).all()
+    issues = ItemAudit.query.filter_by(justified=False).all()
     for issue in issues:
         del issue.sub_items[:]
         db.session.delete(issue)


### PR DESCRIPTION
Use proper arguments for filter_by:

Traceback (most recent call last):
  File "./venv/bin/monkey", line 11, in <module>
    load_entry_point('security-monkey', 'console_scripts', 'monkey')()
  File "/home/ubuntu/security_monkey/security_monkey/manage.py", line 625, in main
    manager.run()
  File "/home/ubuntu/venv/local/lib/python2.7/site-packages/flask_script/__init__.py", line 397, in run
    result = self.handle(sys.argv[0], sys.argv[1:])
  File "/home/ubuntu/venv/local/lib/python2.7/site-packages/flask_script/__init__.py", line 376, in handle
    return handle(app, *positional_args, **kwargs)
  File "/home/ubuntu/venv/local/lib/python2.7/site-packages/flask_script/commands.py", line 145, in handle
    return self.run(*args, **kwargs)
  File "/home/ubuntu/security_monkey/security_monkey/manage.py", line 97, in delete_unjustified_issues
    issues = ItemAudit.query.filter_by(ItemAudit.justified==False).all()
TypeError: filter_by() takes exactly 1 argument (2 given)
