### PR TITLE
Improving S3 Auditor and reports dropdown.

### DIFF
--- a/dart/web/ui.html
+++ b/dart/web/ui.html
@@ -45,40 +45,47 @@
                 <li><a href="#/dashboard">Dashboard</a></li>
                 <li><a href="#/items/-/-/-/-/-/-/-/-/1/25">Search</a></li>
                 <li class="dropdown">
-                    <a class="dropdown-toggle" data-toggle="dropdown">Reports <b class="caret"></b></a>
+                    <a class="dropdown-toggle" data-toggle="dropdown">Internet Accessible <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="#/issues/-/iamuser/-/-/-/-/True/active%20accesskey/1/25">IAM User - Active Access Keys</a></li>
-                        <li><a href="#/issues/-/iamuser/-/-/-/-/True/inactive/1/25">IAM User - Inactive Access Keys</a></li>
-                        <li><a href="#/issues/-/iamuser/-/-/-/-/True/unused/1/25">IAM User - Unused Access Keys</a></li>
-                        <li class="divider"></li>
-                        <li><a href="#/issues/-/s3/-/-/-/-/True/ACL%20-%20Unknown%20Cross%20Account%20Access./1/25">S3 - ACL - Unknown Cross Account Access</a></li>
-                        <li><a href="#/issues/-/s3/-/-/-/-/True/POLICY%20-%20Unknown%20Cross%20Account%20Access./1/25">S3 - POLICY - Unknown Cross Account Access</a></li>
                         <li><a href="#/issues/-/s3/-/-/-/-/True/ACL%20-%20AllUsers%20USED./1/25">S3 - ACL - AllUsers USED</a></li>
                         <li><a href="#/issues/-/s3/-/-/-/-/True/POLICY%20-%20This%20Policy%20Allows%20Access%20From%20Anyone./1/25">S3 - POLICY - This Policy Allows Access From Anyone</a></li>
+                        <li><a href="#/issues/-/s3/-/-/-/-/True/POLICY%20-%20This%20Policy%20Allows%20Conditional%20Access%20From%20Anyone./1/25">S3 - POLICY - This Policy Allows Conditional Access From Anyone</a></li>
+                        <li><a href="#/issues/-/s3/-/-/-/-/True/ACL%20-%20AuthenticatedUsers%20USED./1/25">S3 - ACL - Authenticated Users</a></li>
+                        <li class="divider"></li>
+                        <li><a href="#/issues/-/sns/-/-/-/-/True/SNS%20Topic%20open%20to%20everyone/1/25">SNS - Open to the World</a></li>
+                        <li><a href="#/issues/-/sqs/-/-/-/-/True/SQS%20Queue%20open%20to%20everyone/1/25">SQS - Open to the World</a></li>
+                        <li><a href="#/issues/-/elasticsearchservice/-/-/-/-/True/ElasticSearch%20Service%20domain%20open%20to%20everyone/1/25">ElasticSearch - Open to the World</a></li>
+                        <li><a href="#/issues/-/kms/-/-/-/-/True/open%20to%20the%20world/1/25">KMS - Open to the World</a></li>
+                        <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Security%20Group%20ingress%20rule%20contains%200.0.0.0%2F0/1/25">Security Group Ingress 0.0.0.0/0</a></li>
+                        <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Security%20Group%20egress%20rule%20contains%200.0.0.0%2F0/1/25">Security Group Egress 0.0.0.0/0</a></li>
+                        <li><a href="#/issues/-/iamrole/-/-/-/-/True/allows%20assume-role%20from%20anyone/1/25">IAM Role Allows AssumeRole from Anyone</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown">
+                    <a class="dropdown-toggle" data-toggle="dropdown">Cross Account <b class="caret"></b></a>
+                    <ul class="dropdown-menu">
+                        <li><a href="#/issues/-/s3/-/-/-/-/True/ACL%20-%20Unknown%20Cross%20Account%20Access./1/25">S3 - ACL - Unknown Cross Account Access</a></li>
+                        <li><a href="#/issues/-/s3/-/-/-/-/True/POLICY%20-%20Unknown%20Cross%20Account%20Access./1/25">S3 - POLICY - Unknown Cross Account Access</a></li>
                         <li><a href="#/issues/-/s3/-/-/-/-/True/ACL%20-%20AuthenticatedUsers%20USED./1/25">S3 - ACL - Authenticated Users</a></li>
                         <li class="divider"></li>
                         <li><a href="#/issues/-/sns/-/-/-/-/True/Unknown%20Cross%20Account%20Access/1/25">SNS - Unknown Cross Account Access</a></li>
-                        <li class="divider"></li>
-                        <li><a href="#/issues/-/sqs/-/-/-/-/True/SQS%20Queue%20open%20to%20everyone/1/25">SQS - Open to the World</a></li>
-                        <li class="divider"></li>
-                        <li><a href="#/issues/-/elasticsearchservice/-/-/-/-/True/ElasticSearch%20Service%20domain%20open%20to%20everyone/1/25">ElasticSearch - Open to the World</a></li>
-                        <li class="divider"></li>
-                        <li><a href="#/issues/-/kms/-/-/-/-/True/open%20to%20the%20world/1/25">KMS - Open to the World</a></li>
                         <li><a href="#/issues/-/kms/-/-/-/-/True/Condition%20-%20kms%3ACallerAccount/1/25">KMS - Condition - Cross Account</a></li>
                         <li><a href="#/issues/-/kms/-/-/-/-/True/Principal%20-%20/1/25">KMS - Principal - Cross Account</a></li>
+                        <li><a href="#/issues/-/iamrole/-/-/-/-/True/IAM%20Role%20allows%20assume-role%20from%20an%20Unknown%20Account/1/25">IAM Role Allows AssumeRole from Unknown Account</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown">
+                    <a class="dropdown-toggle" data-toggle="dropdown">Reports <b class="caret"></b></a>
+                    <ul class="dropdown-menu">
+                        <li><a href="#/issues/-/iamuser/-/-/-/-/True/User%20has%20active%20accesskey./1/25">IAM User - Active Access Keys</a></li>
+                        <li><a href="#/issues/-/iamuser/-/-/-/-/True/inactive/1/25">IAM User - Inactive Access Keys</a></li>
+                        <li><a href="#/issues/-/iamuser/-/-/-/-/True/unused/1/25">IAM User - Unused Access Keys</a></li>
                         <li class="divider"></li>
                         <li><a href="#/issues/-/cloudtrail/-/-/-/-/True/CloudTrail%20is%20disabled/1/25">CloudTrail - Disabled</a></li>
                         <li><a href="#/issues/-/cloudtrail/-/-/-/-/True/CloudTrail%20is%20not%20enabled%20for%20multi-region/1/25">CloudTrail - Not Multi-Region</a></li>
                         <li class="divider"></li>
-                        <li><a href="#/issues/-/securitygroup/-/-/-/-/True/-/1/25">Security Group Issues</a></li>
-                        <li><a href="#/issues/-/rds/-/-/-/-/True/-/1/25">RDS Security Group Issues</a></li>
-                        <li><a href="#/issues/-/vpc/-/-/-/-/True/-/1/25">VPC Issues</a></li>
                         <li><a href="#/issues/-/elb/-/-/-/-/True/-/1/25">ELB Issues</a></li>
                         <li><a href="#/issues/-/iamssl/-/-/-/-/True/-/1/25">SSL Issues</a></li>
-                        <li><a href="#/issues/-/iamrole/-/-/-/-/True/-/1/25">IAM Role Issues</a></li>
-                        <li><a href="#/issues/-/iamgroup/-/-/-/-/True/-/1/25">IAM Group Issues</a></li>
-                        <li><a href="#/issues/-/policy/-/-/-/-/True/-/1/25">Managed Policy Issues</a></li>
-                        <li><a href="#/issues/-/redshift/-/-/-/-/True/-/1/25">Redshift Issues</a></li>
                         <li class="divider"></li>
                         <li><a href="#/justified/-/-/-/-/-/-/-/-/1/25">Justified Issues</a></li>
                     </ul>

--- a/dart/web/ui.html
+++ b/dart/web/ui.html
@@ -58,6 +58,7 @@
                         <li><a href="#/issues/-/kms/-/-/-/-/True/open%20to%20the%20world/1/25">KMS - Open to the World</a></li>
                         <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Security%20Group%20ingress%20rule%20contains%200.0.0.0%2F0/1/25">Security Group Ingress 0.0.0.0/0</a></li>
                         <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Security%20Group%20egress%20rule%20contains%200.0.0.0%2F0/1/25">Security Group Egress 0.0.0.0/0</a></li>
+                        <li><a href="#/issues/-/elb/-/-/-/-/True/VPC%20ELB%20is%20Internet%20accessible/1/25">VPC ELB is Internet Accessible</a></li>
                         <li><a href="#/issues/-/iamrole/-/-/-/-/True/allows%20assume-role%20from%20anyone/1/25">IAM Role Allows AssumeRole from Anyone</a></li>
                     </ul>
                 </li>


### PR DESCRIPTION
This PR closes 3 issues:
- Improves the reports dropdown (#539).
- #342 - s3 auditor should better handle conditions 
- #641 - S3 auditor needs source vpce exemption

S3 bucket policies with a wildcard principal 
- `POLICY - This Policy Allows Conditional Access From Anyone.` with score of 3.  Will stuff the condition keys into the notes section like `IpAddress/aws:SourceIp` or `StringEquals/aws:sourceVpce` or `StringLike/aws:Referer`.
- `POLICY - This Policy Allows Access From Anyone.` with a score of 10