### PR TITLE
Alb auditor

### DIFF
--- a/dart/web/ui.html
+++ b/dart/web/ui.html
@@ -59,6 +59,7 @@
                         <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Security%20Group%20ingress%20rule%20contains%200.0.0.0%2F0/1/25">Security Group Ingress 0.0.0.0/0</a></li>
                         <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Security%20Group%20egress%20rule%20contains%200.0.0.0%2F0/1/25">Security Group Egress 0.0.0.0/0</a></li>
                         <li><a href="#/issues/-/elb/-/-/-/-/True/VPC%20ELB%20is%20Internet%20accessible/1/25">VPC ELB is Internet Accessible</a></li>
+                        <li><a href="#/issues/-/alb/-/-/-/-/True/ALB%20is%20Internet%20accessible/1/25">ALB is Internet Accessible</a></li>
                         <li><a href="#/issues/-/iamrole/-/-/-/-/True/allows%20assume-role%20from%20anyone/1/25">IAM Role Allows AssumeRole from Anyone</a></li>
                     </ul>
                 </li>
@@ -70,8 +71,11 @@
                         <li><a href="#/issues/-/s3/-/-/-/-/True/ACL%20-%20AuthenticatedUsers%20USED./1/25">S3 - ACL - Authenticated Users</a></li>
                         <li class="divider"></li>
                         <li><a href="#/issues/-/sns/-/-/-/-/True/Unknown%20Cross%20Account%20Access/1/25">SNS - Unknown Cross Account Access</a></li>
+                        <li><a href="#/issues/-/sqs/-/-/-/-/True/Unknown%20Cross%20Account%20Access/1/25">SQS - Unknown Cross Account Access</a></li>
                         <li><a href="#/issues/-/kms/-/-/-/-/True/Condition%20-%20kms%3ACallerAccount/1/25">KMS - Condition - Cross Account</a></li>
                         <li><a href="#/issues/-/kms/-/-/-/-/True/Principal%20-%20/1/25">KMS - Principal - Cross Account</a></li>
+                        <li><a href="#/issues/-/elb/-/-/-/-/True/VPC%20ELB%20accessible%20from%20non-private%20CIDR./1/25">VPC ELB accessible from non-private CIDR.</a></li>
+                        <li><a href="#/issues/-/alb/-/-/-/-/True/ALB%20accessible%20from%20non-private%20CIDR./1/25">ALB accessible from non-private CIDR.</a></li>
                         <li><a href="#/issues/-/iamrole/-/-/-/-/True/IAM%20Role%20allows%20assume-role%20from%20an%20Unknown%20Account/1/25">IAM Role Allows AssumeRole from Unknown Account</a></li>
                     </ul>
                 </li>
@@ -86,6 +90,7 @@
                         <li><a href="#/issues/-/cloudtrail/-/-/-/-/True/CloudTrail%20is%20not%20enabled%20for%20multi-region/1/25">CloudTrail - Not Multi-Region</a></li>
                         <li class="divider"></li>
                         <li><a href="#/issues/-/elb/-/-/-/-/True/-/1/25">ELB Issues</a></li>
+                        <li><a href="#/issues/-/alb/-/-/-/-/True/-/1/25">ALB Issues</a></li>
                         <li><a href="#/issues/-/iamssl/-/-/-/-/True/-/1/25">SSL Issues</a></li>
                         <li class="divider"></li>
                         <li><a href="#/justified/-/-/-/-/-/-/-/-/1/25">Justified Issues</a></li>

--- a/security_monkey/auditors/elb.py
+++ b/security_monkey/auditors/elb.py
@@ -160,19 +160,29 @@ class ELBAuditor(Auditor):
             for sgid in security_groups:
                 for sg in sg_items:
                     if sg.config.get('id') == sgid:
-                        sg_cidrs = []
+                        sg_cidrs = set()
+                        internet_accessible_cidrs = set()
                         for rule in sg.config.get('rules', []):
                             cidr = rule.get('cidr_ip', '')
+
                             if rule.get('rule_type', None) == 'ingress' and cidr:
-                                if not check_rfc_1918(cidr) and not self._check_inclusion_in_network_whitelist(cidr):
-                                    sg_cidrs.append(cidr)
+                                if cidr.endswith('/0'):
+                                    internet_accessible_cidrs.add(cidr)
+                                elif not check_rfc_1918(cidr) and not self._check_inclusion_in_network_whitelist(cidr):
+                                    sg_cidrs.add(cidr)
 
                         if sg_cidrs:
                             notes = 'SG [{sgname}] via [{cidr}]'.format(
                                 sgname=sg.name,
-                                cidr=', '.join(sg_cidrs)
-                            )
+                                cidr=', '.join(sg_cidrs))
+                            self.add_issue(1, 'VPC ELB accessible from non-private CIDR.', elb_item, notes=notes)
+
+                        if internet_accessible_cidrs:
+                            notes = 'SG [{sgname}] via [{cidr}]'.format(
+                                sgname=sg.name,
+                                cidr=', '.join(internet_accessible_cidrs))
                             self.add_issue(1, 'VPC ELB is Internet accessible.', elb_item, notes=notes)
+
                         break
 
     def check_listener_reference_policy(self, elb_item):

--- a/security_monkey/auditors/elbv2.py
+++ b/security_monkey/auditors/elbv2.py
@@ -1,0 +1,132 @@
+#     Copyright 2014 Netflix, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.auditors.elbv2
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  Patrick Kelley <pkelley@netflix.com> @monkeysecurity
+
+"""
+from security_monkey.watchers.elbv2 import ELBv2
+from security_monkey.auditor import Auditor
+from security_monkey.watchers.security_group import SecurityGroup
+from security_monkey.common.utils import check_rfc_1918
+from security_monkey.datastore import NetworkWhitelistEntry
+
+import ipaddr
+
+
+class ELBv2Auditor(Auditor):
+    index = ELBv2.index
+    i_am_singular = ELBv2.i_am_singular
+    i_am_plural = ELBv2.i_am_plural
+    network_whitelist = []
+    support_watcher_indexes = [SecurityGroup.index]
+
+    def __init__(self, accounts=None, debug=False):
+        super(ELBv2Auditor, self).__init__(accounts=accounts, debug=debug)
+
+    def prep_for_audit(self):
+        self.network_whitelist = NetworkWhitelistEntry.query.all()
+
+    def _check_inclusion_in_network_whitelist(self, cidr):
+        for entry in self.network_whitelist:
+            if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork(str(entry.cidr)):
+                return True
+        return False
+    
+    def check_internet_facing(self, alb):
+        scheme = alb.config.get('Scheme')
+        if scheme == 'internet-facing':
+            # Grab each attached security group and determine if they contain
+            # a public IP
+            security_groups = alb.config.get('SecurityGroups', [])
+            sg_items = self.get_watcher_support_items(SecurityGroup.index, alb.account)
+            for sgid in security_groups:
+                for sg in sg_items:
+                    if sg.config.get('id') == sgid:
+                        sg_cidrs = set()
+                        internet_accessible_cidrs = set()
+                        for rule in sg.config.get('rules', []):
+                            cidr = rule.get('cidr_ip', '')
+
+                            if rule.get('rule_type', None) == 'ingress' and cidr:
+                                if cidr.endswith('/0'):
+                                    internet_accessible_cidrs.add(cidr)
+                                elif not check_rfc_1918(cidr) and not self._check_inclusion_in_network_whitelist(cidr):
+                                    sg_cidrs.add(cidr)
+
+                        if sg_cidrs:
+                            notes = 'SG [{sgname}] via [{cidr}]'.format(
+                                sgname=sg.name,
+                                cidr=', '.join(sg_cidrs))
+                            self.add_issue(1, 'ALB accessible from non-private CIDR.', alb, notes=notes)
+
+                        if internet_accessible_cidrs:
+                            notes = 'SG [{sgname}] via [{cidr}]'.format(
+                                sgname=sg.name,
+                                cidr=', '.join(internet_accessible_cidrs))
+                            self.add_issue(1, 'ALB is Internet accessible.', alb, notes=notes)
+
+                        break
+
+    def check_logging(self, alb):
+        attributes = alb.config.get('Attributes', [])
+        for attribute in attributes:
+            if attribute.get('Key') == 'access_logs.s3.enabled':
+                if attribute['Value'] == 'false':
+                    self.add_issue(1, 'ALB is not configured for logging.', alb)
+                return
+
+    def check_deletion_protection(self, alb):
+        attributes = alb.config.get('Attributes', [])
+        for attribute in attributes:
+            if attribute.get('Key') == 'deletion_protection.enabled':
+                if attribute['Value'] == 'false':
+                    self.add_issue(1, 'ALB is not configured for deletion protection.', alb)
+                return
+
+    def check_ssl_policy(self, alb):
+        """
+        ALB SSL Policies are much simpler than ELB (classic) policies.
+        - Custom policies are not allowed.
+        - Try to use ELBSecurityPolicy-2016-08
+        - Alert on unknown policy or if using ELBSecurityPolicy-TLS-1-0-2015-04
+        - The ELBSecurityPolicy-2016-08 and ELBSecurityPolicy-2015-05 security policies for Application Load Balancers are identical.
+
+        http://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
+        """
+        supported_ssl_policies = set([
+            'ELBSecurityPolicy-2016-08',
+            'ELBSecurityPolicy-TLS-1-2-2017-01',
+            'ELBSecurityPolicy-TLS-1-1-2017-01',
+            'ELBSecurityPolicy-2015-05',
+            'ELBSecurityPolicy-TLS-1-0-2015-04'])
+
+        for listener in alb.config.get('Listeners', []):
+            port = listener.get('Port')
+            ssl_policy = listener.get('SslPolicy')
+            if not ssl_policy:
+                continue
+
+            if ssl_policy == 'ELBSecurityPolicy-TLS-1-0-2015-04':
+                notes = 'Policy {0} on port {1}'.format(ssl_policy, port)
+                self.add_issue(5,
+                    'ELBSecurityPolicy-TLS-1-0-2015-04 contains a weaker cipher (DES-CBC3-SHA) '
+                    'for backwards compatibility with Windows XP systems. Vulnerable to SWEET32 CVE-2016-2183.',
+                    alb, notes=notes)
+
+            if ssl_policy not in supported_ssl_policies:
+                self.add_issue(10, 'Unknown reference policy.', alb, notes=ssl_policy)

--- a/security_monkey/auditors/vpc/vpn.py
+++ b/security_monkey/auditors/vpc/vpn.py
@@ -37,6 +37,6 @@ class VPNAuditor(Auditor):
         if vpn_item.config.get('tunnels'):
             for tunnel in vpn_item.config.get('tunnels'):
                 if tunnel.get('status') != "UP":
-                    notes = "{} - {} - {}".join(tunnel.get('outside_ip_address'), tunnel.get('status'), tunnel.get('status_message'))
-                    self.add_issue(1, "{} tunnel is not UP".format(i_am_singular), vpn_item, notes=notes)
+                    notes = "{} - {} - {}".format(tunnel.get('outside_ip_address'), tunnel.get('status'), tunnel.get('status_message'))
+                    self.add_issue(1, "{} tunnel is not UP".format(self.i_am_singular), vpn_item, notes=notes)
 

--- a/security_monkey/watchers/elbv2.py
+++ b/security_monkey/watchers/elbv2.py
@@ -8,7 +8,7 @@ class ELBv2(CloudAuxWatcher):
     i_am_singular = 'ALB'
     i_am_plural = 'ALBs'
     honor_ephemerals = False
-    ephemeral_paths = ['_version']
+    ephemeral_paths = ['_version', 'TargetGroupHealth$*$Target$Id']
     service_name = 'elbv2'
 
     def get_name_from_list_output(self, item):

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'dpath==1.3.2',
         'pyyaml==3.11',
         'jira==0.32',
-        'cloudaux>=1.2.8',
+        'cloudaux>=1.3.1',
         'joblib>=0.9.4',
         'pyjwt>=1.01'
     ],


### PR DESCRIPTION
- Updating Report dropdowns.
- Adding ephemeral section to ALB watcher.
- Bumping cloudaux to 1.3.1
- Fixing syntax errors in VPN Auditor.
- Adding ALB Auditor
- Spitting "Accessible from non-private CIDR" out of "Internet Accessible" for ELBs and ALBs.

(Internet Accessible for ELBs/ALBs now means access from `/0` explicitly.)

