### PR TITLE
Sanitizing account identifiers.

### DIFF
--- a/security_monkey/account_managers/aws_account.py
+++ b/security_monkey/account_managers/aws_account.py
@@ -50,3 +50,11 @@ class AWSAccountManager(AccountManager):
 
     def __init__(self):
         super(AWSAccountManager, self).__init__()
+
+    def sanitize_account_identifier(self, identifier):
+        """AWS identifer sanitization will strip and remove any hyphens.
+        
+        Returns:
+            stripped identifier with hyphens removed
+        """
+        return identifier.replace('-', '').strip()


### PR DESCRIPTION
Initial stab at fixing #783

All account identifiers will be stripped() of leading/trailing white space.
AWS identifiers will have hyphens removed.