### PR TITLE
add docker-compose.override.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ secmonkey.env
 *.crt
 *.key
 postgres-data/
+
+docker-compose.override.yml


### PR DESCRIPTION
To allow easy overriding of docker environment and configuration.