### PR TITLE
Ec2instance watcher issue798

### DIFF
--- a/security_monkey/watchers/ec2/ec2_instance.py
+++ b/security_monkey/watchers/ec2/ec2_instance.py
@@ -67,45 +67,43 @@ class EC2Instance(Watcher):
                 for reservation in reservations:
                     instances = reservation.get('Instances')
                     for instance in instances:
-                        instances = reservation.get('Instances')
-                        for instance in instances:
-                            name = None
-                            if instance.get('Tags') is not None:
-                                for tag in instance.get('Tags'):
-                                    if tag['Key'] == 'Name':
-                                        name = tag['Value']
-                                        break
+                        name = None
+                        if instance.get('Tags') is not None:
+                            for tag in instance.get('Tags'):
+                                if tag['Key'] == 'Name':
+                                    name = tag['Value']
+                                    break
 
-                            instance_id = instance['InstanceId']
-                            if name is None:
-                                name = instance_id
+                        instance_id = instance['InstanceId']
+                        if name is None:
+                            name = instance_id
 
-                            if self.check_ignore_list(name):
-                                continue
+                        if self.check_ignore_list(name):
+                            continue
 
-                        config = {
-                            'name': name,
-                            'instance_id': instance_id,
-                            'image_id': instance.get('ImageId'),
-                            'state': instance.get('State'),
-                            'private_dns_name': instance.get('PrivateDnsName'),
-                            'public_dns_name': instance.get('PublicDnsName'),
-                            'instance_type': instance.get('InstanceType'),
-                            'launch_time': str(instance.get('LaunchTime')),
-                            'placement': instance.get('placement'),
-                            'subnet_id': instance.get('SubnetId'),
-                            'vpc_id': instance.get('VpcId'),
-                            'private_ip_address': instance.get('PrivateIpAddress'),
-                            'public_ip_address': instance.get('PublicIpAddress'),
-                        }
+                    config = {
+                        'name': name,
+                        'instance_id': instance_id,
+                        'image_id': instance.get('ImageId'),
+                        'state': instance.get('State'),
+                        'private_dns_name': instance.get('PrivateDnsName'),
+                        'public_dns_name': instance.get('PublicDnsName'),
+                        'instance_type': instance.get('InstanceType'),
+                        'launch_time': str(instance.get('LaunchTime')),
+                        'placement': instance.get('placement'),
+                        'subnet_id': instance.get('SubnetId'),
+                        'vpc_id': instance.get('VpcId'),
+                        'private_ip_address': instance.get('PrivateIpAddress'),
+                        'public_ip_address': instance.get('PublicIpAddress'),
+                    }
 
-                        unique_name = name + '(' + instance_id + ')'
+                    unique_name = name + '(' + instance_id + ')'
 
-                        item = EC2InstanceItem(region=kwargs['region'],
-                                               account=kwargs['account_name'],
-                                               name=unique_name, config=dict(config))
+                    item = EC2InstanceItem(region=kwargs['region'],
+                                           account=kwargs['account_name'],
+                                           name=unique_name, config=dict(config))
 
-                        item_list.append(item)
+                    item_list.append(item)
 
             return item_list, exception_map
         return slurp_items()

--- a/security_monkey/watchers/ec2/ec2_instance.py
+++ b/security_monkey/watchers/ec2/ec2_instance.py
@@ -81,29 +81,29 @@ class EC2Instance(Watcher):
                         if self.check_ignore_list(name):
                             continue
 
-                    config = {
-                        'name': name,
-                        'instance_id': instance_id,
-                        'image_id': instance.get('ImageId'),
-                        'state': instance.get('State'),
-                        'private_dns_name': instance.get('PrivateDnsName'),
-                        'public_dns_name': instance.get('PublicDnsName'),
-                        'instance_type': instance.get('InstanceType'),
-                        'launch_time': str(instance.get('LaunchTime')),
-                        'placement': instance.get('placement'),
-                        'subnet_id': instance.get('SubnetId'),
-                        'vpc_id': instance.get('VpcId'),
-                        'private_ip_address': instance.get('PrivateIpAddress'),
-                        'public_ip_address': instance.get('PublicIpAddress'),
-                    }
+                        config = {
+                            'name': name,
+                            'instance_id': instance_id,
+                            'image_id': instance.get('ImageId'),
+                            'state': instance.get('State'),
+                            'private_dns_name': instance.get('PrivateDnsName'),
+                            'public_dns_name': instance.get('PublicDnsName'),
+                            'instance_type': instance.get('InstanceType'),
+                            'launch_time': str(instance.get('LaunchTime')),
+                            'placement': instance.get('placement'),
+                            'subnet_id': instance.get('SubnetId'),
+                            'vpc_id': instance.get('VpcId'),
+                            'private_ip_address': instance.get('PrivateIpAddress'),
+                            'public_ip_address': instance.get('PublicIpAddress'),
+                        }
 
-                    unique_name = name + '(' + instance_id + ')'
+                        unique_name = name + '(' + instance_id + ')'
 
-                    item = EC2InstanceItem(region=kwargs['region'],
-                                           account=kwargs['account_name'],
-                                           name=unique_name, config=dict(config))
+                        item = EC2InstanceItem(region=kwargs['region'],
+                                               account=kwargs['account_name'],
+                                               name=unique_name, config=dict(config))
 
-                    item_list.append(item)
+                        item_list.append(item)
 
             return item_list, exception_map
         return slurp_items()


### PR DESCRIPTION
Fix for the issue https://github.com/Netflix/security_monkey/issues/798

Bug: Instance count information was getting incorrectly recorded
Problem: After retrieving instances using AWS API, instances list was iterated twice in loop. This lead to duplicating results and missing some other ones