### PR TITLE
#756 SWAG syncing.

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -187,6 +187,13 @@ A common example would be "test" for your testing AWS account or "prod" for your
 The `--id IDENTIFIER` is the back-end cloud service identifier for a given provider. For AWS, it's the 12 digit account number, 
 and for GCP, it's the project ID.
 
+### Syncing With SWAG
+
+If you're using [SWAG](https://github.com/Netflix-Skunkworks/swag-client). You can populate your database via the following command:
+
+    monkey sync_swag --owner <example-corp> --bucket-name <my-bucket> --bucket-prefix accounts.json --bucket-region us-east-1 -u
+
+
 
 ### AWS Only: S3 Canonical IDs
 

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         'joblib>=0.9.4',
         'pyjwt>=1.01',
         'netaddr',
+        'swag_client',
         'idna==2.5'  # Pinning to idna to avoid a dependency problem with requests.
         # First identified as a problem by Qmando - https://github.com/requests/requests/pull/4223
     ],


### PR DESCRIPTION
Addresses #756, adds a new command line option that allows syncing account metadata between swag and security monkey. Marks accounts with security_monkey enabled as an 'active' account in security_monkey's database.

