### PR TITLE
Adding RDS Snapshot Auditor.

### DIFF
--- a/dart/web/ui.html
+++ b/dart/web/ui.html
@@ -52,7 +52,7 @@
                         <li><a href="#/issues/-/elb/-/-/-/-/True/VPC%20ELB%20is%20Internet%20accessible/1/25">VPC ELB is Internet Accessible</a></li>
                         <li><a href="#/issues/-/alb/-/-/-/-/True/ALB%20is%20Internet%20accessible/1/25">ALB is Internet Accessible</a></li>
                         <li class="divider"></li>
-                        <li><a href="#/issues/-/elasticsearchservice%2Ckms%2Clambda%2Cs3%2Csns%2Csqs%2Cglacier/-/-/-/-/True/Internet%20Accessible/1/25">via Resource Policy</a></li>
+                        <li><a href="#/issues/-/elasticsearchservice%2Cglacier%2Ckms%2Clambda%2Crdssnapshot%2Cs3%2Csns%2Csqs/-/-/-/-/True/Internet%20Accessible/1/25">via Resource Policy</a></li>
                         <li><a href="#/issues/-/iamrole/-/-/-/-/True/allows%20assume-role%20from%20anyone/1/25">IAM Role Allows AssumeRole from Anyone</a></li>
                     </ul>
                 </li>
@@ -62,9 +62,9 @@
                         <li><a href="#/issues/-/elb/-/-/-/-/True/VPC%20ELB%20accessible%20from%20non-private%20CIDR./1/25">VPC ELB accessible from non-private CIDR.</a></li>
                         <li><a href="#/issues/-/alb/-/-/-/-/True/ALB%20accessible%20from%20non-private%20CIDR./1/25">ALB accessible from non-private CIDR.</a></li>
                         <li class="divider"></li>
-                        <li><a href="#/issues/-/elasticsearchservice%2Ckms%2Clambda%2Cs3%2Csns%2Csqs%2Cglacier/-/-/-/-/True/Unknown%20Access/1/25">Unknown Access via Resource Policy</a></li>
-                        <li><a href="#/issues/-/elasticsearchservice%2Ckms%2Clambda%2Cs3%2Csns%2Csqs%2Cglacier/-/-/-/-/True/Friendly%20Cross%20Account/1/25">Friendly Access via Resource Policy</a></li>
-                        <li><a href="#/issues/-/elasticsearchservice%2Ckms%2Clambda%2Cs3%2Csns%2Csqs%2Cglacier/-/-/-/-/True/Thirdparty%20Cross%20Account/1/25">Thirdparty Access via Resource Policy</a></li>
+                        <li><a href="#/issues/-/elasticsearchservice%2Cglacier%2Ckms%2Clambda%2Crdssnapshot%2Cs3%2Csns%2Csqs/-/-/-/-/True/Unknown%20Access/1/25">Unknown Access via Resource Policy</a></li>
+                        <li><a href="#/issues/-/elasticsearchservice%2Cglacier%2Ckms%2Clambda%2Crdssnapshot%2Cs3%2Csns%2Csqs/-/-/-/-/True/Friendly%20Cross%20Account/1/25">Friendly Access via Resource Policy</a></li>
+                        <li><a href="#/issues/-/elasticsearchservice%2Cglacier%2Ckms%2Clambda%2Crdssnapshot%2Cs3%2Csns%2Csqs/-/-/-/-/True/Thirdparty%20Cross%20Account/1/25">Thirdparty Access via Resource Policy</a></li>
                         <li class="divider"></li>
                         <li><a href="#/issues/-/iamrole/-/-/-/-/True/IAM%20Role%20allows%20assume-role%20from%20an%20Unknown%20Account/1/25">IAM Role Allows AssumeRole from Unknown Account</a></li>
                     </ul>

--- a/security_monkey/auditors/rds_snapshot.py
+++ b/security_monkey/auditors/rds_snapshot.py
@@ -1,0 +1,82 @@
+#     Copyright 2017 Netflix, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.auditors.rds_snapshot
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor::  Patrick Kelley <patrick@netflix.com>
+
+"""
+from security_monkey.auditor import Auditor, Entity
+from security_monkey.watchers.rds.rds_snapshot import RDSSnapshot
+
+
+class RDSSnapshotAuditor(Auditor):
+    index = RDSSnapshot.index
+    i_am_singular = RDSSnapshot.i_am_singular
+    i_am_plural = RDSSnapshot.i_am_plural
+
+    def __init__(self, accounts=None, debug=False):
+        super(RDSSnapshotAuditor, self).__init__(accounts=accounts, debug=debug)
+
+    def prep_for_audit(self):
+        super(RDSSnapshotAuditor, self).prep_for_audit()
+        self.FRIENDLY = { account['identifier']: account['name'] for account in self.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'] if account['label'] == 'friendly'}
+        self.THIRDPARTY = { account['identifier']: account['name'] for account in self.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'] if account['label'] == 'thirdparty'}
+
+    def check_internet_accessible(self, item):
+        if 'all' in item.config.get('Attributes', {}).get('restore', []):
+            entity = Entity(category='account', value='all')
+            self.record_internet_access(item, entity, actions=['restore'])
+
+    def check_friendly_cross_account(self, item):
+        accounts = item.config.get('Attributes', {}).get('restore', [])
+        for account in accounts:
+            if account == 'all':
+                continue
+
+            if account in self.FRIENDLY:
+                entity = Entity(
+                    category='account',
+                    value=account,
+                    account_name=self.FRIENDLY[account],
+                    account_identifier=account)
+                self.record_friendly_access(item, entity, actions=['restore'])
+
+    def check_thirdparty_cross_account(self, item):
+        accounts = item.config.get('Attributes', {}).get('restore', [])
+        for account in accounts:
+            if account == 'all':
+                continue
+
+            if account in self.THIRDPARTY:
+                entity = Entity(
+                    category='account',
+                    value=account,
+                    account_name=self.THIRDPARTY[account],
+                    account_identifier=account)
+                self.record_thirdparty_access(item, entity, actions=['restore'])
+
+    def check_unknown_cross_account(self, item):
+        accounts = item.config.get('Attributes', {}).get('restore', [])
+        for account in accounts:
+            if account == 'all':
+                continue
+
+            if account not in self.FRIENDLY and account not in self.THIRDPARTY:
+                entity = Entity(
+                    category='account',
+                    value=account)
+                self.record_unknown_access(item, entity, actions=['restore'])

--- a/security_monkey/auditors/resource_policy_auditor.py
+++ b/security_monkey/auditors/resource_policy_auditor.py
@@ -20,214 +20,25 @@
 
 """
 from security_monkey import app
-from security_monkey.auditor import Auditor, Categories, Entity
-from security_monkey.datastore import Account, Item, Technology, NetworkWhitelistEntry
+from security_monkey.auditor import Auditor, Entity
+from security_monkey.datastore import Account
 
 from policyuniverse.arn import ARN
 from policyuniverse.policy import Policy
 from policyuniverse.statement import Statement
-from threading import Lock
+
 import json
 import dpath.util
 from dpath.exceptions import PathNotFound
-from collections import defaultdict
 import ipaddr
-import netaddr
 
 
-def add(to, key, value):
-    if not key:
-        return
-    if key in to:
-        to[key].add(value)
-    else:
-        to[key] = set([value])
 
 class ResourcePolicyAuditor(Auditor):
-    OBJECT_STORE = defaultdict(dict)
-    OBJECT_STORE_LOCK = Lock()
 
     def __init__(self, accounts=None, debug=False):
         super(ResourcePolicyAuditor, self).__init__(accounts=accounts, debug=debug)
         self.policy_keys = ['Policy']
-
-    def prep_for_audit(self):
-        self._load_object_store()
-
-    @classmethod
-    def _load_object_store(cls):
-        with cls.OBJECT_STORE_LOCK:
-            if not cls.OBJECT_STORE:
-                cls._load_s3_buckets()
-                cls._load_userids()
-                cls._load_accounts()
-                cls._load_elasticips()
-                cls._load_vpcs()
-                cls._load_vpces()
-                cls._load_natgateways()
-                cls._load_network_whitelist()
-                cls._merge_cidrs()
-
-    @classmethod
-    def _merge_cidrs(cls):
-        """
-        We learned about CIDRs from the following functions:
-        -   _load_elasticips()
-        -   _load_vpcs()
-        -   _load_vpces()
-        -   _load_natgateways()
-        -   _load_network_whitelist()
-
-        These cidr's are stored in the OBJECT_STORE in a way that is not optimal:
-
-            OBJECT_STORE['cidr']['54.0.0.1'] = set(['123456789012'])
-            OBJECT_STORE['cidr']['54.0.0.0'] = set(['123456789012'])
-            ...
-            OBJECT_STORE['cidr']['54.0.0.255/32'] = set(['123456789012'])
-
-        The above example is attempting to illustrate that account `123456789012`
-        contains `54.0.0.0/24`, maybe from 256 elastic IPs.
-
-        If a resource policy were attempting to ingress this range as a `/24` instead
-        of as individual IPs, it would not work.  We need to use the `cidr_merge`
-        method from the `netaddr` library.  We need to preserve the account identifiers
-        that are associated with each cidr as well.
-
-        # Using:
-        # https://netaddr.readthedocs.io/en/latest/tutorial_01.html?highlight=summarize#summarizing-list-of-addresses-and-subnets
-        # import netaddr
-        # netaddr.cidr_merge(ip_list)
-
-        Step 1: Group CIDRs by account:
-        #   ['123456789012'] = ['IP', 'IP']
-
-        Step 2:
-        Merge each account's cidr's separately and repalce the OBJECT_STORE['cidr'] entry.
-
-        Return:
-            `None`.  Mutates the cls.OBJECT_STORE['cidr'] datastructure.
-        """
-        if not 'cidr' in cls.OBJECT_STORE:
-            return
-
-        # step 1
-        merged = defaultdict(set)
-        for cidr, accounts in cls.OBJECT_STORE['cidr'].items():
-            for account in accounts:
-                merged[account].add(cidr)
-
-        del cls.OBJECT_STORE['cidr']
-
-        # step 2
-        for account, cidrs in merged.items():
-            merged_cidrs = netaddr.cidr_merge(cidrs)
-            for cidr in merged_cidrs:
-                add(cls.OBJECT_STORE['cidr'], str(cidr), account)
-
-    @classmethod
-    def _load_s3_buckets(cls):
-        """Store the S3 bucket ARNs from all our accounts"""
-        results = cls._load_related_items('s3')
-        for item in results:
-            add(cls.OBJECT_STORE['s3'], item.name, item.account.identifier)
-
-    @classmethod
-    def _load_vpcs(cls):
-        """Store the VPC IDs. Also, extract & store network/NAT ranges."""
-        results = cls._load_related_items('vpc')
-        for item in results:
-            add(cls.OBJECT_STORE['vpc'], item.latest_config.get('id'), item.account.identifier)
-            add(cls.OBJECT_STORE['cidr'], item.latest_config.get('cidr_block'), item.account.identifier)
-
-            vpcnat_tags = unicode(item.latest_config.get('tags', {}).get('vpcnat', ''))
-            vpcnat_tag_cidrs = vpcnat_tags.split(',')
-            for vpcnat_tag_cidr in vpcnat_tag_cidrs:
-                add(cls.OBJECT_STORE['cidr'], vpcnat_tag_cidr.strip(), item.account.identifier)
-
-    @classmethod
-    def _load_vpces(cls):
-        """Store the VPC Endpoint IDs."""
-        results = cls._load_related_items('endpoint')
-        for item in results:
-            add(cls.OBJECT_STORE['vpce'], item.latest_config.get('id'), item.account.identifier)
-
-    @classmethod
-    def _load_elasticips(cls):
-        """Store the Elastic IPs."""
-        results = cls._load_related_items('elasticip')
-        for item in results:
-            add(cls.OBJECT_STORE['cidr'], item.latest_config.get('public_ip'), item.account.identifier)
-            add(cls.OBJECT_STORE['cidr'], item.latest_config.get('private_ip_address'), item.account.identifier)
-
-    @classmethod
-    def _load_natgateways(cls):
-        """Store the NAT Gateway CIDRs."""
-        results = cls._load_related_items('natgateway')
-        for gateway in results:
-            for address in gateway.latest_config.get('nat_gateway_addresses', []):
-                add(cls.OBJECT_STORE['cidr'], address['public_ip'], gateway.account.identifier)
-                add(cls.OBJECT_STORE['cidr'], address['private_ip'], gateway.account.identifier)
-
-    @classmethod
-    def _load_network_whitelist(cls):
-        """Stores the Network Whitelist CIDRs."""
-        whitelist_entries = NetworkWhitelistEntry.query.all()
-        for entry in whitelist_entries:
-            add(cls.OBJECT_STORE['cidr'], entry.cidr, '000000000000')
-
-    @classmethod
-    def _load_userids(cls):
-        """Store the UserIDs from all IAMUsers and IAMRoles."""
-        user_results = cls._load_related_items('iamuser')
-        role_results = cls._load_related_items('iamrole')
-
-        for item in user_results:
-            add(cls.OBJECT_STORE['userid'], item.latest_config.get('UserId'), item.account.identifier)
-
-        for item in role_results:
-            add(cls.OBJECT_STORE['userid'], item.latest_config.get('RoleId'), item.account.identifier)
-
-    @classmethod
-    def _load_accounts(cls):
-        """Store the account IDs of all friendly/thirdparty accounts."""
-        friendly_accounts = Account.query.filter(Account.third_party == False).all()
-        third_party = Account.query.filter(Account.third_party == True).all()
-
-        cls.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'] = list()
-        cls.OBJECT_STORE['ACCOUNTS']['FRIENDLY'] = set()
-        cls.OBJECT_STORE['ACCOUNTS']['THIRDPARTY'] = set()
-
-        for account in friendly_accounts:
-            add(cls.OBJECT_STORE['ACCOUNTS'], 'FRIENDLY', account.identifier)
-            cls.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'].append(dict(
-                name=account.name,
-                identifier=account.identifier,
-                label='friendly',
-                s3_name=account.getCustom('s3_name'),
-                s3_canonical_id=account.getCustom('canonical_id')))
-
-        for account in third_party:
-            add(cls.OBJECT_STORE['ACCOUNTS'], 'THIRDPARTY', account.identifier)
-            cls.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'].append(dict(
-                name=account.name,
-                identifier=account.identifier,
-                label='thirdparty',
-                s3_name=account.getCustom('s3_name'),
-                s3_canonical_id=account.getCustom('canonical_id')))
-
-    @staticmethod
-    def _load_related_items(technology_name):
-        query = Item.query.join((Technology, Technology.id == Item.tech_id))
-        query = query.filter(Technology.name==technology_name)
-        return query.all()
-
-    def _get_account(self, key, value):
-        """ _get_account('s3_name', 'blah') """
-        if key == 'aws':
-            return dict(name='AWS', identifier='AWS')
-        for account in self.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS']:
-            if unicode(account.get(key, '')).lower() == value.lower():
-                return account
 
     def load_policies(self, item):
         """For a given item, return a list of all resource policies.

--- a/security_monkey/tests/auditors/test_rds_snapshot.py
+++ b/security_monkey/tests/auditors/test_rds_snapshot.py
@@ -1,0 +1,110 @@
+#     Copyright 2017 Netflix, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.tests.auditors.test_rds_snapshot
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Patrick Kelley <pkelley@netflix.com> @monkeysecurity
+
+"""
+from security_monkey.tests import SecurityMonkeyTestCase
+from security_monkey.auditors.rds_snapshot import RDSSnapshotAuditor
+from security_monkey.watchers.rds.rds_snapshot import RDSSnapshot, RDSSnapshotItem
+from security_monkey.datastore import Account, AccountType
+from security_monkey import db
+
+
+class RDSSnapshotAuditorTestCase(SecurityMonkeyTestCase):
+
+    def pre_test_setup(self):
+        RDSSnapshotAuditor(accounts=['TEST_ACCOUNT']).OBJECT_STORE.clear()
+        account_type_result = AccountType(name='AWS')
+        db.session.add(account_type_result)
+        db.session.commit()
+
+        # main
+        account = Account(identifier="123456789123", name="TEST_ACCOUNT",
+                          account_type_id=account_type_result.id, notes="TEST_ACCOUNT",
+                          third_party=False, active=True)
+        # friendly
+        account2 = Account(identifier="222222222222", name="TEST_ACCOUNT_TWO",
+                          account_type_id=account_type_result.id, notes="TEST_ACCOUNT_TWO",
+                          third_party=False, active=True)
+        # third party
+        account3 = Account(identifier="333333333333", name="TEST_ACCOUNT_THREE",
+                          account_type_id=account_type_result.id, notes="TEST_ACCOUNT_THREE",
+                          third_party=True, active=True)
+
+        db.session.add(account)
+        db.session.add(account2)
+        db.session.add(account3)
+        db.session.commit()
+
+    def test_check_internet_accessible(self):
+        config0 = {'Attributes': { 'restore': ['all'] } }
+        config1 = {'Attributes': { 'restore': [] } }
+
+        rsa = RDSSnapshotAuditor(accounts=['TEST_ACCOUNT'])
+        rsa.prep_for_audit()
+
+        item = RDSSnapshotItem(config=config0)
+        rsa.check_internet_accessible(item)
+        self.assertEquals(len(item.audit_issues), 1)
+        self.assertEquals(item.audit_issues[0].score, 10)
+        self.assertEquals(item.audit_issues[0].issue, 'Internet Accessible')
+        self.assertEquals(item.audit_issues[0].notes, 'Entity: [account:all] Actions: ["restore"]')
+
+        item = RDSSnapshotItem(config=config1)
+        rsa.check_internet_accessible(item)
+        self.assertEquals(len(item.audit_issues), 0)
+
+    def test_check_friendly(self):
+        config0 = {'Attributes': { 'restore': ["222222222222"] } }
+
+        rsa = RDSSnapshotAuditor(accounts=['TEST_ACCOUNT'])
+        rsa.prep_for_audit()
+
+        item = RDSSnapshotItem(config=config0)
+        rsa.check_friendly_cross_account(item)
+        self.assertEquals(len(item.audit_issues), 1)
+        self.assertEquals(item.audit_issues[0].score, 0)
+        self.assertEquals(item.audit_issues[0].issue, 'Friendly Cross Account')
+        self.assertEquals(item.audit_issues[0].notes, 'Account: [222222222222/TEST_ACCOUNT_TWO] Entity: [account:222222222222] Actions: ["restore"]')
+
+    def test_check_thirdparty(self):
+        config0 = {'Attributes': { 'restore': ["333333333333"] } }
+
+        rsa = RDSSnapshotAuditor(accounts=['TEST_ACCOUNT'])
+        rsa.prep_for_audit()
+
+        item = RDSSnapshotItem(config=config0)
+        rsa.check_thirdparty_cross_account(item)
+        self.assertEquals(len(item.audit_issues), 1)
+        self.assertEquals(item.audit_issues[0].score, 0)
+        self.assertEquals(item.audit_issues[0].issue, 'Thirdparty Cross Account')
+        self.assertEquals(item.audit_issues[0].notes, 'Account: [333333333333/TEST_ACCOUNT_THREE] Entity: [account:333333333333] Actions: ["restore"]')
+
+    def test_check_unknown(self):
+        config0 = {'Attributes': { 'restore': ["444444444444"] } }
+
+        rsa = RDSSnapshotAuditor(accounts=['TEST_ACCOUNT'])
+        rsa.prep_for_audit()
+
+        item = RDSSnapshotItem(config=config0)
+        rsa.check_unknown_cross_account(item)
+        self.assertEquals(len(item.audit_issues), 1)
+        self.assertEquals(item.audit_issues[0].score, 10)
+        self.assertEquals(item.audit_issues[0].issue, 'Unknown Access')
+        self.assertEquals(item.audit_issues[0].notes, 'Entity: [account:444444444444] Actions: ["restore"]')

--- a/security_monkey/watchers/rds/rds_snapshot.py
+++ b/security_monkey/watchers/rds/rds_snapshot.py
@@ -61,8 +61,7 @@ class RDSSnapshot(Watcher):
                     while True:
                         response = self.wrap_aws_rate_limited_call(
                             rds.describe_db_snapshots,
-                            Marker=marker
-                        )
+                            Marker=marker)
 
                         snapshots.extend(response.get('DBSnapshots'))
 
@@ -89,26 +88,24 @@ class RDSSnapshot(Watcher):
                     if self.check_ignore_list(name):
                         continue
 
-                    config = {
-                        'snapshot_id': name,
-                        'allocated_storage': snapshot.get('AllocatedStorage'),
-                        'availability_zone': snapshot.get('AvailabilityZone'),
-                        'db_instance_id': snapshot.get('DBInstanceIdentifier'),
-                        'encrypted': snapshot.get('Encrypted'),
-                        'engine': snapshot.get('Engine'),
-                        'engine_version': snapshot.get('EngineVersion'),
-                        'instance_create_time': str(snapshot.get('InstanceCreateTime')),
-                        'kms_key_id': snapshot.get('KmsKeyId'),
-                        'license_model': snapshot.get('LicenseModel'),
-                        'master_username': snapshot.get('MasterUsername'),
-                        'option_group_name': snapshot.get('OptionGroupName'),
-                        'port': snapshot.get('Port'),
-                        'snapshot_create_time': str(snapshot.get('SnapshotCreateTime')),
-                        'snapshot_type': snapshot.get('SnapshotType'),
-                        'storage_type': snapshot.get('StorageType'),
-                        'vpc_id': snapshot.get('VpcId'),
-                        'arn': snapshot.get('DBSnapshotArn')
-                    }
+                    config = dict(snapshot)
+                    config['InstanceCreateTime'] = str(config.get('InstanceCreateTime'))
+                    config['SnapshotCreateTime'] = str(config.get('SnapshotCreateTime'))
+                    config['Arn'] = str(config.get('DBSnapshotArn'))
+                    config['Attributes'] = dict()
+
+                    try:
+                        attributes = self.wrap_aws_rate_limited_call(
+                            rds.describe_db_snapshot_attributes,
+                            DBSnapshotIdentifier=snapshot.get('DBSnapshotIdentifier'))
+
+                        for attribute in attributes['DBSnapshotAttributesResult']['DBSnapshotAttributes']:
+                            config['Attributes'][attribute['AttributeName']] = attribute['AttributeValues']
+
+                    except Exception as e:
+                        if region.name not in TROUBLE_REGIONS:
+                            exc = BotoConnectionIssue(str(e), self.index, account, region.name)
+                            self.slurp_exception((self.index, account, region.name, name), exc, exception_map)
 
                     item = RDSSnapshotItem(
                         region=region.name, account=account, name=name,


### PR DESCRIPTION
- Requires new permission: `rds:describedbsnapshotattributes`
- Updates RDS Snapshot watcher to save the snapshot attributes.  (Share data is stored in attributes.)
- Adds a new auditor that checks for `all` or checks the account identifiers for friendly, thirdparty, or unknown cross account access.
- Adds tests for the new auditor.
- Refactors `OBJECT_STORE` out of ResourcePolicyAuditor and into the parent Auditor so the data can be used with any auditor.