### PR TITLE
Fix: ACTIVE_PROVIDERS was initialized by mistake

### DIFF
--- a/env-config/config.py
+++ b/env-config/config.py
@@ -115,7 +115,7 @@ CORE_THREADS = 25
 MAX_THREADS = 30
 
 # SSO SETTINGS:
-ACTIVE_PROVIDERS = ['']  # "aad", "ping", "google" or "onelogin"
+ACTIVE_PROVIDERS = []  # "aad", "ping", "google" or "onelogin"
 
 AAD_NAME = 'AzureAD'  # Use to override the Ping name in the UI.
 AAD_REDIRECT_URI = "{BASE}api/1/auth/aad".format(BASE=BASE_URL)


### PR DESCRIPTION
Hi @monkeysecurity, we should merge this pull request as it fixes an error in my previous PR, ACTIVE_PROVIDERS was initialized to [''] when it should have been left as an empty list []