### PR TITLE
fix BJS endpoint & change TROUBLE_REGIONS for BJS

### DIFF
--- a/env-config/config.py
+++ b/env-config/config.py
@@ -58,6 +58,7 @@ LOG_CFG = {
 # and Commercial Accounts to watch Commercial Accounts. They should not mix.
 
 AWS_GOVCLOUD = False
+AWS_BJS = False
 
 
 SQLALCHEMY_DATABASE_URI = 'postgresql://securitymonkeyuser:securitymonkeypassword@localhost:5432/secmonkey'

--- a/security_monkey/__init__.py
+++ b/security_monkey/__init__.py
@@ -68,6 +68,10 @@ if app.config.get("AWS_GOVCLOUD"):
     ARN_PARTITION = 'aws-us-gov'
     AWS_DEFAULT_REGION = 'us-gov-west-1'
 
+if app.config.get("AWS_BJS"):
+    ARN_PARTITION = 'aws-cn'
+    AWS_DEFAULT_REGION = 'cn-north-1'
+
 ARN_PREFIX= 'arn:' + ARN_PARTITION
 
 db = SQLAlchemy(app)

--- a/security_monkey/constants.py
+++ b/security_monkey/constants.py
@@ -20,6 +20,18 @@
 
 """
 
+from flask import Flask
+from flask import render_template
+from flask.helpers import make_response
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+import os
+
+app = Flask(__name__, static_url_path='/static')
+
 # SM will not alert on exceptions that occur while attempting to retrieve data
 # from these regions.  In our case, we do not have permissions to these regions.
-TROUBLE_REGIONS = ['cn-north-1']
+if app.config.get("AWS_BJS"):
+    TROUBLE_REGIONS = ['us-east-1', 'us-east-2','us-west-1','us-west-2','ca-central-1','eu-west-1','eu-central-1','eu-west-2','ap-northeast-1','ap-northeast-2','ap-southeast-1','ap-southeast-2','ap-south-1','sa-east-1','us-gov-west-1']
+else
+    TROUBLE_REGIONS = ['cn-north-1']

--- a/security_monkey/constants.py
+++ b/security_monkey/constants.py
@@ -20,18 +20,15 @@
 
 """
 
-from flask import Flask
-from flask import render_template
-from flask.helpers import make_response
-from flask_sqlalchemy import SQLAlchemy
-from flask_login import LoginManager
-import os
-
-app = Flask(__name__, static_url_path='/static')
+from security_monkey import app
 
 # SM will not alert on exceptions that occur while attempting to retrieve data
 # from these regions.  In our case, we do not have permissions to these regions.
+# three different cases for the different regions
+ 
 if app.config.get("AWS_BJS"):
     TROUBLE_REGIONS = ['us-east-1', 'us-east-2','us-west-1','us-west-2','ca-central-1','eu-west-1','eu-central-1','eu-west-2','ap-northeast-1','ap-northeast-2','ap-southeast-1','ap-southeast-2','ap-south-1','sa-east-1','us-gov-west-1']
-else
-    TROUBLE_REGIONS = ['cn-north-1']
+elif app.config.get('AWS_GOVCLOUD'):
+    TROUBLE_REGIONS = ['us-east-1', 'us-east-2','us-west-1','us-west-2','ca-central-1','eu-west-1','eu-central-1','eu-west-2','ap-northeast-1','ap-northeast-2','ap-southeast-1','ap-southeast-2','ap-south-1','sa-east-1', 'cn-north-1']
+else: 
+    TROUBLE_REGIONS = ['cn-north-1', 'us-gov-west-1']

--- a/security_monkey/decorators.py
+++ b/security_monkey/decorators.py
@@ -161,8 +161,9 @@ def iter_account_region(index=None, accounts=None, service_name=None, exception_
 def get_regions(account, service_name):
     if not service_name:
         return None, [AWS_DEFAULT_REGION]
-
-    sts = boto3.client('sts')
+    
+    region = AWS_DEFAULT_REGION
+    sts = boto3.client('sts',region_name=region)
     role_name = 'SecurityMonkey'
     if account.getCustom("role_name") and account.getCustom("role_name") != '':
         role_name = account.getCustom("role_name")


### PR DESCRIPTION
I built a Security Monkey in Beijing region. When I run it first time , it can show me information in browse. But it sees that something wrong. I thing that this is related to the boto3 API node. Here is logs. Would you check check for me.

```
2017-09-17 09:56:08,809 ERROR: Exceptions have caused nothing to be fetched for IAM Roles/test/universal... CANNOT CONTINUE FOR THIS WATCHER! [in /usr/local/src/security_monkey/security_monkey/scheduler.py:76]
 version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>AuthFailure</Code><Message>AWS was not able to validate the provided access credentials</Message></Error></Errors><RequestID>eaae3aa7-aafa-4c35-a73f-0b5e6190205d</RequestID></Response>
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): sts.amazonaws.com
ERROR:security_monkey:Exceptions have caused nothing to be fetched for IAM Roles/test/universal... CANNOT CONTINUE FOR THIS WATCHER!
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): sts.cn-north-1.amazonaws.com.cn
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): sts.cn-north-1.amazonaws.com.cn
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): acm.cn-north-1.amazonaws.com.cn
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (2): acm.cn-north-1.amazonaws.com.cn
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (3): acm.cn-north-1.amazonaws.com.cn
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (4): acm.cn-north-1.amazonaws.com.cn
2017-09-17 09:56:16,774 INFO: Job "run_change_reporter (trigger: interval[0:15:00], next run at: 2017-09-17 10:07:59.995283)" executed successfully [in build/bdist.linux-x86_64/egg/apscheduler/scheduler.py:527]
INFO:botocore.vendored.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (5): acm.cn-north-1.amazonaws.com.cn
INFO:apscheduler.scheduler:Job "run_change_reporter (trigger: interval[0:15:00], next run at: 2017-09-17 10:07:59.995283)" executed successfully
```

Now , I found that it can monitors my AWS accounts change after 1 hours. But my setting is 15 mins. 