### PR TITLE
Fixing 'fixed' flag. Changing some logging levels.

### DIFF
--- a/migrations/versions/5bd631a1b748_.py
+++ b/migrations/versions/5bd631a1b748_.py
@@ -1,0 +1,44 @@
+"""Updating fixed flag in the issue table to be not nullable.
+
+Revision ID: 5bd631a1b748
+Revises: 4ac52090a637
+Create Date: 2017-09-26 11:05:23.060909
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5bd631a1b748'
+down_revision = '4ac52090a637'
+
+from alembic import op
+import sqlalchemy as sa
+
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
+
+
+Session = sessionmaker()
+Base = declarative_base()
+
+
+class ItemAudit(Base):
+    __tablename__ = 'itemaudit'
+    id = sa.Column(sa.Integer, primary_key=True)
+    fixed = sa.Column(sa.Boolean)
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    # update itemaudit set fixed = False where fixed is NULL
+    session.query(ItemAudit).filter(ItemAudit.fixed==None).update(dict(fixed=False))
+    session.commit()
+
+    # Make column not nullable:
+    op.alter_column('itemaudit', 'fixed', nullable=False)
+
+
+def downgrade():
+    # Make column nullable:
+    op.alter_column('itemaudit', 'fixed', nullable=True)

--- a/security_monkey/datastore.py
+++ b/security_monkey/datastore.py
@@ -186,7 +186,7 @@ class ItemAudit(db.Model):
     origin = Column(Text(), nullable=True)
     origin_summary = Column(Text(), nullable=True)
     class_uuid = Column(String(32), nullable=True)
-    fixed = Column(Boolean, default=False)
+    fixed = Column(Boolean, default=False, nullable=False)
     justified = Column(Boolean)
     justified_user_id = Column(Integer, ForeignKey("user.id"), nullable=True, index=True)
     justification = Column(String(512))

--- a/security_monkey/scheduler.py
+++ b/security_monkey/scheduler.py
@@ -230,6 +230,6 @@ def setup_scheduler():
     except Exception as e:
         if sentry:
             sentry.captureException()
-        app.logger.warn("Scheduler Exception: {}".format(e))
-        app.logger.warn(traceback.format_exc())
+        app.logger.error("Scheduler Exception: {}".format(e))
+        app.logger.error(traceback.format_exc())
         store_exception("scheduler", None, e)

--- a/security_monkey/watcher.py
+++ b/security_monkey/watcher.py
@@ -132,7 +132,7 @@ class Watcher(object):
             # Empty prefix comes back as None instead of an empty string ...
             prefix = result.prefix or ""
             if name.lower().startswith(prefix.lower()):
-                app.logger.warn("Ignoring {}/{} because of IGNORELIST prefix {}".format(self.index, name, result.prefix))
+                app.logger.info("Ignoring {}/{} because of IGNORELIST prefix {}".format(self.index, name, result.prefix))
                 return True
 
         return False


### PR DESCRIPTION
The DB migration in PR #825 did not set the `fixed` flag, leaving it null.

As a result, the UI would not display these migrated issues.

This adds a new DB migration that sets `fixed` to `False` wherever it is `null`.  It also makes the field not-nullable.

Also adjusted a few logging levels to make the logs easier to monitor.