### PR TITLE
rds:describedbsnapshotattributes was missing from the policy

### DIFF
--- a/docs/iam_aws.md
+++ b/docs/iam_aws.md
@@ -170,6 +170,7 @@ You will need to create this role in all AWS accounts that you want to monitor.
                     "rds:describedbinstances",
                     "rds:describedbsecuritygroups",
                     "rds:describedbsnapshots",
+                    "rds:describedbsnapshotattributes",
                     "rds:describedbsubnetgroups",
                     "redshift:describeclusters",
                     "route53:listhostedzones",

--- a/scripts/secmonkey_role_setup.py
+++ b/scripts/secmonkey_role_setup.py
@@ -144,6 +144,7 @@ policy = \
            "rds:describedbinstances",
            "rds:describedbsecuritygroups",
            "rds:describedbsnapshots",
+           "rds:describedbsnapshotattributes",
            "rds:describedbsubnetgroups",
            "redshift:describeclusters",
            "route53:listhostedzones",


### PR DESCRIPTION
Just a typo in the docs as far as I can see.