### PR TITLE
Fixing issue #844. Optionally removing fixed and justified issues from email reports.

### DIFF
--- a/env-config/config-docker.py
+++ b/env-config/config-docker.py
@@ -112,6 +112,9 @@ SECURITY_POST_CHANGE_VIEW = BASE_URL
 # This address gets all change notifications (i.e. 'securityteam@example.com')
 SECURITY_TEAM_EMAIL = os.getenv('SECURITY_MONKEY_SECURITY_TEAM_EMAIL', [])
 
+# If you would prefer the email reports to exclude justified issues, set this to False
+EMAIL_AUDIT_REPORTS_INCLUDE_JUSTIFIED = True
+
 # These are only required if using SMTP instead of SES
 EMAILS_USE_SMTP = env_to_bool(os.getenv('SECURITY_MONKEY_SMTP', True))     # Otherwise, Use SES
 SES_REGION = os.getenv('SECURITY_MONKEY_SES_REGION', 'us-east-1')

--- a/env-config/config-local.py
+++ b/env-config/config-local.py
@@ -86,6 +86,9 @@ SECURITY_POST_CHANGE_VIEW = BASE_URL
 # This address gets all change notifications (i.e. 'securityteam@example.com')
 SECURITY_TEAM_EMAIL = []
 
+# If you would prefer the email reports to exclude justified issues, set this to False
+EMAIL_AUDIT_REPORTS_INCLUDE_JUSTIFIED = True
+
 # These are only required if using SMTP instead of SES
 EMAILS_USE_SMTP = False     # Otherwise, Use SES
 SES_REGION = 'us-east-1'

--- a/env-config/config.py
+++ b/env-config/config.py
@@ -93,6 +93,9 @@ SECURITY_POST_CHANGE_VIEW = BASE_URL
 # This address gets all change notifications (i.e. 'securityteam@example.com')
 SECURITY_TEAM_EMAIL = []
 
+# If you would prefer the email reports to exclude justified issues, set this to False
+EMAIL_AUDIT_REPORTS_INCLUDE_JUSTIFIED = True
+
 # These are only required if using SMTP instead of SES
 EMAILS_USE_SMTP = False     # Otherwise, Use SES
 SES_REGION = 'us-east-1'

--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -719,8 +719,13 @@ class Auditor(object):
         for item in self.items:
             item.totalscore = 0
             for issue in item.db_item.issues:
-                if not issue.justified and not issue.fixed:  # Email reports will no longer contain fixed/justified issues.
-                    item.totalscore = item.totalscore + issue.score
+                if issue.fixed:
+                    continue
+
+                if not app.config.get('EMAIL_AUDIT_REPORTS_INCLUDE_JUSTIFIED', True) and issue.justified:
+                    continue
+
+                item.totalscore = item.totalscore + issue.score
         sorted_list = sorted(self.items, key=lambda item: item.totalscore)
         sorted_list.reverse()
         report_list = []

--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -714,33 +714,24 @@ class Auditor(object):
         """
         jenv = get_jinja_env()
         template = jenv.get_template('jinja_audit_email.html')
-        # This template expects a list of items that have been sorted by total score in
-        # descending order.
+
         for item in self.items:
-            item.totalscore = 0
+            item.reportable_issues = list()
+            item.score = 0
             for issue in item.db_item.issues:
-                if issue.fixed:
+                if issue.fixed or issue.auditor_setting.disabled:
                     continue
-
-                if issue.auditor_setting and issue.auditor_setting.disabled:
-                    continue
-
                 if not app.config.get('EMAIL_AUDIT_REPORTS_INCLUDE_JUSTIFIED', True) and issue.justified:
                     continue
+                item.reportable_issues.append(issue)
+                item.score += issue.score
 
-                item.totalscore = item.totalscore + issue.score
-        sorted_list = sorted(self.items, key=lambda item: item.totalscore)
-        sorted_list.reverse()
-        report_list = []
-        for item in sorted_list:
-            if item.totalscore > 0:
-                report_list.append(item)
-            else:
-                break
-        if len(report_list) > 0:
+        sorted_list = sorted(self.items, key=lambda item: item.score, reverse=True)
+        report_list = [item for item in sorted_list if item.score > 0]
+
+        if report_list:
             return template.render({'items': report_list})
-        else:
-            return False
+        return False
 
     def applies_to_account(self, account):
         """

--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -719,7 +719,8 @@ class Auditor(object):
         for item in self.items:
             item.totalscore = 0
             for issue in item.db_item.issues:
-                item.totalscore = item.totalscore + issue.score
+                if not issue.justified and not issue.fixed:  # Email reports will no longer contain fixed/justified issues.
+                    item.totalscore = item.totalscore + issue.score
         sorted_list = sorted(self.items, key=lambda item: item.totalscore)
         sorted_list.reverse()
         report_list = []

--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -722,6 +722,9 @@ class Auditor(object):
                 if issue.fixed:
                     continue
 
+                if issue.auditor_setting and issue.auditor_setting.disabled:
+                    continue
+
                 if not app.config.get('EMAIL_AUDIT_REPORTS_INCLUDE_JUSTIFIED', True) and issue.justified:
                     continue
 

--- a/security_monkey/templates/jinja_audit_email.html
+++ b/security_monkey/templates/jinja_audit_email.html
@@ -12,9 +12,10 @@
     </tr>
     {% for item in items %}
     <tr>
-      <td rowspan='{{ item.db_item.issues | count }}'>{{ item.account }} / {{ item.region }} / {{item.index}} / {{item.name }}</td>
-      <td rowspan='{{ item.db_item.issues | length }}'>{{ item.totalscore }}</td>
-      {% for issue in item.db_item.issues %}
+      <td rowspan='{{ item.reportable_issues | count }}'>{{ item.account }} / {{ item.region }} / {{item.index}} / {{item.name }}</td>
+      <td rowspan='{{ item.reportable_issues | count }}'>Total: {{ item.db_item.score }} Unjustified: {{ item.db_item.unjustified_score }}</td>
+      {% for issue in item.reportable_issues %}
+
         {% if loop.index > 1 %}
         <tr>
         {% endif %}


### PR DESCRIPTION
Added a new config variable:

`EMAIL_AUDIT_REPORTS_INCLUDE_JUSTIFIED = True`

The default is to send justified issues in the emails.  This can be set to `False`.

This PR also tells SM not to email "fixed" issues.