### PR TITLE
Refactor IAM policy Auditor

### DIFF
--- a/env-config/config.py
+++ b/env-config/config.py
@@ -112,6 +112,12 @@ WTF_CSRF_METHODS = ['DELETE', 'POST', 'PUT', 'PATCH']
 # "NONE", "SUMMARY", or "FULL"
 SECURITYGROUP_INSTANCE_DETAIL = 'FULL'
 
+# To alert on IAM Roles/Users/Groups and Managed Policies with Write capabilities
+# on sensitive services, enumerate the services here:
+# DEFAULT_SENSITIVE = ['cloudhsm', 'cloudtrail', 'acm', 'config', 'kms', 'lambda', 'organizations', 'rds', 'route53', 'shield']
+# Otherwise, SM will alert on all dataplane write access.
+DEFAULT_SENSITIVE = 'ALL'
+
 # Threads used by the scheduler.
 # You will likely need at least one core thread for every account being monitored.
 CORE_THREADS = 25

--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -45,6 +45,7 @@ auditor_registry = defaultdict(list)
 
 class Categories:
     """ Define common issue categories to maintain consistency. """
+    # Resource Policies:
     INTERNET_ACCESSIBLE = 'Internet Accessible'
     INTERNET_ACCESSIBLE_NOTES = '{entity} Actions: {actions}'
     INTERNET_ACCESSIBLE_NOTES_SG = '{entity} Access: [{access}]'
@@ -67,12 +68,19 @@ class Categories:
     CROSS_ACCOUNT_ROOT = 'Cross-Account Root IAM'
     CROSS_ACCOUNT_ROOT_NOTES = '{entity} Actions: {actions}'
 
+    # IAM Policies:
+    ADMIN_ACCESS = 'Administrator Access'
+    ADMIN_ACCESS_NOTES = 'Actions: {actions} Resources: {resource}'
+
+    SENSITIVE_PERMISSIONS = 'Sensitive Permissions'
+    SENSITIVE_PERMISSIONS_NOTES = 'Actions: {actions} Resources: {resource}'
+
+    STATEMENT_CONSTRUCTION = 'Awkward Statement Construction'
+    STATEMENT_CONSTRUCTION_NOTES = 'Construct: {construct}'
+
     # TODO
     # 	INSECURE_CERTIFICATE = 'Insecure Certificate'
     # 	INSECURE_TLS = 'Insecure TLS'
-    # 	OVERLY_BROAD_ACCESS = 'Access Granted Broadly'
-    # 	ADMIN_ACCESS = 'Administrator Access'
-    # 	SENSITIVE_PERMISSIONS = 'Sensitive Permissions'
 
 
 class Entity:

--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -73,10 +73,24 @@ class Categories:
     ADMIN_ACCESS_NOTES = 'Actions: {actions} Resources: {resource}'
 
     SENSITIVE_PERMISSIONS = 'Sensitive Permissions'
-    SENSITIVE_PERMISSIONS_NOTES = 'Actions: {actions} Resources: {resource}'
+    SENSITIVE_PERMISSIONS_NOTES_1 = 'Actions: {actions} Resources: {resource}'
+    SENSITIVE_PERMISSIONS_NOTES_2 = 'Service [{service}] Category: [{category}] Resources: {resource}'
 
     STATEMENT_CONSTRUCTION = 'Awkward Statement Construction'
     STATEMENT_CONSTRUCTION_NOTES = 'Construct: {construct}'
+
+    # Anywhere
+    INFORMATIONAL = 'Informational'
+    INFORMATIONAL_NOTES = '{description}{specific}'
+
+    ROTATION = 'Needs Rotation'
+    ROTATION_NOTES = '{what} last rotated {requirement} on {date}'
+
+    UNUSED = 'Unused Access'
+    UNUSED_NOTES = '{what} last used {requirement} on {date}'
+
+    INSECURE_CONFIGURATION = 'Insecure Configuration'
+    INSECURE_CONFIGURATION_NOTES = '{description}'
 
     # TODO
     # 	INSECURE_CERTIFICATE = 'Insecure Certificate'

--- a/security_monkey/auditors/iam/iam_group.py
+++ b/security_monkey/auditors/iam/iam_group.py
@@ -23,6 +23,7 @@ from security_monkey.watchers.iam.iam_group import IAMGroup
 from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
 from security_monkey.watchers.iam.managed_policy import ManagedPolicy
 
+
 class IAMGroupAuditor(IAMPolicyAuditor):
     index = IAMGroup.index
     i_am_singular = IAMGroup.i_am_singular
@@ -31,45 +32,7 @@ class IAMGroupAuditor(IAMPolicyAuditor):
 
     def __init__(self, accounts=None, debug=False):
         super(IAMGroupAuditor, self).__init__(accounts=accounts, debug=debug)
-
-    def check_star_privileges(self, iamgroup_item):
-        """
-        alert when an IAM Group has a policy allowing '*'.
-        """
-        self.library_check_iamobj_has_star_privileges(iamgroup_item, policies_key='grouppolicies')
-
-    def check_iam_star_privileges(self, iamgroup_item):
-        """
-        alert when an IAM Group has a policy allowing 'iam:*'.
-        """
-        self.library_check_iamobj_has_iam_star_privileges(iamgroup_item, policies_key='grouppolicies')
-
-    def check_iam_privileges(self, iamgroup_item):
-        """
-        alert when an IAM Group has a policy allowing 'iam:XxxxxXxxx'.
-        """
-        self.library_check_iamobj_has_iam_privileges(iamgroup_item, policies_key='grouppolicies')
-
-    def check_iam_passrole(self, iamgroup_item):
-        """
-        alert when an IAM Group has a policy allowing 'iam:PassRole'.
-        This allows the group to pass any role specified in the resource block to an ec2 instance.
-        """
-        self.library_check_iamobj_has_iam_passrole(iamgroup_item, policies_key='grouppolicies')
-
-    def check_notaction(self, iamgroup_item):
-        """
-        alert when an IAM Group has a policy containing 'NotAction'.
-        NotAction combined with an "Effect": "Allow" often provides more privilege
-        than is desired.
-        """
-        self.library_check_iamobj_has_notaction(iamgroup_item, policies_key='grouppolicies')
-
-    def check_security_group_permissions(self, iamgroup_item):
-        """
-        alert when an IAM Group has ec2:AuthorizeSecurityGroupEgress or ec2:AuthorizeSecurityGroupIngress.
-        """
-        self.library_check_iamobj_has_security_group_permissions(iamgroup_item, policies_key='grouppolicies')
+        self.iam_policy_keys = ['grouppolicies']
 
     def check_attached_managed_policies(self, iamgroup_item):
         """

--- a/security_monkey/auditors/iam/iam_group.py
+++ b/security_monkey/auditors/iam/iam_group.py
@@ -32,7 +32,7 @@ class IAMGroupAuditor(IAMPolicyAuditor):
 
     def __init__(self, accounts=None, debug=False):
         super(IAMGroupAuditor, self).__init__(accounts=accounts, debug=debug)
-        self.iam_policy_keys = ['grouppolicies']
+        self.iam_policy_keys = ['grouppolicies$*']
 
     def check_attached_managed_policies(self, iamgroup_item):
         """

--- a/security_monkey/auditors/iam/iam_policy.py
+++ b/security_monkey/auditors/iam/iam_policy.py
@@ -145,7 +145,7 @@ class IAMPolicyAuditor(Auditor):
                 if statement.effect == 'Allow':
                     if 'NotAction' in statement.statement:
                         notes = notes.format(construct='["NotAction"]'
-                        self.add_issue(10, issue item, notes=notes)
+                        self.add_issue(10, issue, item, notes=notes)
 
     def check_notresource(self, item):
         """

--- a/security_monkey/auditors/iam/iam_policy.py
+++ b/security_monkey/auditors/iam/iam_policy.py
@@ -19,37 +19,10 @@
 .. moduleauthor::  Patrick Kelley <pkelley@netflix.com> @monkeysecurity
 
 """
-from security_monkey.auditor import Auditor
+from security_monkey.auditor import Auditor, Categories
 from security_monkey.watchers.iam.managed_policy import ManagedPolicy
 from security_monkey import app
 import json
-
-
-def _iterate_over_sub_policies(sub_policies, check_statement_func):
-    """
-    For each named policy in the policy document, call _iterate_over_statements.
-    """
-    for sub_policy_name in sub_policies:
-        sub_policy = sub_policies[sub_policy_name]
-        _iterate_over_statements(sub_policy, check_statement_func)
-
-
-def _iterate_over_statements(sub_policy, check_statement_func):
-    """
-    For every statement in a given policy, execute check_statement_func.
-    Helps when you don't know if the Statement is going to be a list of dicts
-    or a single dict.
-
-    :param sub_policy: A single named policy within an IAM object.
-    :param check_statement_func: The function used to inspect an IAM Object
-    :return: None
-    """
-    if type(sub_policy['Statement']) is list:
-        statements = sub_policy['Statement']
-        for statement in statements:
-            check_statement_func(statement)
-    else:
-        check_statement_func(sub_policy['Statement'])
 
 
 class IAMPolicyAuditor(Auditor):
@@ -61,132 +34,153 @@ class IAMPolicyAuditor(Auditor):
 
     def __init__(self, accounts=None, debug=False):
         super(IAMPolicyAuditor, self).__init__(accounts=accounts, debug=debug)
+        self.iam_policy_keys = ['InlinePolicies']
 
-    def library_check_iamobj_has_star_privileges(self, iamobj_item, policies_key='InlinePolicies', multiple_policies=True):
+    def load_policies(self, item):
+        policies = list()
+        for key in self.iam_policy_keys:
+            try:
+                policy = dpath.util.values(item.config, key, separator='$')
+                if isinstance(policy, list):
+                    for p in policy:
+                        if not p:
+                            continue
+                        if isinstance(p, list):
+                            policies.extend([Policy(pp) for pp in p])
+                        else:
+                            policies.append(Policy(p))
+                else:
+                    policies.append(Policy(policy))
+            except PathNotFound:
+                continue
+        return policies
+
+    def check_star_privileges(self, item):
         """
         alert when an IAM Object has a policy allowing '*'.
         """
-        tag = '{0} has full admin privileges.'.format(self.i_am_singular)
+        issue = Categories.ADMIN_ACCESS
+        notes = Categories.ADMIN_ACCESS_NOTES
 
-        def check_statement(statement):
-            if statement["Effect"] == "Allow":
-                if "Action" in statement and type(statement["Action"]) is list:
-                    for action in statement["Action"]:
-                        if action == "*":
-                            self.add_issue(10, tag, iamobj_item, notes=json.dumps(statement))
-                else:
-                    if "Action" in statement and statement["Action"] == "*":
-                        self.add_issue(10, tag, iamobj_item, notes=json.dumps(statement))
+        for policy in self.load_policies(item):
+            for statement in policy.statements:
+                if statement.effect == "Allow":
+                    if '*' in statement.actions:
+                        resources = json.dumps(sorted(list(statement.resources)))
+                        notes = notes.format(actions='["*"]', resource=resources)
+                        self.add_issue(10, issue, item, notes=notes)
 
-        if multiple_policies:
-            _iterate_over_sub_policies(iamobj_item.config.get(policies_key, {}), check_statement)
-        else:
-            _iterate_over_statements(iamobj_item.config[policies_key], check_statement)
-
-    def library_check_iamobj_has_iam_star_privileges(self, iamobj_item, policies_key='InlinePolicies', multiple_policies=True):
+    def check_iam_star_privileges(self, item):
         """
         alert when an IAM Object has a policy allowing 'iam:*'.
         """
-        tag = '{0} has full IAM privileges.'.format(self.i_am_singular)
+        issue = Categories.ADMIN_ACCESS
+        notes = Categories.ADMIN_ACCESS_NOTES
 
-        def check_statement(statement):
-            if statement["Effect"] == "Allow":
-                if "Action" in statement and type(statement["Action"]) is list:
-                    for action in statement["Action"]:
-                        if action.lower() == "iam:*":
-                            self.add_issue(10, tag, iamobj_item, notes=json.dumps(statement))
-                else:
-                    if "Action" in statement and statement["Action"].lower() == "iam:*":
-                        self.add_issue(10, tag, iamobj_item, notes=json.dumps(statement))
+        for policy in self.load_policies(item):
+            for statement in policy.statements:
+                if statement.effect == 'Allow':
+                    actions = {action.lower() for action in statement.actions}
+                    if 'iam:*' in actions:
+                        resources = json.dumps(sorted(list(statement.resources)))
+                        notes = notes.format(actions='["iam:*"]', resource=resources)
+                        self.add_issue(10, issue, item, notes=notes)
 
-        if multiple_policies:
-            _iterate_over_sub_policies(iamobj_item.config.get(policies_key, {}), check_statement)
-        else:
-            _iterate_over_statements(iamobj_item.config[policies_key], check_statement)
-
-    def library_check_iamobj_has_iam_privileges(self, iamobj_item, policies_key='InlinePolicies', multiple_policies=True):
+    def check_iam_mutating_privileges(self, item):
         """
-        alert when an IAM Object has a policy allowing 'iam:XxxxxXxxx'.
+        alert when an IAM Object has a policy allowing mutating IAM permissions.
         """
-        tag = '{0} has IAM privileges.'.format(self.i_am_singular)
+        issue = Categories.SENSITIVE_PERMISSIONS
+        notes = CATEGORIES.SENSITIVE_PERMISSIONS_NOTES
 
-        def check_statement(statement):
-            if statement["Effect"] == "Allow":
-                if "Action" in statement and type(statement["Action"]) is list:
-                    for action in statement["Action"]:
-                        if action.lower().startswith("iam:") and action.lower() not in self.explicit_iam_checks:
-                            self.add_issue(9, tag, iamobj_item, notes=json.dumps(statement))
-                else:
-                    if "Action" in statement and statement["Action"].lower().startswith("iam:") and statement["Action"].lower() not in self.explicit_iam_checks:
-                        self.add_issue(9, tag, iamobj_item, notes=json.dumps(statement))
+        mutating_iam_prefixes = [
+            'add', 'attach', 'create', 'delete', 'detach', 'put', 'remove', 'set', 'update', 'upload'
+        ]
 
-        if multiple_policies:
-            _iterate_over_sub_policies(iamobj_item.config.get(policies_key, {}), check_statement)
-        else:
-            _iterate_over_statements(iamobj_item.config[policies_key], check_statement)
+        for policy in self.load_policies(item):
+            for statement in policy.statements:
+                mutating_actions = set()
+                if statement.effect == 'Allow':
+                    for action in statement.actions_expanded:
+                        if not action.lower().startswith('iam:'):
+                            continue
 
-    def library_check_iamobj_has_iam_passrole(self, iamobj_item, policies_key='InlinePolicies', multiple_policies=True):
+                        for prefix in mutating_iam_prefixes:
+                            if action.lower().startswith(prefix):
+                                mutating_actions.add(action)
+
+                    if mutating_actions:
+                        resources = json.dumps(sorted(list(statement.resources)))
+                        actions = json.dumps(sorted(list(mutating_actions)))
+                        notes = notes.format(actions=actions, resource=resources)
+                        self.add_issue(10, issue, item, notes=notes)
+
+    def check_iam_passrole(self, item):
         """
         alert when an IAM Object has a policy allowing 'iam:PassRole'.
         This allows the object to pass any role specified in the resource block to an ec2 instance.
         """
-        tag = '{0} has iam:PassRole privileges.'.format(self.i_am_singular)
+        issue = Categories.SENSITIVE_PERMISSIONS
+        notes = CATEGORIES.SENSITIVE_PERMISSIONS_NOTES
 
-        def check_statement(statement):
-            if statement["Effect"] == "Allow":
-                if "Action" in statement and type(statement["Action"]) is list:
-                    for action in statement["Action"]:
-                        if action.lower() == "iam:passrole":
-                            self.add_issue(9, tag, iamobj_item, notes=json.dumps(statement))
-                else:
-                    if "Action" in statement and statement["Action"].lower() == "iam:passrole":
-                        self.add_issue(9, tag, iamobj_item, notes=json.dumps(statement))
+        for policy in self.load_policies(item):
+            for statement in policy.statements:
+                if statement.effect == 'Allow':
+                    if 'iam:passrole' in statement.actions_expanded:
+                        resources = json.dumps(sorted(list(statement.resources)))
+                        notes = notes.format(actions='["iam:passrole"]', resource=resources)
+                        self.add_issue(10, issue, item, notes=notes)
 
-        if multiple_policies:
-            _iterate_over_sub_policies(iamobj_item.config.get(policies_key, {}), check_statement)
-        else:
-            _iterate_over_statements(iamobj_item.config[policies_key], check_statement)
-
-    def library_check_iamobj_has_notaction(self, iamobj_item, policies_key='InlinePolicies', multiple_policies=True):
+    def check_notaction(self, item):
         """
         alert when an IAM Object has a policy containing 'NotAction'.
         NotAction combined with an "Effect": "Allow" often provides more privilege
         than is desired.
         """
-        tag = '{0} contains NotAction.'.format(self.i_am_singular)
+        issue = Categories.STATEMENT_CONSTRUCTION
+        notes = Categories.STATEMENT_CONSTRUCTION_NOTES
 
-        def check_statement(statement):
-            if statement["Effect"] == "Allow":
-                if "NotAction" in statement:
-                    self.add_issue(10, tag, iamobj_item, notes=json.dumps(statement["NotAction"]))
+        for policy in self.load_policies(item):
+            for statement in policy.statements:
+                if statement.effect == 'Allow':
+                    if 'NotAction' in statement.statement:
+                        notes = notes.format(construct='["NotAction"]'
+                        self.add_issue(10, issue item, notes=notes)
 
-        if multiple_policies:
-            _iterate_over_sub_policies(iamobj_item.config.get(policies_key, {}), check_statement)
-        else:
-            _iterate_over_statements(iamobj_item.config[policies_key], check_statement)
+    def check_notresource(self, item):
+        """
+        alert when an IAM Object has a policy containing 'NotResoure'.
+        NotResource combined with an "Effect": "Allow" often provides more privilege
+        than is desired.
+        """
+        issue = Categories.STATEMENT_CONSTRUCTION
+        notes = Categories.STATEMENT_CONSTRUCTION_NOTES
 
-    def library_check_iamobj_has_security_group_permissions(self, iamobj_item, policies_key='InlinePolicies', multiple_policies=True):
+        for policy in self.load_policies(item):
+            for statement in policy.statements:
+                if statement.effect == 'Allow':
+                    if 'NotResource' in statement.statement:
+                        notes = notes.format(construct='["NotResource"]'
+                        self.add_issue(10, issue, item, notes=notes)
+
+    def check_security_group_permissions(self, item):
         """
         alert when an IAM Object has ec2:AuthorizeSecurityGroupEgress or ec2:AuthorizeSecurityGroupIngress.
         """
-        tag = '{0} can change security groups.'.format(self.i_am_singular)
+        issue = Categories.SENSITIVE_PERMISSIONS
+        notes = Categories.SENSITIVE_PERMISSIONS_NOTES
 
-        def check_statement(statement):
-            if statement["Effect"] == "Allow":
-                if "Action" in statement and type(statement["Action"]) is list:
-                    for action in statement["Action"]:
-                        if action.lower() == "ec2:authorizesecuritygroupegress" or action.lower() == "ec2:authorizesecuritygroupingress":
-                            self.add_issue(7, tag, iamobj_item, notes=action)
-                else:
-                    if "Action" in statement:
-                        action = statement["Action"]
-                        if action.lower() == "ec2:authorizesecuritygroupegress" or action.lower() == "ec2:authorizesecuritygroupingress":
-                            self.add_issue(7, tag, iamobj_item, notes=action)
+        permissions = {"ec2:authorizesecuritygroupegress", "ec2:authorizesecuritygroupingress"}
 
-        if multiple_policies:
-            _iterate_over_sub_policies(iamobj_item.config.get(policies_key, {}), check_statement)
-        else:
-            _iterate_over_statements(iamobj_item.config[policies_key], check_statement)
+        for policy in self.load_policies(item):
+            for statement in policy.statements:
+                if statement.effect == 'Allow':
+                    permissions = statement.actions_expanded.intersection(permissions)
+                    if permissions:
+                        resources = json.dumps(sorted(list(statement.resources)))
+                        actions = json.dumps(sorted(list(permissions)))
+                        notes = notes.format(actions=actions, resource=resources)
+                        self.add_issue(7, issue, item, notes=notes)
 
     def library_check_attached_managed_policies(self, iam_item, iam_type):
         """

--- a/security_monkey/auditors/iam/iam_policy.py
+++ b/security_monkey/auditors/iam/iam_policy.py
@@ -96,8 +96,7 @@ class IAMPolicyAuditor(Auditor):
         issue = Categories.SENSITIVE_PERMISSIONS
         notes = Categories.SENSITIVE_PERMISSIONS_NOTES_2
 
-        DEFAULT_SENSITIVE = ['cloudhsm', 'cloudtrail', 'acm', 'config', 'kms', 'lambda', 'organizations', 'rds', 'route53', 'shield']
-        sensitive_services = app.config.get('SENSITIVE_SERVICES', DEFAULT_SENSITIVE)
+        sensitive_services = app.config.get('SENSITIVE_SERVICES', 'ALL')
         if not sensitive_services:
             return
 
@@ -110,6 +109,10 @@ class IAMPolicyAuditor(Auditor):
                 if statement.effect == 'Allow':
                     summary = statement.action_summary()
                     for service, categories in summary.items():
+
+                        if sensitive_services != 'ALL' and service not in sensitive_services:
+                            continue
+
                         if 'DataPlaneMutating' in categories:
                             note = notes.format(
                                 service=service,

--- a/security_monkey/auditors/iam/iam_policy.py
+++ b/security_monkey/auditors/iam/iam_policy.py
@@ -28,7 +28,6 @@ import json
 
 class IAMPolicyAuditor(Auditor):
 
-
     def __init__(self, accounts=None, debug=False):
         super(IAMPolicyAuditor, self).__init__(accounts=accounts, debug=debug)
         self.iam_policy_keys = ['InlinePolicies']
@@ -76,6 +75,10 @@ class IAMPolicyAuditor(Auditor):
 
         for policy in self.load_iam_policies(item):
             for statement in policy.statements:
+                # Don't create issues for roles already known to be Admins
+                if '*' in statement.actions:
+                    continue
+
                 if statement.effect == 'Allow':
                     summary = statement.action_summary()
                     for service, categories in summary.items():
@@ -100,6 +103,10 @@ class IAMPolicyAuditor(Auditor):
 
         for policy in self.load_iam_policies(item):
             for statement in policy.statements:
+                # Don't create issues for roles already known to be Admins
+                if '*' in statement.actions:
+                    continue
+
                 if statement.effect == 'Allow':
                     summary = statement.action_summary()
                     for service, categories in summary.items():
@@ -120,6 +127,10 @@ class IAMPolicyAuditor(Auditor):
 
         for policy in self.load_iam_policies(item):
             for statement in policy.statements:
+                # Don't create issues for roles already known to be Admins
+                if '*' in statement.actions:
+                    continue
+
                 if statement.effect == 'Allow':
                     if 'iam:passrole' in statement.actions_expanded:
                         resources = json.dumps(sorted(list(statement.resources)))
@@ -169,6 +180,10 @@ class IAMPolicyAuditor(Auditor):
 
         for policy in self.load_iam_policies(item):
             for statement in policy.statements:
+                # Don't create issues for roles already known to be Admins
+                if '*' in statement.actions:
+                    continue
+
                 if statement.effect == 'Allow':
                     permissions = statement.actions_expanded.intersection(permissions)
                     if permissions:

--- a/security_monkey/auditors/iam/iam_policy.py
+++ b/security_monkey/auditors/iam/iam_policy.py
@@ -30,7 +30,7 @@ class IAMPolicyAuditor(Auditor):
 
     def __init__(self, accounts=None, debug=False):
         super(IAMPolicyAuditor, self).__init__(accounts=accounts, debug=debug)
-        self.iam_policy_keys = ['InlinePolicies']
+        self.iam_policy_keys = ['InlinePolicies$*']
 
     def load_iam_policies(self, item):
         return self.load_policies(item, self.iam_policy_keys)

--- a/security_monkey/auditors/iam/iam_role.py
+++ b/security_monkey/auditors/iam/iam_role.py
@@ -36,7 +36,7 @@ class IAMRoleAuditor(IAMPolicyAuditor, ResourcePolicyAuditor):
         # ResourcePolicyAuditor will look inside AssumeRolePolicyDocument
         # while the IAMPolicyAuditor will inspect the InlinePolicies section.
         self.policy_keys = ["AssumeRolePolicyDocument"]
-        self.iam_policy_keys = ['InlinePolicies']
+        self.iam_policy_keys = ['InlinePolicies$*']
 
     def check_attached_managed_policies(self, iamrole_item):
         """

--- a/security_monkey/auditors/iam/iam_role.py
+++ b/security_monkey/auditors/iam/iam_role.py
@@ -23,10 +23,6 @@ from security_monkey.watchers.iam.iam_role import IAMRole
 from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
 from security_monkey.auditors.resource_policy_auditor import ResourcePolicyAuditor
 from security_monkey.watchers.iam.managed_policy import ManagedPolicy
-from security_monkey.datastore import Account
-
-from policyuniverse.arn import ARN
-import json
 
 
 class IAMRoleAuditor(IAMPolicyAuditor, ResourcePolicyAuditor):
@@ -40,45 +36,7 @@ class IAMRoleAuditor(IAMPolicyAuditor, ResourcePolicyAuditor):
         # ResourcePolicyAuditor will look inside AssumeRolePolicyDocument
         # while the IAMPolicyAuditor will inspect the InlinePolicies section.
         self.policy_keys = ["AssumeRolePolicyDocument"]
-
-    def check_star_privileges(self, iamrole_item):
-        """
-        alert when an IAM Role has a policy allowing '*'.
-        """
-        self.library_check_iamobj_has_star_privileges(iamrole_item, policies_key='InlinePolicies')
-
-    def check_iam_star_privileges(self, iamrole_item):
-        """
-        alert when an IAM Role has a policy allowing 'iam:*'.
-        """
-        self.library_check_iamobj_has_iam_star_privileges(iamrole_item, policies_key='InlinePolicies')
-
-    def check_iam_privileges(self, iamrole_item):
-        """
-        alert when an IAM Role has a policy allowing 'iam:XxxxxXxxx'.
-        """
-        self.library_check_iamobj_has_iam_privileges(iamrole_item, policies_key='InlinePolicies')
-
-    def check_iam_passrole(self, iamrole_item):
-        """
-        alert when an IAM Role has a policy allowing 'iam:PassRole'.
-        This allows the role to pass any role specified in the resource block to an ec2 instance.
-        """
-        self.library_check_iamobj_has_iam_passrole(iamrole_item, policies_key='InlinePolicies')
-
-    def check_notaction(self, iamrole_item):
-        """
-        alert when an IAM Role has a policy containing 'NotAction'.
-        NotAction combined with an "Effect": "Allow" often provides more privilege
-        than is desired.
-        """
-        self.library_check_iamobj_has_notaction(iamrole_item, policies_key='InlinePolicies')
-
-    def check_security_group_permissions(self, iamrole_item):
-        """
-        alert when an IAM Role has ec2:AuthorizeSecurityGroupEgress or ec2:AuthorizeSecurityGroupIngress.
-        """
-        self.library_check_iamobj_has_security_group_permissions(iamrole_item, policies_key='InlinePolicies')
+        self.iam_policy_keys = ['InlinePolicies']
 
     def check_attached_managed_policies(self, iamrole_item):
         """

--- a/security_monkey/auditors/iam/iam_user.py
+++ b/security_monkey/auditors/iam/iam_user.py
@@ -44,6 +44,7 @@ class IAMUserAuditor(IAMPolicyAuditor):
         Prepare for the audit by calculating 90 days ago.
         This is used to check if access keys have been rotated.
         """
+        super(IAMUserAuditor, self).prep_for_audit()
         now = datetime.datetime.now()
         then = now - datetime.timedelta(days=90)
         self.ninety_days_ago = then.replace(tzinfo=tz.gettz('UTC'))

--- a/security_monkey/auditors/iam/iam_user.py
+++ b/security_monkey/auditors/iam/iam_user.py
@@ -28,6 +28,7 @@ from security_monkey.watchers.iam.iam_user import IAMUser
 from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
 from security_monkey.watchers.iam.managed_policy import ManagedPolicy
 
+
 class IAMUserAuditor(IAMPolicyAuditor):
     index = IAMUser.index
     i_am_singular = IAMUser.i_am_singular
@@ -36,6 +37,7 @@ class IAMUserAuditor(IAMPolicyAuditor):
 
     def __init__(self, accounts=None, debug=False):
         super(IAMUserAuditor, self).__init__(accounts=accounts, debug=debug)
+        self.iam_policy_keys = ['InlinePolicies']
 
     def prep_for_audit(self):
         """
@@ -95,45 +97,6 @@ class IAMUserAuditor(IAMPolicyAuditor):
                     if last_used_date < self.ninety_days_ago:
                         notes = "Key: [{}] Last Used: {}".format(akey, last_used_str)
                         self.add_issue(1, 'Active accesskey unused in last 90 days.', iamuser_item, notes=notes)
-
-    def check_star_privileges(self, iamuser_item):
-        """
-        alert when an IAM User has a policy allowing '*'.
-        """
-        self.library_check_iamobj_has_star_privileges(iamuser_item, policies_key='InlinePolicies')
-
-    def check_iam_star_privileges(self, iamuser_item):
-        """
-        alert when an IAM User has a policy allowing 'iam:*'.
-        """
-        self.library_check_iamobj_has_iam_star_privileges(iamuser_item, policies_key='InlinePolicies')
-
-    def check_iam_privileges(self, iamuser_item):
-        """
-        alert when an IAM User has a policy allowing 'iam:XxxxxXxxx'.
-        """
-        self.library_check_iamobj_has_iam_privileges(iamuser_item, policies_key='InlinePolicies')
-
-    def check_iam_passrole(self, iamuser_item):
-        """
-        alert when an IAM User has a policy allowing 'iam:PassRole'.
-        This allows the user to pass any role specified in the resource block to an ec2 instance.
-        """
-        self.library_check_iamobj_has_iam_passrole(iamuser_item, policies_key='InlinePolicies')
-
-    def check_notaction(self, iamuser_item):
-        """
-        alert when an IAM User has a policy containing 'NotAction'.
-        NotAction combined with an "Effect": "Allow" often provides more privilege
-        than is desired.
-        """
-        self.library_check_iamobj_has_notaction(iamuser_item, policies_key='InlinePolicies')
-
-    def check_security_group_permissions(self, iamuser_item):
-        """
-        alert when an IAM User has ec2:AuthorizeSecurityGroupEgress or ec2:AuthorizeSecurityGroupIngress.
-        """
-        self.library_check_iamobj_has_security_group_permissions(iamuser_item, policies_key='InlinePolicies')
 
     def check_no_mfa(self, iamuser_item):
         """

--- a/security_monkey/auditors/iam/iam_user.py
+++ b/security_monkey/auditors/iam/iam_user.py
@@ -37,7 +37,7 @@ class IAMUserAuditor(IAMPolicyAuditor):
 
     def __init__(self, accounts=None, debug=False):
         super(IAMUserAuditor, self).__init__(accounts=accounts, debug=debug)
-        self.iam_policy_keys = ['InlinePolicies']
+        self.iam_policy_keys = ['InlinePolicies$*']
 
     def prep_for_audit(self):
         """

--- a/security_monkey/auditors/iam/managed_policy.py
+++ b/security_monkey/auditors/iam/managed_policy.py
@@ -61,12 +61,19 @@ class ManagedPolicyAuditor(IAMPolicyAuditor):
         if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
             super(ManagedPolicyAuditor, self).check_iam_star_privileges(item)
 
-    def check_iam_mutating_privileges(self, item):
+    def check_permissions(self, item):
         """
-        alert when an IAM Object has a policy allowing mutating IAM permissions.
+        Alert when an IAM Object has a policy allowing permission modification.
         """
         if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
-            super(ManagedPolicyAuditor, self).check_iam_mutating_privileges(item)
+            super(ManagedPolicyAuditor, self).check_permissions(item)
+
+    def check_mutable_sensitive_services(self, item):
+        """
+        Alert when an IAM Object has DataPlaneMutating permissions for sensitive services.
+        """
+        if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
+            super(ManagedPolicyAuditor, self).check_mutable_sensitive_services(item)
 
     def check_iam_passrole(self, item):
         """

--- a/security_monkey/auditors/iam/managed_policy.py
+++ b/security_monkey/auditors/iam/managed_policy.py
@@ -43,78 +43,58 @@ class ManagedPolicyAuditor(IAMPolicyAuditor):
 
     def __init__(self, accounts=None, debug=False):
         super(ManagedPolicyAuditor, self).__init__(accounts=accounts, debug=debug)
+        self.iam_policy_keys = ['policy']
 
-    def prep_for_audit(self):
-        """
-        No prep necessary.
-        """
-        pass
-
-    def check_star_privileges(self, iam_object):
+    def check_star_privileges(self, item):
         """
         alert when an IAM Object has a policy allowing '*'.
         """
-        if not is_aws_managed_policy(iam_object) or (is_aws_managed_policy(iam_object) and has_attached_resources(iam_object)):
-            self.library_check_iamobj_has_star_privileges(
-                iam_object,
-                policies_key='policy',
-                multiple_policies=False
-            )
+        if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
+            super.check_star_privileges(item)
 
-    def check_iam_star_privileges(self, iam_object):
+    def check_iam_star_privileges(self, item):
         """
         alert when an IAM Object has a policy allowing 'iam:*'.
         """
-        if not is_aws_managed_policy(iam_object) or (is_aws_managed_policy(iam_object) and has_attached_resources(iam_object)):
-            self.library_check_iamobj_has_iam_star_privileges(
-                iam_object,
-                policies_key='policy',
-                multiple_policies=False
-            )
+        if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
+            super.check_iam_star_privileges(item)
 
-    def check_iam_privileges(self, iam_object):
+    def check_iam_mutating_privileges(self, item):
         """
-        alert when an IAM Object has a policy allowing 'iam:XxxxxXxxx'.
+        alert when an IAM Object has a policy allowing mutating IAM permissions.
         """
-        if not is_aws_managed_policy(iam_object) or (is_aws_managed_policy(iam_object) and has_attached_resources(iam_object)):
-            self.library_check_iamobj_has_iam_privileges(
-                iam_object,
-                policies_key='policy',
-                multiple_policies=False
-            )
+        if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
+            super.check_iam_mutating_privileges(item)
 
-    def check_iam_passrole(self, iam_object):
+    def check_iam_passrole(self, item):
         """
         alert when an IAM Object has a policy allowing 'iam:PassRole'.
         This allows the object to pass any role specified in the resource block to an ec2 instance.
         """
-        if not is_aws_managed_policy(iam_object) or (is_aws_managed_policy(iam_object) and has_attached_resources(iam_object)):
-            self.library_check_iamobj_has_iam_passrole(
-                iam_object,
-                policies_key='policy',
-                multiple_policies=False
-            )
+        if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
+            super.check_iam_passrole(item)
 
-    def check_notaction(self, iam_object):
+    def check_notaction(self, item):
         """
         alert when an IAM Object has a policy containing 'NotAction'.
         NotAction combined with an "Effect": "Allow" often provides more privilege
         than is desired.
         """
-        if not is_aws_managed_policy(iam_object) or (is_aws_managed_policy(iam_object) and has_attached_resources(iam_object)):
-            self.library_check_iamobj_has_notaction(
-                iam_object,
-                policies_key='policy',
-                multiple_policies=False
-            )
+        if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
+            super.check_notaction(item)
 
-    def check_security_group_permissions(self, iam_object):
+    def check_notresource(self, item):
+        """
+        alert when an IAM Object has a policy containing 'NotResource'.
+        NotResource combined with an "Effect": "Allow" often provides more privilege
+        than is desired.
+        """
+        if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
+            super.check_notresource(item)
+
+    def check_security_group_permissions(self, item):
         """
         alert when an IAM Object has ec2:AuthorizeSecurityGroupEgress or ec2:AuthorizeSecurityGroupIngress.
         """
-        if not is_aws_managed_policy(iam_object) or (is_aws_managed_policy(iam_object) and has_attached_resources(iam_object)):
-            self.library_check_iamobj_has_security_group_permissions(
-                iam_object,
-                policies_key='policy',
-                multiple_policies=False
-            )
+        if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
+            super.check_security_group_permissions(item)

--- a/security_monkey/auditors/iam/managed_policy.py
+++ b/security_monkey/auditors/iam/managed_policy.py
@@ -23,18 +23,20 @@ from security_monkey.watchers.iam.managed_policy import ManagedPolicy
 from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
 from security_monkey import ARN_PREFIX
 
-def is_aws_managed_policy(iam_obj):
-    return ARN_PREFIX + ':iam::aws:policy/' in iam_obj.config['arn']
 
-def has_attached_resources(iam_obj):
-    if iam_obj.config['attached_users'] and len(iam_obj.config['attached_users']) > 0:
+def is_aws_managed_policy(item):
+    return ARN_PREFIX + ':iam::aws:policy/' in item.config['arn']
+
+def has_attached_resources(item):
+    if 'attached_users' in item.config and len(item.config['attached_users']) > 0:
         return True
-    elif iam_obj.config['attached_roles'] and len(iam_obj.config['attached_roles']) > 0:
+    elif 'attached_roles' in item.config and len(item.config['attached_roles']) > 0:
         return True
-    elif iam_obj.config['attached_groups'] and len(iam_obj.config['attached_groups']) > 0:
+    elif 'attached_groups' in item.config and len(item.config['attached_groups']) > 0:
         return True
     else:
         return False
+
 
 class ManagedPolicyAuditor(IAMPolicyAuditor):
     index = ManagedPolicy.index
@@ -50,21 +52,21 @@ class ManagedPolicyAuditor(IAMPolicyAuditor):
         alert when an IAM Object has a policy allowing '*'.
         """
         if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
-            super.check_star_privileges(item)
+            super(ManagedPolicyAuditor, self).check_star_privileges(item)
 
     def check_iam_star_privileges(self, item):
         """
         alert when an IAM Object has a policy allowing 'iam:*'.
         """
         if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
-            super.check_iam_star_privileges(item)
+            super(ManagedPolicyAuditor, self).check_iam_star_privileges(item)
 
     def check_iam_mutating_privileges(self, item):
         """
         alert when an IAM Object has a policy allowing mutating IAM permissions.
         """
         if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
-            super.check_iam_mutating_privileges(item)
+            super(ManagedPolicyAuditor, self).check_iam_mutating_privileges(item)
 
     def check_iam_passrole(self, item):
         """
@@ -72,7 +74,7 @@ class ManagedPolicyAuditor(IAMPolicyAuditor):
         This allows the object to pass any role specified in the resource block to an ec2 instance.
         """
         if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
-            super.check_iam_passrole(item)
+            super(ManagedPolicyAuditor, self).check_iam_passrole(item)
 
     def check_notaction(self, item):
         """
@@ -81,7 +83,7 @@ class ManagedPolicyAuditor(IAMPolicyAuditor):
         than is desired.
         """
         if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
-            super.check_notaction(item)
+            super(ManagedPolicyAuditor, self).check_notaction(item)
 
     def check_notresource(self, item):
         """
@@ -90,11 +92,11 @@ class ManagedPolicyAuditor(IAMPolicyAuditor):
         than is desired.
         """
         if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
-            super.check_notresource(item)
+            super(ManagedPolicyAuditor, self).check_notresource(item)
 
     def check_security_group_permissions(self, item):
         """
         alert when an IAM Object has ec2:AuthorizeSecurityGroupEgress or ec2:AuthorizeSecurityGroupIngress.
         """
         if not is_aws_managed_policy(item) or (is_aws_managed_policy(item) and has_attached_resources(item)):
-            super.check_security_group_permissions(item)
+            super(ManagedPolicyAuditor, self).check_security_group_permissions(item)

--- a/security_monkey/auditors/resource_policy_auditor.py
+++ b/security_monkey/auditors/resource_policy_auditor.py
@@ -28,8 +28,6 @@ from policyuniverse.policy import Policy
 from policyuniverse.statement import Statement
 
 import json
-import dpath.util
-from dpath.exceptions import PathNotFound
 import ipaddr
 
 
@@ -39,43 +37,11 @@ class ResourcePolicyAuditor(Auditor):
         super(ResourcePolicyAuditor, self).__init__(accounts=accounts, debug=debug)
         self.policy_keys = ['Policy']
 
-    def load_policies(self, item):
-        """For a given item, return a list of all resource policies.
-        
-        Most items only have a single resource policy, typically found 
-        inside the config with the key, "Policy".
-        
-        Some technologies have multiple resource policies.  A lambda function
-        is an example of an item with multiple resource policies.
-        
-        The lambda function auditor can define a list of `policy_keys`.  Each
-        item in this list is the dpath to one of the resource policies.
-        
-        The `policy_keys` defaults to ['Policy'] unless overriden by a subclass.
-        
-        Returns:
-            list of Policy objects
-        """
-        policies = list()
-        for key in self.policy_keys:
-            try:
-                policy = dpath.util.values(item.config, key, separator='$')
-                if isinstance(policy, list):
-                    for p in policy:
-                        if not p:
-                            continue
-                        if isinstance(p, list):
-                            policies.extend([Policy(pp) for pp in p])
-                        else:
-                            policies.append(Policy(p))
-                else:
-                    policies.append(Policy(policy))
-            except PathNotFound:
-                continue
-        return policies
+    def load_resource_policies(self, item):
+        return self.load_policies(item, self.policy_keys)
 
     def check_internet_accessible(self, item):
-        policies = self.load_policies(item)
+        policies = self.load_resource_policies(item)
         for policy in policies:
             if policy.is_internet_accessible():
                 entity = Entity(category='principal', value='*')
@@ -83,7 +49,7 @@ class ResourcePolicyAuditor(Auditor):
                 self.record_internet_access(item, entity, actions)
 
     def check_friendly_cross_account(self, item):
-        policies = self.load_policies(item)
+        policies = self.load_resource_policies(item)
         for policy in policies:
             for statement in policy.statements:
                 if statement.effect != 'Allow':
@@ -94,7 +60,7 @@ class ResourcePolicyAuditor(Auditor):
                         self.record_friendly_access(item, entity, list(statement.actions))
 
     def check_thirdparty_cross_account(self, item):
-        policies = self.load_policies(item)
+        policies = self.load_resource_policies(item)
         for policy in policies:
             for statement in policy.statements:
                 if statement.effect != 'Allow':
@@ -105,7 +71,7 @@ class ResourcePolicyAuditor(Auditor):
                         self.record_thirdparty_access(item, entity, list(statement.actions))
 
     def check_unknown_cross_account(self, item):
-        policies = self.load_policies(item)
+        policies = self.load_resoruce_policies(item)
         for policy in policies:
             if policy.is_internet_accessible():
                 continue
@@ -127,7 +93,7 @@ class ResourcePolicyAuditor(Auditor):
                         self.record_unknown_access(item, entity, list(statement.actions))
 
     def check_root_cross_account(self, item):
-        policies = self.load_policies(item)
+        policies = self.load_resource_policies(item)
         for policy in policies:
             for statement in policy.statements:
                 if statement.effect != 'Allow':

--- a/security_monkey/auditors/resource_policy_auditor.py
+++ b/security_monkey/auditors/resource_policy_auditor.py
@@ -71,7 +71,7 @@ class ResourcePolicyAuditor(Auditor):
                         self.record_thirdparty_access(item, entity, list(statement.actions))
 
     def check_unknown_cross_account(self, item):
-        policies = self.load_resoruce_policies(item)
+        policies = self.load_resource_policies(item)
         for policy in policies:
             if policy.is_internet_accessible():
                 continue

--- a/security_monkey/tests/auditors/test_iam.py
+++ b/security_monkey/tests/auditors/test_iam.py
@@ -369,7 +369,7 @@ class IAMTestCase(SecurityMonkeyTestCase):
         auditor = IAMPolicyAuditor(accounts=['unittest'])
         iamobj = MockIAMObj()
 
-        iamobj.config = {'InlinePolicies': json.loads(FULL_ADMIN_POLICY_BARE)}
+        iamobj.config = {'InlinePolicies': dict(MyPolicy=json.loads(FULL_ADMIN_POLICY_BARE))}
 
         self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
         auditor.check_star_privileges(iamobj)
@@ -517,7 +517,7 @@ class IAMTestCase(SecurityMonkeyTestCase):
         auditor = IAMPolicyAuditor(accounts=['unittest'])
         iamobj = MockIAMObj()
 
-        iamobj.config = {'InlinePolicies': json.loads(IAM_ADMIN)}
+        iamobj.config = {'InlinePolicies': dict(MyPolicy=json.loads(IAM_ADMIN))}
 
         self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
         auditor.check_iam_star_privileges(iamobj)
@@ -532,7 +532,7 @@ class IAMTestCase(SecurityMonkeyTestCase):
         auditor = IAMPolicyAuditor(accounts=['unittest'])
         iamobj = MockIAMObj()
 
-        iamobj.config = {'InlinePolicies': json.loads(IAM_MUTATING)}
+        iamobj.config = {'InlinePolicies': dict(MyPolicy=json.loads(IAM_MUTATING))}
 
         self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
         auditor.check_permissions(iamobj)
@@ -547,7 +547,7 @@ class IAMTestCase(SecurityMonkeyTestCase):
         auditor = IAMPolicyAuditor(accounts=['unittest'])
         iamobj = MockIAMObj()
 
-        iamobj.config = {'InlinePolicies': json.loads(IAM_PASSROLE)}
+        iamobj.config = {'InlinePolicies': dict(MyPolicy=json.loads(IAM_PASSROLE))}
 
         self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
         auditor.check_iam_passrole(iamobj)
@@ -562,7 +562,7 @@ class IAMTestCase(SecurityMonkeyTestCase):
         auditor = IAMPolicyAuditor(accounts=['unittest'])
         iamobj = MockIAMObj()
 
-        iamobj.config = {'InlinePolicies': json.loads(IAM_NOTACTION)}
+        iamobj.config = {'InlinePolicies': dict(MyPolicy=json.loads(IAM_NOTACTION))}
 
         self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
         auditor.check_notaction(iamobj)
@@ -577,7 +577,7 @@ class IAMTestCase(SecurityMonkeyTestCase):
         auditor = IAMPolicyAuditor(accounts=['unittest'])
         iamobj = MockIAMObj()
 
-        iamobj.config = {'InlinePolicies': json.loads(IAM_NOTRESOURCE)}
+        iamobj.config = {'InlinePolicies': dict(MyPolicy=json.loads(IAM_NOTRESOURCE))}
 
         self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
         auditor.check_notresource(iamobj)
@@ -592,7 +592,7 @@ class IAMTestCase(SecurityMonkeyTestCase):
         auditor = IAMPolicyAuditor(accounts=['unittest'])
         iamobj = MockIAMObj()
 
-        iamobj.config = {'InlinePolicies': json.loads(IAM_SG_MUTATION)}
+        iamobj.config = {'InlinePolicies': dict(MyPolicy=json.loads(IAM_SG_MUTATION))}
 
         self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
         auditor.check_security_group_permissions(iamobj)
@@ -607,7 +607,7 @@ class IAMTestCase(SecurityMonkeyTestCase):
         auditor = IAMPolicyAuditor(accounts=['unittest'])
 
         iamobj = MockIAMObj()
-        iamobj.config = {'InlinePolicies': json.loads(FULL_ADMIN_POLICY_SINGLE_ENTRY)}
+        iamobj.config = {'InlinePolicies': dict(MyPolicy=json.loads(FULL_ADMIN_POLICY_SINGLE_ENTRY))}
 
         self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
         auditor.check_star_privileges(iamobj)
@@ -622,7 +622,7 @@ class IAMTestCase(SecurityMonkeyTestCase):
         auditor = IAMPolicyAuditor(accounts=['unittest'])
 
         iamobj = MockIAMObj()
-        iamobj.config = {'InlinePolicies': json.loads(FULL_ADMIN_POLICY_LIST)}
+        iamobj.config = {'InlinePolicies': dict(MyPolicy=json.loads(FULL_ADMIN_POLICY_LIST))}
 
         self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
         auditor.check_star_privileges(iamobj)
@@ -637,7 +637,7 @@ class IAMTestCase(SecurityMonkeyTestCase):
         auditor = IAMPolicyAuditor(accounts=['unittest'])
 
         iamobj = MockIAMObj()
-        iamobj.config = {'InlinePolicies': json.loads(NO_ADMIN_POLICY_LIST)}
+        iamobj.config = {'InlinePolicies': dict(MyPolicy=json.loads(NO_ADMIN_POLICY_LIST))}
 
         self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
         auditor.check_star_privileges(iamobj)
@@ -655,8 +655,8 @@ class IAMTestCase(SecurityMonkeyTestCase):
         policies = auditor.load_iam_policies(iamobj)
         self.assertIs(len(policies), 0, "Zero policies expected")
         
-        auditor.iam_policy_keys = ['InlinePolicies']
-        iamobj.config = {'InlinePolicies': [json.loads(IAM_ADMIN), json.loads(IAM_PASSROLE)]}
+        auditor.iam_policy_keys = ['InlinePolicies$*']
+        iamobj.config = {'InlinePolicies': dict(Admin=json.loads(IAM_ADMIN), PassRole=json.loads(IAM_PASSROLE))}
         policies = auditor.load_iam_policies(iamobj)
         self.assertIs(len(policies), 2, "Two policies expected but received {}".format(len(policies)))
 

--- a/security_monkey/tests/auditors/test_iam.py
+++ b/security_monkey/tests/auditors/test_iam.py
@@ -170,7 +170,8 @@ FULL_ADMIN_POLICY_BARE = """
 {
     "Statement":    {
         "Effect": "Allow",
-        "Action": "*"
+        "Action": "*",
+        "Resource": "*"
     }
 }
 """
@@ -179,7 +180,8 @@ FULL_ADMIN_POLICY_SINGLE_ENTRY = """
 {
     "Statement":    {
         "Effect": "Allow",
-        "Action": ["*"]
+        "Action": ["*"],
+        "Resource": ["*"]
     }
 }
 """
@@ -192,7 +194,8 @@ FULL_ADMIN_POLICY_LIST = """
             "filler",
             "*",
             "morefiller"
-        ]
+        ],
+        "Resource": ["someresource"]
     }
 }
 """
@@ -204,11 +207,89 @@ NO_ADMIN_POLICY_LIST = """
         "Action": [
             "filler",
             "morefiller"
-        ]
+        ],
+        "Resource": ["someresource"]
     }
 }
 """
 
+IAM_ADMIN = """
+{
+    "Statement":    {
+        "Effect": "Allow",
+        "Action": [
+            "iam:*"
+        ],
+        "Resource": ["someresource"]
+    }
+}
+"""
+
+IAM_MUTATING = """
+{
+    "Statement":    {
+        "Effect": "Allow",
+        "Action": [
+            "iam:addsomething",
+            "iam:attachsomething",
+            "iam:createsomething",
+            "iam:deletesomething",
+            "iam:detachsomething",
+            "ec2:somepermission"
+        ],
+        "Resource": ["someresource"]
+    }
+}
+"""
+
+IAM_PASSROLE = """
+{
+    "Statement":    {
+        "Effect": "Allow",
+        "Action": [
+            "iam:PassRole"
+        ],
+        "Resource": ["someresource"]
+    }
+}
+"""
+
+IAM_NOTACTION = """
+{
+    "Statement":    {
+        "Effect": "Allow",
+        "NotAction": [
+            "iam:*"
+        ],
+        "Resource": ["someresource"]
+    }
+}
+"""
+
+IAM_NOTRESOURCE = """
+{
+    "Statement":    {
+        "Effect": "Allow",
+        "Action": [
+            "iam:*"
+        ],
+        "NotResource": ["someresource"]
+    }
+}
+"""
+
+IAM_SG_MUTATION = """
+{
+    "Statement":    {
+        "Effect": "Allow",
+        "Action": [
+            "ec2:authorizeSecurityGroupIngress",
+            "ec2:authorizeSecurityGroupEgress"
+        ],
+        "Resource": ["someresource"]
+    }
+}
+"""
 
 
 class MockIAMObj:
@@ -268,7 +349,7 @@ class IAMTestCase(SecurityMonkeyTestCase):
 
         self.assertEqual(get_cert_info(EXTERNAL_VALID_STR), valid)
 
-    def test_iam_full_admin_only(self):
+    def test_full_admin_only(self):
         import json
         from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
 
@@ -280,11 +361,230 @@ class IAMTestCase(SecurityMonkeyTestCase):
         self.assertIs(len(iamobj.audit_issues), 0,
                       "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
 
-        auditor.library_check_iamobj_has_star_privileges(iamobj, multiple_policies=False)
+        auditor.check_star_privileges(iamobj)
         self.assertIs(len(iamobj.audit_issues), 1,
                       "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
 
-    def test_iam_full_admin_list_single_entry(self):
+    def test_managed_policy_full_admin_only(self):
+        import json
+        from security_monkey.auditors.iam.managed_policy import ManagedPolicyAuditor
+
+        auditor = ManagedPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {
+            'arn': 'arn:iam::aws:policy/',
+            'policy': json.loads(FULL_ADMIN_POLICY_BARE)}
+
+        self.assertIs(len(iamobj.audit_issues), 0,
+                      "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+
+        auditor.check_star_privileges(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1,
+                      "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_managed_policy_iam_admin_only(self):
+        import json
+        from security_monkey.auditors.iam.managed_policy import ManagedPolicyAuditor
+
+        auditor = ManagedPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {
+            'arn': 'arn:iam::aws:policy/',
+            'policy': json.loads(IAM_ADMIN)}
+
+        self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+        auditor.check_iam_star_privileges(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1, "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_managed_policy_iam_mutating_only(self):
+        import json
+        from security_monkey.auditors.iam.managed_policy import ManagedPolicyAuditor
+
+        auditor = ManagedPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {
+            'arn': 'arn:iam::aws:policy/',
+            'policy': json.loads(IAM_MUTATING)}
+
+        self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+        auditor.check_iam_mutating_privileges(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1, "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_managed_policy_iam_passrole(self):
+        import json
+        from security_monkey.auditors.iam.managed_policy import ManagedPolicyAuditor
+
+        auditor = ManagedPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {
+            'arn': 'arn:iam::aws:policy/',
+            'policy': json.loads(IAM_PASSROLE)}
+
+        self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+        auditor.check_iam_passrole(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1, "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_managed_policy_iam_notaction(self):
+        import json
+        from security_monkey.auditors.iam.managed_policy import ManagedPolicyAuditor
+
+        auditor = ManagedPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {
+            'arn': 'arn:iam::aws:policy/',
+            'policy': json.loads(IAM_NOTACTION)}
+
+        self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+        auditor.check_notaction(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1, "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_managed_policy_iam_notresource(self):
+        import json
+        from security_monkey.auditors.iam.managed_policy import ManagedPolicyAuditor
+
+        auditor = ManagedPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {
+            'arn': 'arn:iam::aws:policy/',
+            'policy': json.loads(IAM_NOTRESOURCE)}
+
+        self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+        auditor.check_notresource(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1, "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_managed_policy_security_group_permissions(self):
+        import json
+        from security_monkey.auditors.iam.managed_policy import ManagedPolicyAuditor
+
+        auditor = ManagedPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {
+            'arn': 'arn:iam::aws:policy/',
+            'policy': json.loads(IAM_SG_MUTATION)}
+
+        self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+        auditor.check_security_group_permissions(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1, "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_managed_policy_has_attached_resources(self):
+        import json
+        from security_monkey.auditors.iam.managed_policy import has_attached_resources
+
+        iamobj = MockIAMObj()
+        iamobj.config = {}
+        self.assertIs(False, has_attached_resources(iamobj))
+        iamobj.config = {'attached_users': ['user1']}
+        self.assertIs(True, has_attached_resources(iamobj))
+        iamobj.config = {'attached_roles': ['role1']}
+        self.assertIs(True, has_attached_resources(iamobj))
+        iamobj.config = {'attached_groups': ['group1']}
+        self.assertIs(True, has_attached_resources(iamobj))
+
+    def test_iam_full_admin_only(self):
+        import json
+        from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
+
+        auditor = IAMPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {'InlinePolicies': json.loads(IAM_ADMIN)}
+
+        self.assertIs(len(iamobj.audit_issues), 0,
+                      "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+
+        auditor.check_iam_star_privileges(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1,
+                      "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_iam_mutating(self):
+        import json
+        from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
+
+        auditor = IAMPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {'InlinePolicies': json.loads(IAM_MUTATING)}
+
+        self.assertIs(len(iamobj.audit_issues), 0,
+                      "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+
+        # from pdb import set_trace; set_trace()
+        auditor.check_iam_mutating_privileges(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1,
+                      "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_iam_passrole(self):
+        import json
+        from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
+
+        auditor = IAMPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {'InlinePolicies': json.loads(IAM_PASSROLE)}
+
+        self.assertIs(len(iamobj.audit_issues), 0,
+                      "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+
+        auditor.check_iam_passrole(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1,
+                      "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_iam_notaction(self):
+        import json
+        from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
+
+        auditor = IAMPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {'InlinePolicies': json.loads(IAM_NOTACTION)}
+
+        self.assertIs(len(iamobj.audit_issues), 0,
+                      "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+
+        auditor.check_notaction(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1,
+                      "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_iam_notresource(self):
+        import json
+        from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
+
+        auditor = IAMPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {'InlinePolicies': json.loads(IAM_NOTRESOURCE)}
+
+        self.assertIs(len(iamobj.audit_issues), 0,
+                      "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+
+        auditor.check_notresource(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1,
+                      "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_iam_sg_mutation(self):
+        import json
+        from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
+
+        auditor = IAMPolicyAuditor(accounts=['unittest'])
+        iamobj = MockIAMObj()
+
+        iamobj.config = {'InlinePolicies': json.loads(IAM_SG_MUTATION)}
+
+        self.assertIs(len(iamobj.audit_issues), 0,
+                      "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+
+        auditor.check_security_group_permissions(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1,
+                      "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_full_admin_list_single_entry(self):
         import json
         from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
 
@@ -296,11 +596,11 @@ class IAMTestCase(SecurityMonkeyTestCase):
         self.assertIs(len(iamobj.audit_issues), 0,
                       "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
 
-        auditor.library_check_iamobj_has_star_privileges(iamobj, multiple_policies=False)
+        auditor.check_star_privileges(iamobj)
         self.assertIs(len(iamobj.audit_issues), 1,
                       "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
 
-    def test_iam_full_admin_list(self):
+    def test_full_admin_list(self):
         import json
         from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
 
@@ -312,7 +612,7 @@ class IAMTestCase(SecurityMonkeyTestCase):
         self.assertIs(len(iamobj.audit_issues), 0,
                       "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
 
-        auditor.library_check_iamobj_has_star_privileges(iamobj, multiple_policies=False)
+        auditor.check_star_privileges(iamobj)
         self.assertIs(len(iamobj.audit_issues), 1,
                       "Policy should have 1 alert but has {}".format(len(iamobj.audit_issues)))
 
@@ -328,5 +628,213 @@ class IAMTestCase(SecurityMonkeyTestCase):
         self.assertIs(len(iamobj.audit_issues), 0,
                       "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
 
-        auditor.library_check_iamobj_has_star_privileges(iamobj, multiple_policies=False)
+        auditor.check_star_privileges(iamobj)
         self.assertIs(len(iamobj.audit_issues), 0, "Policy should have 0 alert but has {}".format(len(iamobj.audit_issues)))
+
+    def test_load_policies(self):
+        import json
+        from security_monkey.auditors.iam.iam_policy import IAMPolicyAuditor
+
+        auditor = IAMPolicyAuditor(accounts=['unittest'])
+
+        iamobj = MockIAMObj()
+        iamobj.config = {'InlinePolicies': None}
+
+        policies = auditor.load_iam_policies(iamobj)
+        self.assertIs(len(policies), 0, "Zero policies expected")
+        
+        auditor.iam_policy_keys = ['InlinePolicies']
+        iamobj.config = {'InlinePolicies': [json.loads(IAM_ADMIN), json.loads(IAM_PASSROLE)]}
+        policies = auditor.load_iam_policies(iamobj)
+        self.assertIs(len(policies), 2, "Two policies expected but received {}".format(len(policies)))
+
+
+    def pre_test_setup(self):
+        from security_monkey.auditors.iam.iam_role import IAMRoleAuditor
+        from security_monkey.datastore import Account, AccountType
+        from security_monkey import db
+
+        IAMRoleAuditor(accounts=['TEST_ACCOUNT']).OBJECT_STORE.clear()
+        account_type_result = AccountType(name='AWS')
+        db.session.add(account_type_result)
+        db.session.commit()
+
+        # main
+        account = Account(identifier="012345678910", name="TEST_ACCOUNT",
+                          account_type_id=account_type_result.id, notes="TEST_ACCOUNT",
+                          third_party=False, active=True)
+        # friendly
+        account2 = Account(identifier="222222222222", name="TEST_ACCOUNT_TWO",
+                          account_type_id=account_type_result.id, notes="TEST_ACCOUNT_TWO",
+                          third_party=False, active=True)
+        # third party
+        account3 = Account(identifier="333333333333", name="TEST_ACCOUNT_THREE",
+                          account_type_id=account_type_result.id, notes="TEST_ACCOUNT_THREE",
+                          third_party=True, active=True)
+
+        db.session.add(account)
+        db.session.add(account2)
+        db.session.add(account3)
+        db.session.commit()
+
+    def test_iamrole_trust_policy(self):
+        from security_monkey.auditors.iam.iam_role import IAMRoleAuditor
+
+        trust_policy = {
+            "Version": "2008-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Principal": {
+                        "AWS": ["arn:aws:iam::222222222222:role/SomeRole"]
+                    },
+                    "Effect": "Allow",
+                    "Sid": ""
+                }
+            ]
+        }
+
+        auditor = IAMRoleAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+
+        iamobj = MockIAMObj()
+        iamobj.account = 'TEST_ACCOUNT'
+        iamobj.config = {'InlinePolicies': None, 'AssumeRolePolicyDocument': trust_policy}
+
+        auditor.check_friendly_cross_account(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1, "Cross Account Trust Policy not Flagged")
+    
+    def test_iamuser_active_access_keys(self):
+        from security_monkey.auditors.iam.iam_user import IAMUserAuditor
+        auditor = IAMUserAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+        
+        iamobj = MockIAMObj()
+        iamobj.config = {
+            'AccessKeys': [{
+                'Status': 'Active',
+                'AccessKeyId': 'SomeAccessKeyId'
+            },
+            {
+                'Status': 'Active',
+                'AccessKeyId': 'SomeOtherAccessKeyId'
+            }]
+        }
+
+        auditor.check_active_access_keys(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 2, "Should have two active access keys.")
+
+    def test_iamuser_inactive_access_keys(self):
+        from security_monkey.auditors.iam.iam_user import IAMUserAuditor
+        auditor = IAMUserAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+        
+        iamobj = MockIAMObj()
+        iamobj.config = {
+            'AccessKeys': [{
+                'Status': 'Inactive',
+                'AccessKeyId': 'SomeAccessKeyId'
+            },
+            {
+                'Status': 'Inactive',
+                'AccessKeyId': 'SomeOtherAccessKeyId'
+            }]
+        }
+
+        auditor.check_inactive_access_keys(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 2, "Should have two inactive access keys.")
+
+    def test_iamuser_access_key_rotation(self):
+        from security_monkey.auditors.iam.iam_user import IAMUserAuditor
+        auditor = IAMUserAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+        
+        iamobj = MockIAMObj()
+        iamobj.config = {
+            'AccessKeys': [{
+                'Status': 'Active',
+                'AccessKeyId': 'SomeAccessKeyId',
+                'CreateDate': '2015-09-21 23:38:49+00:00'
+            },
+            {
+                'Status': 'Active',
+                'AccessKeyId': 'SomeOtherAccessKeyId',
+                'CreateDate': '2015-09-21 23:38:49+00:00'
+            }]
+        }
+
+        auditor.check_access_key_rotation(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1, "Should have an issue for access keys in need of rotation.")
+
+    def test_iamuser_access_key_last_used(self):
+        from security_monkey.auditors.iam.iam_user import IAMUserAuditor
+        auditor = IAMUserAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+        
+        iamobj = MockIAMObj()
+        iamobj.config = {
+            'AccessKeys': [{
+                'Status': 'Active',
+                'AccessKeyId': 'SomeAccessKeyId',
+                'CreateDate': '2015-09-21 23:38:49+00:00'
+            },
+            {
+                'Status': 'Active',
+                'AccessKeyId': 'SomeOtherAccessKeyId',
+                'LastUsedDate': '2015-09-21 23:38:49+00:00'
+            }]
+        }
+
+        auditor.check_access_key_last_used(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 2, "Should have an issue for an unused access key.")
+
+    def test_iamuser_check_no_mfa(self):
+        from security_monkey.auditors.iam.iam_user import IAMUserAuditor
+        auditor = IAMUserAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+        
+        iamobj = MockIAMObj()
+        iamobj.config = {
+            'MfaDevices': False,
+            'LoginProfile': True
+        }
+
+        auditor.check_no_mfa(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1, "Should raise an issue for User with loginprofile and no MFA.")
+
+    def test_iamuser_check_loginprofile_plus_akeys(self):
+        from security_monkey.auditors.iam.iam_user import IAMUserAuditor
+        auditor = IAMUserAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+        
+        iamobj = MockIAMObj()
+        iamobj.config = {
+            'LoginProfile': True,
+            'AccessKeys': [{
+                'Status': 'Active',
+                'AccessKeyId': 'SomeAccessKeyId',
+            },
+            {
+                'Status': 'Active',
+                'AccessKeyId': 'SomeOtherAccessKeyId',
+            }]
+        }
+
+        auditor.check_loginprofile_plus_akeys(iamobj)
+        self.assertIs(len(iamobj.audit_issues), 1, "Should raise an issue for User with loginprofile and access keys.")
+
+        iamobj2 = MockIAMObj()
+        iamobj2.config = {
+            'LoginProfile': False,
+            'AccessKeys': [{
+                'Status': 'Active',
+                'AccessKeyId': 'SomeAccessKeyId',
+            },
+            {
+                'Status': 'Active',
+                'AccessKeyId': 'SomeOtherAccessKeyId',
+            }]
+        }
+
+        auditor.check_loginprofile_plus_akeys(iamobj2)
+        self.assertIs(len(iamobj2.audit_issues), 0, "Should not raise an issue.")

--- a/security_monkey/tests/auditors/test_resource_policy_auditor.py
+++ b/security_monkey/tests/auditors/test_resource_policy_auditor.py
@@ -1,7 +1,7 @@
 from security_monkey.tests import SecurityMonkeyTestCase
 from security_monkey.auditor import Entity
 from security_monkey.auditors.resource_policy_auditor import ResourcePolicyAuditor
-from security_monkey import db 
+from security_monkey import db
 from security_monkey.watcher import ChangeItem
 from security_monkey.datastore import Datastore
 from security_monkey.datastore import Account, AccountType, ItemAudit
@@ -158,7 +158,7 @@ class ResourcePolicyTestCase(SecurityMonkeyTestCase):
         rpa = ResourcePolicyAuditor(accounts=["012345678910"])
         # Policy class has no equivelance test at the moment.
         # Compare the underlying dicts instead
-        policies = [policy.policy for policy in rpa.load_policies(test_item)]
+        policies = [policy.policy for policy in rpa.load_resource_policies(test_item)]
         self.assertEqual([policy01], policies)
         
         
@@ -194,7 +194,7 @@ class ResourcePolicyTestCase(SecurityMonkeyTestCase):
                     })))
             
         rpa.policy_keys = ['Policies$Aliases$*', 'Policies$DEFAULT', 'Policies$Versions$*']
-        policies = [policy.policy for policy in rpa.load_policies(test_item)]
+        policies = [policy.policy for policy in rpa.load_resource_policies(test_item)]
         self.assertEqual([policy01, policy02, policy03, policy04], policies)
         
     def test_prep_for_audit(self):

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         'pyyaml==3.11',
         'jira==0.32',
         'cloudaux>=1.3.3',
-        'policyuniverse>=1.0.7.1',
+        'policyuniverse>=1.1.0.0',
         'joblib>=0.9.4',
         'pyjwt>=1.01',
         'netaddr',


### PR DESCRIPTION
Refactor IAM policy Auditor to use categories and PolicyUniverse parsing logic.

TODO:

- [x] - Update tests.
- [x] - Update IAM User Auditor to use Categories.
- [x] - Refactor `load_policies()` into auditor.py so that it doesn't need to be in both `iam_policy.py` and `resource_policy_auditor.py`
- [x] - Use PolicyUniverse's IAM Action Categories to create alerts.
- [x] - Deploy and verify proper function.

Depends on https://github.com/Netflix-Skunkworks/policyuniverse/pull/5

(Tests will likely break until that PR is merged and a new version pushed to pypi.)