### PR TITLE
Link ELB/ALB issues to related security groups where appropriate

### DIFF
--- a/dart/web/ui.html
+++ b/dart/web/ui.html
@@ -48,8 +48,7 @@
                     <a class="dropdown-toggle" data-toggle="dropdown">Internet Accessible <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                         <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Internet%20Accessible/1/25">Security Group</a></li>
-                        <li><a href="#/issues/-/elb/-/-/-/-/True/Internet%20Accessible/1/25">ELB</a></li>
-                        <li><a href="#/issues/-/alb/-/-/-/-/True/ALB%20is%20Internet%20accessible/1/25">ALB is Internet Accessible</a></li>
+                        <li><a href="#/issues/-/elb%2Calb/-/-/-/-/True/Internet%20Accessible/1/25">ELB/ALB</a></li>
                         <li class="divider"></li>
                         <li><a href="#/issues/-/elasticsearchservice%2Cglacier%2Ckms%2Clambda%2Crdssnapshot%2Cs3%2Csns%2Csqs%2Ciamrole/-/-/-/-/True/Internet%20Accessible/1/25">via Resource Policy</a></li>
                     </ul>
@@ -57,15 +56,13 @@
                 <li class="dropdown">
                     <a class="dropdown-toggle" data-toggle="dropdown">Cross Account <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="#/issues/-/alb/-/-/-/-/True/ALB%20accessible%20from%20non-private%20CIDR./1/25">ALB accessible from non-private CIDR.</a></li>
-                        <li class="divider"></li>
                         <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Unknown%20Access/1/25">Security Group Unknown Access</a></li>
                         <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Friendly%20Cross%20Account/1/25">Security Group Friendly Access</a></li>
                         <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Thirdparty%20Cross%20Account/1/25">Security Group Thirdparty Access</a></li>
                         <li class="divider"></li>
-                        <li><a href="#/issues/-/elb/-/-/-/-/True/Unknown%20Access/1/25">ELB Unknown Access</a></li>
-                        <li><a href="#/issues/-/elb/-/-/-/-/True/Friendly%20Cross%20Account/1/25">ELB Friendly Access</a></li>
-                        <li><a href="#/issues/-/elb/-/-/-/-/True/Thirdparty%20Cross%20Account/1/25">ELB Thirdparty Access</a></li>
+                        <li><a href="#/issues/-/elb%2Calb/-/-/-/-/True/Unknown%20Access/1/25">ELB/ALB Unknown Access</a></li>
+                        <li><a href="#/issues/-/elb%2Calb/-/-/-/-/True/Friendly%20Cross%20Account/1/25">ELB/ALB Friendly Access</a></li>
+                        <li><a href="#/issues/-/elb%2Calb/-/-/-/-/True/Thirdparty%20Cross%20Account/1/25">ELB/ALB Thirdparty Access</a></li>
                         <li class="divider"></li>
                         <li><a href="#/issues/-/elasticsearchservice%2Cglacier%2Ckms%2Clambda%2Crdssnapshot%2Cs3%2Csns%2Csqs%2Ciamrole/-/-/-/-/True/Unknown%20Access/1/25">Unknown Access via Resource Policy</a></li>
                         <li><a href="#/issues/-/elasticsearchservice%2Cglacier%2Ckms%2Clambda%2Crdssnapshot%2Cs3%2Csns%2Csqs%2Ciamrole/-/-/-/-/True/Friendly%20Cross%20Account/1/25">Friendly Access via Resource Policy</a></li>

--- a/dart/web/ui.html
+++ b/dart/web/ui.html
@@ -47,9 +47,8 @@
                 <li class="dropdown">
                     <a class="dropdown-toggle" data-toggle="dropdown">Internet Accessible <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Security%20Group%20ingress%20rule%20contains%200.0.0.0%2F0/1/25">Security Group Ingress 0.0.0.0/0</a></li>
-                        <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Security%20Group%20egress%20rule%20contains%200.0.0.0%2F0/1/25">Security Group Egress 0.0.0.0/0</a></li>
-                        <li><a href="#/issues/-/elb/-/-/-/-/True/VPC%20ELB%20is%20Internet%20accessible/1/25">VPC ELB is Internet Accessible</a></li>
+                        <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Internet%20Accessible/1/25">Security Group</a></li>
+                        <li><a href="#/issues/-/elb/-/-/-/-/True/Internet%20Accessible/1/25">ELB</a></li>
                         <li><a href="#/issues/-/alb/-/-/-/-/True/ALB%20is%20Internet%20accessible/1/25">ALB is Internet Accessible</a></li>
                         <li class="divider"></li>
                         <li><a href="#/issues/-/elasticsearchservice%2Cglacier%2Ckms%2Clambda%2Crdssnapshot%2Cs3%2Csns%2Csqs%2Ciamrole/-/-/-/-/True/Internet%20Accessible/1/25">via Resource Policy</a></li>
@@ -58,8 +57,15 @@
                 <li class="dropdown">
                     <a class="dropdown-toggle" data-toggle="dropdown">Cross Account <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="#/issues/-/elb/-/-/-/-/True/VPC%20ELB%20accessible%20from%20non-private%20CIDR./1/25">VPC ELB accessible from non-private CIDR.</a></li>
                         <li><a href="#/issues/-/alb/-/-/-/-/True/ALB%20accessible%20from%20non-private%20CIDR./1/25">ALB accessible from non-private CIDR.</a></li>
+                        <li class="divider"></li>
+                        <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Unknown%20Access/1/25">Security Group Unknown Access</a></li>
+                        <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Friendly%20Cross%20Account/1/25">Security Group Friendly Access</a></li>
+                        <li><a href="#/issues/-/securitygroup/-/-/-/-/True/Thirdparty%20Cross%20Account/1/25">Security Group Thirdparty Access</a></li>
+                        <li class="divider"></li>
+                        <li><a href="#/issues/-/elb/-/-/-/-/True/Unknown%20Access/1/25">ELB Unknown Access</a></li>
+                        <li><a href="#/issues/-/elb/-/-/-/-/True/Friendly%20Cross%20Account/1/25">ELB Friendly Access</a></li>
+                        <li><a href="#/issues/-/elb/-/-/-/-/True/Thirdparty%20Cross%20Account/1/25">ELB Thirdparty Access</a></li>
                         <li class="divider"></li>
                         <li><a href="#/issues/-/elasticsearchservice%2Cglacier%2Ckms%2Clambda%2Crdssnapshot%2Cs3%2Csns%2Csqs%2Ciamrole/-/-/-/-/True/Unknown%20Access/1/25">Unknown Access via Resource Policy</a></li>
                         <li><a href="#/issues/-/elasticsearchservice%2Cglacier%2Ckms%2Clambda%2Crdssnapshot%2Cs3%2Csns%2Csqs%2Ciamrole/-/-/-/-/True/Friendly%20Cross%20Account/1/25">Friendly Access via Resource Policy</a></li>

--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -92,10 +92,15 @@ class Categories:
     INSECURE_CONFIGURATION = 'Insecure Configuration'
     INSECURE_CONFIGURATION_NOTES = '{description}'
 
+    RECOMMENDATION = 'Recommendation'
+    RECOMMENDATION_NOTES = '{description}'
+
+    INSECURE_TLS = 'Insecure TLS'
+    INSECURE_TLS_NOTES = 'Policy: [{policy}] Port: [{port}] Reason: [{reason}]'
+    INSECURE_TLS_NOTES_2 = 'Policy: [{policy}] Port: [{port}] Reason: [{reason}] CVE: [{cve}]'
+
     # TODO
     # 	INSECURE_CERTIFICATE = 'Insecure Certificate'
-    # 	INSECURE_TLS = 'Insecure TLS'
-
 
 class Entity:
     """ Entity instances provide a place to map policy elements like s3:my_bucket to the related account. """

--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -96,8 +96,8 @@ class Categories:
     RECOMMENDATION_NOTES = '{description}'
 
     INSECURE_TLS = 'Insecure TLS'
-    INSECURE_TLS_NOTES = 'Policy: [{policy}] Port: [{port}] Reason: [{reason}]'
-    INSECURE_TLS_NOTES_2 = 'Policy: [{policy}] Port: [{port}] Reason: [{reason}] CVE: [{cve}]'
+    INSECURE_TLS_NOTES = 'Policy: [{policy}] Port: {port} Reason: [{reason}]'
+    INSECURE_TLS_NOTES_2 = 'Policy: [{policy}] Port: {port} Reason: [{reason}] CVE: [{cve}]'
 
     # TODO
     # 	INSECURE_CERTIFICATE = 'Insecure Certificate'

--- a/security_monkey/auditors/elb.py
+++ b/security_monkey/auditors/elb.py
@@ -150,6 +150,8 @@ class ELBAuditor(Auditor):
         protocol_and_ports = defaultdict(set)
         for listener in item.config.get('ListenerDescriptions', []):
             protocol = listener.get('Protocol')
+            if not protocol:
+                continue
             if protocol == '-1':
                 protocol = 'ALL_PROTOCOLS'
             elif 'HTTP' in protocol:
@@ -162,6 +164,9 @@ class ELBAuditor(Auditor):
         Verify issue is on a port for which the ELB contains a listener.
         Entity: [cidr:::/0] Access: [ingress:tcp:80]
         """
+        if not issue.notes:
+            return False
+
         protocol_and_ports = self._get_listener_ports_and_protocols(item)
         issue_regex = r'Entity: \[[^\]]+\] Access: \[(.+)\:(.+)\:(.+)\]'
         match = re.search(issue_regex, issue.notes)

--- a/security_monkey/auditors/elb.py
+++ b/security_monkey/auditors/elb.py
@@ -241,69 +241,122 @@ class ELBAuditor(Auditor):
         """
         logging = elb_item.config.get('Attributes', {}).get('AccessLog', {})
         if not logging:
-            self.add_issue(1, 'ELB is not configured for logging.', elb_item)
+            self.add_issue(1, Categories.RECOMMENDATION, elb_item, notes='Enable access logs')
             return
 
         if not logging.get('Enabled'):
-            self.add_issue(1, 'ELB is not configured for logging.', elb_item)
+            self.add_issue(1, Categories.RECOMMENDATION, elb_item, notes='Enable access logs')
             return
 
     def _process_reference_policy(self, reference_policy, policy_name, port, elb_item):
-        notes = "Policy {0} on port {1}".format(policy_name, port)
         if reference_policy is None:
-            self.add_issue(8, "Custom listener policies are discouraged.", elb_item, notes=notes)
+            notes = Categories.INSECURE_TLS_NOTES.format(
+                policy=policy_name, port=port,
+                reason="Custom listener policies discouraged")
+            self.add_issue(8, Categories.INSECURE_TLS, elb_item, notes=notes)
             return
 
         if reference_policy == 'ELBSecurityPolicy-2011-08':
-            self.add_issue(10, "ELBSecurityPolicy-2011-08 is vulnerable and deprecated", elb_item, notes=notes)
-            self.add_issue(10, "ELBSecurityPolicy-2011-08 is vulnerable to poodlebleed", elb_item, notes=notes)
-            self.add_issue(10, "ELBSecurityPolicy-2011-08 lacks server order cipher preference.", elb_item, notes=notes)
-            self.add_issue(10, "ELBSecurityPolicy-2011-08 contains RC4 ciphers "
-                           "(RC4-SHA) that have been removed in newer policies.", elb_item, notes=notes)
-            self.add_issue(5, "ELBSecurityPolicy-2011-08 contains a weaker cipher (DES-CBC3-SHA) "
-                           "for backwards compatibility with Windows XP systems. Vulnerable to SWEET32 CVE-2016-2183.", elb_item, notes=notes)
+            notes = Categories.INSECURE_TLS_NOTES.format(
+                policy=reference_policy, port=port,
+                reason="Vulnerable and deprecated")
+            self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
+
+            notes = Categories.INSECURE_TLS_NOTES.format(
+                policy=reference_policy, port=port,
+                reason="Vulnerable to poodlebleed")
+            self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
+
+            notes = Categories.INSECURE_TLS_NOTES.format(
+                policy=reference_policy, port=port,
+                reason="Lacks server order cipher preference")
+            self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
+
+            notes = Categories.INSECURE_TLS_NOTES.format(
+                policy=reference_policy, port=port,
+                reason="Contains RC4 ciphers (RC4-SHA)")
+            self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
+
+            notes = Categories.INSECURE_TLS_NOTES_2.format(
+                policy=reference_policy, port=port,
+                reason='Weak cipher (DES-CBC3-SHA) for Windows XP support',
+                cve='SWEET32 CVE-2016-2183')
+            self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
+
             return
 
         if reference_policy == 'ELBSecurityPolicy-2014-01':
             # Massively different cipher suite than 2011-08
             # Introduces Server Order Preference
-            self.add_issue(10, "ELBSecurityPolicy-2014-01 is vulnerable to poodlebleed", elb_item, notes=notes)
-            self.add_issue(5, "ELBSecurityPolicy-2014-01 uses diffie-hellman (DHE-DSS-AES1280SHA). "
-                           "Vulnerable to LOGJAM CVE-2015-4000.", elb_item, notes=notes)
-            self.add_issue(10, "ELBSecurityPolicy-2014-01 contains RC4 ciphers "
-                           "(ECDHE-RSA-RC4-SHA and RC4-SHA) that have been removed in newer policies.", elb_item, notes=notes)
+            notes = Categories.INSECURE_TLS_NOTES.format(
+                policy=reference_policy, port=port,
+                reason="Vulnerable to poodlebleed")
+            self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
+
+            notes = Categories.INSECURE_TLS_NOTES_2.format(
+                policy=reference_policy, port=port,
+                reason="Uses diffie-hellman (DHE-DSS-AES1280SHA)",
+                cve='LOGJAM CVE-2015-4000')
+            self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
+            
+            notes = Categories.INSECURE_TLS_NOTES.format(
+                policy=reference_policy, port=port,
+                reason="Contains RC4 ciphers (ECDHE-RSA-RC4-SHA and RC4-SHA)")
+            self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
             return
 
         if reference_policy == 'ELBSecurityPolicy-2014-10':
             # Dropped SSLv3 to stop Poodlebleed CVE-2014-3566
             # https://aws.amazon.com/security/security-bulletins/CVE-2014-3566-advisory/
-            self.add_issue(10, "ELBSecurityPolicy-2014-10 contains RC4 ciphers "
-                           "(ECDHE-RSA-RC4-SHA and RC4-SHA) that have been removed in newer policies.", elb_item, notes=notes)
-            self.add_issue(5, "ELBSecurityPolicy-2014-10 uses diffie-hellman (DHE-DSS-AES1280SHA). "
-                           "Vulnerable to LOGJAM CVE-2015-4000.", elb_item, notes=notes)
+            notes = Categories.INSECURE_TLS_NOTES.format(
+                policy=reference_policy, port=port,
+                reason="Contains RC4 ciphers (ECDHE-RSA-RC4-SHA and RC4-SHA)")
+            self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
+
+            notes = Categories.INSECURE_TLS_NOTES_2.format(
+                policy=reference_policy, port=port,
+                reason="Uses diffie-hellman (DHE-DSS-AES1280SHA)",
+                cve='LOGJAM CVE-2015-4000')
+            self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
+
             return
 
         if reference_policy == 'ELBSecurityPolicy-2015-02':
             # Yay! Dropped RC4, but broke Windows XP.
             # https://forums.aws.amazon.com/ann.jspa?annID=2877
-            self.add_issue(0, "ELBSecurityPolicy-2015-02 is not compatible with Windows XP systems.", elb_item, notes=notes)
-            self.add_issue(5, "ELBSecurityPolicy-2015-02 uses diffie-hellman (DHE-DSS-AES1280SHA). "
-                           "Vulnerable to LOGJAM CVE-2015-4000.", elb_item, notes=notes)
+            self.add_issue(0, Categories.INFORMATIONAL, elb_item, 
+                notes="ELBSecurityPolicy-2015-02 is not Windows XP compatible")
+
+            notes = Categories.INSECURE_TLS_NOTES.format(
+                policy=reference_policy, port=port,
+                reason="Uses diffie-hellman (DHE-DSS-AES1280SHA)",
+                cve='LOGJAM CVE-2015-4000')
+            self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
             return
 
         if reference_policy == 'ELBSecurityPolicy-2015-03':
             # Re-introduced DES-CBC3-SHA so Windows XP would work again.
-            self.add_issue(0, "ELBSecurityPolicy-2015-03 contains a weaker cipher (DES-CBC3-SHA) "
-                           "for backwards compatibility with Windows XP systems. Vulnerable to SWEET32 CVE-2016-2183.", elb_item, notes=notes)
-            self.add_issue(5, "ELBSecurityPolicy-2015-03 uses diffie-hellman (DHE-DSS-AES1280SHA). "
-                           "Vulnerable to LOGJAM CVE-2015-4000.", elb_item, notes=notes)
+            notes = Categories.INSECURE_TLS_NOTES_2.format(
+                policy=reference_policy, port=port,
+                reason='Weak cipher (DES-CBC3-SHA) for Windows XP support',
+                cve='SWEET32 CVE-2016-2183')
+            self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
+            
+            notes = Categories.INSECURE_TLS_NOTES_2.format(
+                policy=reference_policy, port=port,
+                reason="Uses diffie-hellman (DHE-DSS-AES1280SHA)",
+                cve='LOGJAM CVE-2015-4000')
+            self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
             return
 
         if reference_policy == 'ELBSecurityPolicy-2015-05':
             # Yay! - Removes diffie-hellman (DHE-DSS-AES128-SHA), likely to mitigate logjam CVE-2015-400
             # https://forums.aws.amazon.com/ann.jspa?annID=3061
-            self.add_issue(0, "ELBSecurityPolicy-2015-03 contains a weaker cipher (DES-CBC3-SHA) "
-                           "for backwards compatibility with Windows XP systems. Vulnerable to SWEET32 CVE-2016-2183", elb_item, notes=notes)
+            notes = Categories.INSECURE_TLS_NOTES_2.format(
+                policy=reference_policy, port=port,
+                reason='Weak cipher (DES-CBC3-SHA) for Windows XP support',
+                cve='SWEET32 CVE-2016-2183')
+            self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
             return
 
         if reference_policy == 'ELBSecurityPolicy-2016-08':
@@ -316,8 +369,8 @@ class ELBAuditor(Auditor):
             # https://forums.aws.amazon.com/ann.jspa?annID=4475
             return
 
-        notes = reference_policy
-        self.add_issue(10, "Unknown reference policy.", elb_item, notes=notes)
+        notes = Categories.INSECURE_TLS_NOTES.format(policy=reference_policy, port=port, reason='Unknown reference policy')
+        self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
     def _process_custom_listener_policy(self, policy_name, policy, port, elb_item):
         """
@@ -327,29 +380,43 @@ class ELBAuditor(Auditor):
             missing server order preference
             deprecated ciphers
         """
-        notes = "Policy {0} on port {1}".format(policy_name, port)
-
         if policy.get('protocols', {}).get('sslv2', None):
-            self.add_issue(10, "SSLv2 is enabled", elb_item, notes=notes)
+            notes = Categories.INSECURE_TLS_NOTES.format(
+                policy=policy_name, port=port,
+                reason='SSLv2 is enabled')
+            self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
         if policy.get('protocols', {}).get('sslv3', None):
-            self.add_issue(10, "SSLv3 is enabled", elb_item, notes=notes)
+            notes = Categories.INSECURE_TLS_NOTES.format(
+                policy=policy_name, port=port,
+                reason='SSLv3 is enabled')
+            self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
         server_defined_cipher_order = policy.get('server_defined_cipher_order', None)
         if server_defined_cipher_order is False:
-            self.add_issue(10, "Server Defined Cipher Order is Disabled.", elb_item, notes=notes)
+            notes = Categories.INSECURE_TLS_NOTES.format(
+                policy=policy_name, port=port,
+                reason="Server defined cipher order is disabled")
+            self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
         for cipher in policy['supported_ciphers']:
             if cipher in EXPORT_CIPHERS:
-                c_notes = "{0} - {1}".format(notes, cipher)
                 # CVE-2015-0204
                 # https://aws.amazon.com/security/security-bulletins/ssl-issue--freak-attack-/
-                self.add_issue(10, "Export Grade Cipher Used. Vuln to FREAK attack.", elb_item, notes=c_notes)
+                notes = Categories.INSECURE_TLS_NOTES_2.format(
+                    policy=policy_name, port=port,
+                    reason='Export grade cipher ({cipher})'.format(cipher=cipher),
+                    cve="FREAK CVE-2015-0204")
+                self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
             if cipher in DEPRECATED_CIPHERS:
-                c_notes = "{0} - {1}".format(notes, cipher)
-                self.add_issue(10, "Deprecated Cipher Used.", elb_item, notes=c_notes)
+                notes = Categories.INSECURE_TLS_NOTES.format(
+                    policy=policy_name, port=port,
+                    reason='Deprecated cipher ({cipher})'.format(cipher=cipher))
+                self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
             if cipher in NOTRECOMMENDED_CIPHERS:
-                c_notes = "{0} - {1}".format(notes, cipher)
-                self.add_issue(10, "Cipher Not Recommended.", elb_item, notes=c_notes)
+                notes = Categories.INSECURE_TLS_NOTES.format(
+                    policy=policy_name, port=port,
+                    reason='Cipher not recommended ({cipher})'.format(cipher=cipher))
+                self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)

--- a/security_monkey/auditors/elb.py
+++ b/security_monkey/auditors/elb.py
@@ -207,10 +207,10 @@ class ELBAuditor(Auditor):
         """
         alert when an ELB has an "internet-facing" scheme
         and a security group containing ingress issues on a listener port.
-        -   Friendly Cross Account Access
-        -   ThirdParty Cross Account Access
+        -   Friendly Cross Account
+        -   Thirdparty Cross Account
         -   Unknown Access
-        -   Internet Accessible (/0)
+        -   Internet Accessible
         """
         scheme = elb_item.config.get('Scheme', None)
         vpc = elb_item.config.get('VPCId', None)

--- a/security_monkey/auditors/elb.py
+++ b/security_monkey/auditors/elb.py
@@ -253,37 +253,37 @@ class ELBAuditor(Auditor):
             self.add_issue(1, Categories.RECOMMENDATION, elb_item, notes='Enable access logs')
             return
 
-    def _process_reference_policy(self, reference_policy, policy_name, port, elb_item):
+    def _process_reference_policy(self, reference_policy, policy_name, ports, elb_item):
         if reference_policy is None:
             notes = Categories.INSECURE_TLS_NOTES.format(
-                policy=policy_name, port=port,
+                policy=policy_name, port=ports,
                 reason="Custom listener policies discouraged")
             self.add_issue(8, Categories.INSECURE_TLS, elb_item, notes=notes)
             return
 
         if reference_policy == 'ELBSecurityPolicy-2011-08':
             notes = Categories.INSECURE_TLS_NOTES.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason="Vulnerable and deprecated")
             self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
             notes = Categories.INSECURE_TLS_NOTES.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason="Vulnerable to poodlebleed")
             self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
             notes = Categories.INSECURE_TLS_NOTES.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason="Lacks server order cipher preference")
             self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
             notes = Categories.INSECURE_TLS_NOTES.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason="Contains RC4 ciphers (RC4-SHA)")
             self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
             notes = Categories.INSECURE_TLS_NOTES_2.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason='Weak cipher (DES-CBC3-SHA) for Windows XP support',
                 cve='SWEET32 CVE-2016-2183')
             self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
@@ -294,18 +294,18 @@ class ELBAuditor(Auditor):
             # Massively different cipher suite than 2011-08
             # Introduces Server Order Preference
             notes = Categories.INSECURE_TLS_NOTES.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason="Vulnerable to poodlebleed")
             self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
             notes = Categories.INSECURE_TLS_NOTES_2.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason="Uses diffie-hellman (DHE-DSS-AES1280SHA)",
                 cve='LOGJAM CVE-2015-4000')
             self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
             
             notes = Categories.INSECURE_TLS_NOTES.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason="Contains RC4 ciphers (ECDHE-RSA-RC4-SHA and RC4-SHA)")
             self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
             return
@@ -314,12 +314,12 @@ class ELBAuditor(Auditor):
             # Dropped SSLv3 to stop Poodlebleed CVE-2014-3566
             # https://aws.amazon.com/security/security-bulletins/CVE-2014-3566-advisory/
             notes = Categories.INSECURE_TLS_NOTES.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason="Contains RC4 ciphers (ECDHE-RSA-RC4-SHA and RC4-SHA)")
             self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
             notes = Categories.INSECURE_TLS_NOTES_2.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason="Uses diffie-hellman (DHE-DSS-AES1280SHA)",
                 cve='LOGJAM CVE-2015-4000')
             self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
@@ -333,7 +333,7 @@ class ELBAuditor(Auditor):
                 notes="ELBSecurityPolicy-2015-02 is not Windows XP compatible")
 
             notes = Categories.INSECURE_TLS_NOTES.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason="Uses diffie-hellman (DHE-DSS-AES1280SHA)",
                 cve='LOGJAM CVE-2015-4000')
             self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
@@ -342,13 +342,13 @@ class ELBAuditor(Auditor):
         if reference_policy == 'ELBSecurityPolicy-2015-03':
             # Re-introduced DES-CBC3-SHA so Windows XP would work again.
             notes = Categories.INSECURE_TLS_NOTES_2.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason='Weak cipher (DES-CBC3-SHA) for Windows XP support',
                 cve='SWEET32 CVE-2016-2183')
             self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
             
             notes = Categories.INSECURE_TLS_NOTES_2.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason="Uses diffie-hellman (DHE-DSS-AES1280SHA)",
                 cve='LOGJAM CVE-2015-4000')
             self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
@@ -358,7 +358,7 @@ class ELBAuditor(Auditor):
             # Yay! - Removes diffie-hellman (DHE-DSS-AES128-SHA), likely to mitigate logjam CVE-2015-400
             # https://forums.aws.amazon.com/ann.jspa?annID=3061
             notes = Categories.INSECURE_TLS_NOTES_2.format(
-                policy=reference_policy, port=port,
+                policy=reference_policy, port=ports,
                 reason='Weak cipher (DES-CBC3-SHA) for Windows XP support',
                 cve='SWEET32 CVE-2016-2183')
             self.add_issue(5, Categories.INSECURE_TLS, elb_item, notes=notes)
@@ -374,10 +374,10 @@ class ELBAuditor(Auditor):
             # https://forums.aws.amazon.com/ann.jspa?annID=4475
             return
 
-        notes = Categories.INSECURE_TLS_NOTES.format(policy=reference_policy, port=port, reason='Unknown reference policy')
+        notes = Categories.INSECURE_TLS_NOTES.format(policy=reference_policy, port=ports, reason='Unknown reference policy')
         self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
-    def _process_custom_listener_policy(self, policy_name, policy, port, elb_item):
+    def _process_custom_listener_policy(self, policy_name, policy, ports, elb_item):
         """
         Alerts on:
             sslv2
@@ -387,20 +387,20 @@ class ELBAuditor(Auditor):
         """
         if policy.get('protocols', {}).get('sslv2', None):
             notes = Categories.INSECURE_TLS_NOTES.format(
-                policy=policy_name, port=port,
+                policy=policy_name, port=ports,
                 reason='SSLv2 is enabled')
             self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
         if policy.get('protocols', {}).get('sslv3', None):
             notes = Categories.INSECURE_TLS_NOTES.format(
-                policy=policy_name, port=port,
+                policy=policy_name, port=ports,
                 reason='SSLv3 is enabled')
             self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
         server_defined_cipher_order = policy.get('server_defined_cipher_order', None)
         if server_defined_cipher_order is False:
             notes = Categories.INSECURE_TLS_NOTES.format(
-                policy=policy_name, port=port,
+                policy=policy_name, port=ports,
                 reason="Server defined cipher order is disabled")
             self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
@@ -409,19 +409,19 @@ class ELBAuditor(Auditor):
                 # CVE-2015-0204
                 # https://aws.amazon.com/security/security-bulletins/ssl-issue--freak-attack-/
                 notes = Categories.INSECURE_TLS_NOTES_2.format(
-                    policy=policy_name, port=port,
+                    policy=policy_name, port=ports,
                     reason='Export grade cipher ({cipher})'.format(cipher=cipher),
                     cve="FREAK CVE-2015-0204")
                 self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
             if cipher in DEPRECATED_CIPHERS:
                 notes = Categories.INSECURE_TLS_NOTES.format(
-                    policy=policy_name, port=port,
+                    policy=policy_name, port=ports,
                     reason='Deprecated cipher ({cipher})'.format(cipher=cipher))
                 self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)
 
             if cipher in NOTRECOMMENDED_CIPHERS:
                 notes = Categories.INSECURE_TLS_NOTES.format(
-                    policy=policy_name, port=port,
+                    policy=policy_name, port=ports,
                     reason='Cipher not recommended ({cipher})'.format(cipher=cipher))
                 self.add_issue(10, Categories.INSECURE_TLS, elb_item, notes=notes)

--- a/security_monkey/auditors/elbv2.py
+++ b/security_monkey/auditors/elbv2.py
@@ -25,7 +25,9 @@ from security_monkey.watchers.security_group import SecurityGroup
 from security_monkey.common.utils import check_rfc_1918
 from security_monkey.datastore import NetworkWhitelistEntry
 
+from collections import defaultdict
 import ipaddr
+import re
 
 
 class ELBv2Auditor(Auditor):
@@ -33,7 +35,8 @@ class ELBv2Auditor(Auditor):
     i_am_singular = ELBv2.i_am_singular
     i_am_plural = ELBv2.i_am_plural
     network_whitelist = []
-    support_watcher_indexes = [SecurityGroup.index]
+    # support_watcher_indexes = [SecurityGroup.index]
+    support_auditor_indexes = [SecurityGroup.index]
 
     def __init__(self, accounts=None, debug=False):
         super(ELBv2Auditor, self).__init__(accounts=accounts, debug=debug)
@@ -46,41 +49,73 @@ class ELBv2Auditor(Auditor):
             if ipaddr.IPNetwork(cidr) in ipaddr.IPNetwork(str(entry.cidr)):
                 return True
         return False
-    
+
+    def _get_listener_ports_and_protocols(self, item):
+        """
+        "Listeners": [
+            {
+              "Protocol": "HTTP",
+              "Port": 80,
+            }
+          ],
+        """
+        protocol_and_ports = defaultdict(set)
+        for listener in item.config.get('Listeners', []):
+            protocol = listener.get('Protocol')
+            if protocol == '-1':
+                protocol = 'all_protocols'
+            elif 'HTTP' in protocol:
+                protocol = 'tcp'
+            protocol_and_ports[protocol].add(listener.get('Port'))
+        return protocol_and_ports
+
+    def _issue_matches_listeners(self, item, issue):
+        """
+        Verify issue is on a port for which the ALB contains a listener.
+        Entity: [cidr:::/0] Access: [ingress:tcp:80]
+        """
+        protocol_and_ports = self._get_listener_ports_and_protocols(item)
+        issue_regex = r'Entity: \[[^\]]+\] Access: \[(.+)\:(.+)\:(.+)\]'
+        match = re.search(issue_regex, issue.notes)
+        if not match:
+            return False
+
+        direction = match.group(1)
+        protocol = match.group(2)
+        port = match.group(3)
+
+        listener_ports = protocol_and_ports.get(protocol, [])
+
+        if direction != 'ingress':
+            return False
+
+        if protocol == 'all_protocols':
+            return True
+
+        match = re.search(r'(\d+)-(\d+)', port)
+        if match:
+            from_port = int(match.group(1))
+            to_port = int(match.group(2))
+        else:
+            from_port = to_port = int(port)
+
+        for listener_port in listener_ports:
+            if int(listener_port) >= from_port and int(listener_port) <= to_port:
+                return True
+        return False
+
     def check_internet_facing(self, alb):
         scheme = alb.config.get('Scheme')
         if scheme == 'internet-facing':
-            # Grab each attached security group and determine if they contain
-            # a public IP
-            security_groups = alb.config.get('SecurityGroups', [])
-            sg_items = self.get_watcher_support_items(SecurityGroup.index, alb.account)
-            for sgid in security_groups:
-                for sg in sg_items:
-                    if sg.config.get('id') == sgid:
-                        sg_cidrs = set()
-                        internet_accessible_cidrs = set()
-                        for rule in sg.config.get('rules', []):
-                            cidr = rule.get('cidr_ip', '')
+            security_group_ids = set(alb.config.get('SecurityGroups', []))
+            sg_auditor_items = self.get_auditor_support_items(SecurityGroup.index, alb.account)
+            security_auditor_groups = [sg for sg in sg_auditor_items if sg.config.get('id') in security_group_ids]
 
-                            if rule.get('rule_type', None) == 'ingress' and cidr:
-                                if cidr.endswith('/0'):
-                                    internet_accessible_cidrs.add(cidr)
-                                elif not check_rfc_1918(cidr) and not self._check_inclusion_in_network_whitelist(cidr):
-                                    sg_cidrs.add(cidr)
-
-                        if sg_cidrs:
-                            notes = 'SG [{sgname}] via [{cidr}]'.format(
-                                sgname=sg.name,
-                                cidr=', '.join(sg_cidrs))
-                            self.add_issue(1, 'ALB accessible from non-private CIDR.', alb, notes=notes)
-
-                        if internet_accessible_cidrs:
-                            notes = 'SG [{sgname}] via [{cidr}]'.format(
-                                sgname=sg.name,
-                                cidr=', '.join(internet_accessible_cidrs))
-                            self.add_issue(1, 'ALB is Internet accessible.', alb, notes=notes)
-
-                        break
+            for sg in security_auditor_groups:
+                for issue in sg.db_item.issues:
+                    if self._issue_matches_listeners(alb, issue):
+                        self.link_to_support_item_issues(alb, sg.db_item,
+                            sub_issue_message=issue.issue, score=issue.score)
 
     def check_logging(self, alb):
         attributes = alb.config.get('Attributes', [])

--- a/security_monkey/auditors/elbv2.py
+++ b/security_monkey/auditors/elbv2.py
@@ -145,14 +145,16 @@ class ELBv2Auditor(Auditor):
             'ELBSecurityPolicy-TLS-1-0-2015-04'])
 
         for listener in alb.config.get('Listeners', []):
-            port = listener.get('Port')
+            port = '['+str(listener.get('Port'))+']'
             ssl_policy = listener.get('SslPolicy')
             if not ssl_policy:
                 continue
 
             if ssl_policy == 'ELBSecurityPolicy-TLS-1-0-2015-04':
-                notes = Categories.INSECURE_TLS_NOTES.format(policy=ssl_policy, port=port,
-                    reason='Weak cipher (DES-CBC3-SHA) for Windows XP support. Vulnerable to SWEET32 CVE-2016-2183.')
+                notes = Categories.INSECURE_TLS_NOTES_2.format(
+                    policy=ssl_policy, port=port,
+                    reason='Weak cipher (DES-CBC3-SHA) for Windows XP support',
+                    cve='SWEET32 CVE-2016-2183')
                 self.add_issue(5, Categories.INSECURE_TLS, alb, notes=notes)
 
             if ssl_policy not in supported_ssl_policies:

--- a/security_monkey/auditors/elbv2.py
+++ b/security_monkey/auditors/elbv2.py
@@ -51,6 +51,8 @@ class ELBv2Auditor(Auditor):
         protocol_and_ports = defaultdict(set)
         for listener in item.config.get('Listeners', []):
             protocol = listener.get('Protocol')
+            if not protocol:
+                continue
             if protocol == '-1':
                 protocol = 'ALL_PROTOCOLS'
             elif 'HTTP' in protocol:
@@ -63,6 +65,9 @@ class ELBv2Auditor(Auditor):
         Verify issue is on a port for which the ALB contains a listener.
         Entity: [cidr:::/0] Access: [ingress:tcp:80]
         """
+        if not issue.notes:
+            return False
+
         protocol_and_ports = self._get_listener_ports_and_protocols(item)
         issue_regex = r'Entity: \[[^\]]+\] Access: \[(.+)\:(.+)\:(.+)\]'
         match = re.search(issue_regex, issue.notes)

--- a/security_monkey/tests/auditors/test_elb.py
+++ b/security_monkey/tests/auditors/test_elb.py
@@ -337,13 +337,13 @@ class ELBTestCase(SecurityMonkeyTestCase):
         item = CloudAuxChangeItem(index='elb', account='TEST_ACCOUNT', name='MyELB', 
             arn=ARN_PREFIX + ":elasticloadbalancing:" + AWS_DEFAULT_REGION + ":012345678910:loadbalancer/MyELB", config=INTERNET_ELB)
 
-        auditor._process_reference_policy(None, 'MyCustomPolicy', '443', item)
+        auditor._process_reference_policy(None, 'MyCustomPolicy', '[443]', item)
         self.assertEqual(len(item.audit_issues), 1)
         self.assertEqual(item.audit_issues[0].issue, 'Insecure TLS')
         self.assertEqual(item.audit_issues[0].notes, 'Policy: [MyCustomPolicy] Port: [443] Reason: [Custom listener policies discouraged]')
 
         item.audit_issues = list()
-        auditor._process_reference_policy('ELBSecurityPolicy-2011-08', 'MyCustomPolicy', '443', item)
+        auditor._process_reference_policy('ELBSecurityPolicy-2011-08', 'MyCustomPolicy', '[443]', item)
         self.assertEqual(len(item.audit_issues), 5)
         issues = {issue.issue for issue in item.audit_issues}
         notes = {issue.notes for issue in item.audit_issues}
@@ -355,39 +355,39 @@ class ELBTestCase(SecurityMonkeyTestCase):
         self.assertIn('Policy: [ELBSecurityPolicy-2011-08] Port: [443] Reason: [Weak cipher (DES-CBC3-SHA) for Windows XP support] CVE: [SWEET32 CVE-2016-2183]', notes)
 
         item.audit_issues = list()
-        auditor._process_reference_policy('ELBSecurityPolicy-2014-01', 'MyCustomPolicy', '443', item)
+        auditor._process_reference_policy('ELBSecurityPolicy-2014-01', 'MyCustomPolicy', '[443]', item)
         self.assertEqual(len(item.audit_issues), 3)
 
         item.audit_issues = list()
-        auditor._process_reference_policy('ELBSecurityPolicy-2014-10', 'MyCustomPolicy', '443', item)
+        auditor._process_reference_policy('ELBSecurityPolicy-2014-10', 'MyCustomPolicy', '[443]', item)
         self.assertEqual(len(item.audit_issues), 2)
 
         item.audit_issues = list()
-        auditor._process_reference_policy('ELBSecurityPolicy-2015-02', 'MyCustomPolicy', '443', item)
+        auditor._process_reference_policy('ELBSecurityPolicy-2015-02', 'MyCustomPolicy', '[443]', item)
         self.assertEqual(len(item.audit_issues), 2)
 
         item.audit_issues = list()
-        auditor._process_reference_policy('ELBSecurityPolicy-2015-03', 'MyCustomPolicy', '443', item)
+        auditor._process_reference_policy('ELBSecurityPolicy-2015-03', 'MyCustomPolicy', '[443]', item)
         self.assertEqual(len(item.audit_issues), 2)
 
         item.audit_issues = list()
-        auditor._process_reference_policy('ELBSecurityPolicy-2015-05', 'MyCustomPolicy', '443', item)
+        auditor._process_reference_policy('ELBSecurityPolicy-2015-05', 'MyCustomPolicy', '[443]', item)
         self.assertEqual(len(item.audit_issues), 1)
 
         item.audit_issues = list()
-        auditor._process_reference_policy('ELBSecurityPolicy-2016-08', 'MyCustomPolicy', '443', item)
+        auditor._process_reference_policy('ELBSecurityPolicy-2016-08', 'MyCustomPolicy', '[443]', item)
         self.assertEqual(len(item.audit_issues), 0)
 
         item.audit_issues = list()
-        auditor._process_reference_policy('ELBSecurityPolicy-TLS-1-1-2017-01', 'MyCustomPolicy', '443', item)
+        auditor._process_reference_policy('ELBSecurityPolicy-TLS-1-1-2017-01', 'MyCustomPolicy', '[443]', item)
         self.assertEqual(len(item.audit_issues), 0)
 
         item.audit_issues = list()
-        auditor._process_reference_policy('ELBSecurityPolicy-TLS-1-2-2017-01', 'MyCustomPolicy', '443', item)
+        auditor._process_reference_policy('ELBSecurityPolicy-TLS-1-2-2017-01', 'MyCustomPolicy', '[443]', item)
         self.assertEqual(len(item.audit_issues), 0)
 
         item.audit_issues = list()
-        auditor._process_reference_policy('OTHER_REFERENCE_POLICY', 'MyCustomPolicy', '443', item)
+        auditor._process_reference_policy('OTHER_REFERENCE_POLICY', 'MyCustomPolicy', '[443]', item)
         self.assertEqual(len(item.audit_issues), 1)
         self.assertEqual(item.audit_issues[0].issue, 'Insecure TLS')
         self.assertEqual(item.audit_issues[0].notes, 'Policy: [OTHER_REFERENCE_POLICY] Port: [443] Reason: [Unknown reference policy]')
@@ -403,35 +403,35 @@ class ELBTestCase(SecurityMonkeyTestCase):
         # We'll just modify it and pretend it's a custom policy
         policy = dict(INTERNET_ELB['PolicyDescriptions']['ELBSecurityPolicy-2016-08'])
 
-        auditor._process_custom_listener_policy('ELBSecurityPolicy-2016-08', policy, '443', item)
+        auditor._process_custom_listener_policy('ELBSecurityPolicy-2016-08', policy, '[443]', item)
         self.assertEqual(len(item.audit_issues), 1)
 
         item.audit_issues = list()
         policy['protocols']['sslv2'] = True
-        auditor._process_custom_listener_policy('ELBSecurityPolicy-2016-08', policy, '443', item)
+        auditor._process_custom_listener_policy('ELBSecurityPolicy-2016-08', policy, '[443]', item)
         self.assertEqual(len(item.audit_issues), 2)
 
         item.audit_issues = list()
         policy['server_defined_cipher_order'] = False
-        auditor._process_custom_listener_policy('ELBSecurityPolicy-2016-08', policy, '443', item)
+        auditor._process_custom_listener_policy('ELBSecurityPolicy-2016-08', policy, '[443]', item)
         self.assertEqual(len(item.audit_issues), 3)
 
         # simulate export grade
         item.audit_issues = list()
         policy['supported_ciphers'].append('EXP-RC4-MD5')
-        auditor._process_custom_listener_policy('ELBSecurityPolicy-2016-08', policy, '443', item)
+        auditor._process_custom_listener_policy('ELBSecurityPolicy-2016-08', policy, '[443]', item)
         self.assertEqual(len(item.audit_issues), 4)
 
         # simulate deprecated cipher 
         item.audit_issues = list()
         policy['supported_ciphers'].append('RC2-CBC-MD5')
-        auditor._process_custom_listener_policy('ELBSecurityPolicy-2016-08', policy, '443', item)
+        auditor._process_custom_listener_policy('ELBSecurityPolicy-2016-08', policy, '[443]', item)
         self.assertEqual(len(item.audit_issues), 5)
 
         # simulate not-recommended cipher
         item.audit_issues = list()
         policy['supported_ciphers'].append('CAMELLIA128-SHA')
-        auditor._process_custom_listener_policy('ELBSecurityPolicy-2016-08', policy, '443', item)
+        auditor._process_custom_listener_policy('ELBSecurityPolicy-2016-08', policy, '[443]', item)
         self.assertEqual(len(item.audit_issues), 6)
 
     def test_check_listener_reference_policy(self):

--- a/security_monkey/tests/auditors/test_elbv2.py
+++ b/security_monkey/tests/auditors/test_elbv2.py
@@ -114,7 +114,8 @@ class ELBv2TestCase(SecurityMonkeyTestCase):
         auditor.check_logging(item)
         self.assertEqual(len(item.audit_issues), 1)
         issue = item.audit_issues[0]
-        self.assertEqual(issue.issue, 'ALB is not configured for logging.')
+        self.assertEqual(issue.issue, 'Recommendation')
+        self.assertEqual(issue.notes, 'Enable access logs')
 
     def test_check_deletion_protection(self):
         from security_monkey.auditors.elbv2 import ELBv2Auditor
@@ -137,7 +138,8 @@ class ELBv2TestCase(SecurityMonkeyTestCase):
         auditor.check_deletion_protection(item)
         self.assertEqual(len(item.audit_issues), 1)
         issue = item.audit_issues[0]
-        self.assertEqual(issue.issue, 'ALB is not configured for deletion protection.')
+        self.assertEqual(issue.issue, 'Recommendation')
+        self.assertEqual(issue.notes,  'Enable deletion protection')
 
     def test_check_ssl_policy_no_policy(self):
         from security_monkey.auditors.elbv2 import ELBv2Auditor
@@ -170,10 +172,8 @@ class ELBv2TestCase(SecurityMonkeyTestCase):
         auditor.check_ssl_policy(item)
         self.assertEqual(len(item.audit_issues), 1)
         issue = item.audit_issues[0]
-        self.assertEqual(issue.issue,
-            'ELBSecurityPolicy-TLS-1-0-2015-04 contains a weaker cipher (DES-CBC3-SHA) for backwards compatibility with Windows XP systems. Vulnerable to SWEET32 CVE-2016-2183.')
-        self.assertEqual(issue.notes,
-            'Policy ELBSecurityPolicy-TLS-1-0-2015-04 on port 443')
+        self.assertEqual(issue.issue, 'Insecure TLS')
+        self.assertEqual(issue.notes, 'Policy: [ELBSecurityPolicy-TLS-1-0-2015-04] Port: [443] Reason: [Weak cipher (DES-CBC3-SHA) for Windows XP support. Vulnerable to SWEET32 CVE-2016-2183.]')
 
         item.audit_issues = []
         item.new_config = {
@@ -185,5 +185,5 @@ class ELBv2TestCase(SecurityMonkeyTestCase):
         auditor.check_ssl_policy(item)
         self.assertEqual(len(item.audit_issues), 1)
         issue = item.audit_issues[0]
-        self.assertEqual(issue.issue, 'Unknown reference policy.')
-        self.assertEqual(issue.notes, 'ELBSecurityPolicy-DoesntExist')
+        self.assertEqual(issue.issue, 'Insecure TLS')
+        self.assertEqual(issue.notes, 'Policy: [ELBSecurityPolicy-DoesntExist] Port: [443] Reason: [Unknown reference policy]')

--- a/security_monkey/tests/auditors/test_elbv2.py
+++ b/security_monkey/tests/auditors/test_elbv2.py
@@ -173,7 +173,7 @@ class ELBv2TestCase(SecurityMonkeyTestCase):
         self.assertEqual(len(item.audit_issues), 1)
         issue = item.audit_issues[0]
         self.assertEqual(issue.issue, 'Insecure TLS')
-        self.assertEqual(issue.notes, 'Policy: [ELBSecurityPolicy-TLS-1-0-2015-04] Port: [443] Reason: [Weak cipher (DES-CBC3-SHA) for Windows XP support. Vulnerable to SWEET32 CVE-2016-2183.]')
+        self.assertEqual(issue.notes, 'Policy: [ELBSecurityPolicy-TLS-1-0-2015-04] Port: [443] Reason: [Weak cipher (DES-CBC3-SHA) for Windows XP support] CVE: [SWEET32 CVE-2016-2183]')
 
         item.audit_issues = []
         item.new_config = {

--- a/security_monkey/tests/auditors/test_elbv2.py
+++ b/security_monkey/tests/auditors/test_elbv2.py
@@ -1,0 +1,189 @@
+from security_monkey.datastore import Account, AccountType
+from security_monkey.tests import SecurityMonkeyTestCase
+from security_monkey import db, AWS_DEFAULT_REGION, ARN_PREFIX
+
+
+class ELBv2TestCase(SecurityMonkeyTestCase):
+    def pre_test_setup(self):
+        pass
+
+    def test_check_internet_facing(self):
+        # internet-facing
+        # 0.0.0.0/0
+        from security_monkey.auditors.elbv2 import ELBv2Auditor
+        auditor = ELBv2Auditor(accounts=["012345678910"])
+        
+        alb = {
+            'Scheme': 'internet-facing',
+            'SecurityGroups': ['sg-12345678'],
+            'Listeners': [
+                {
+                    'Protocol': "HTTP",
+                    'Port': 80
+                }]
+        }
+
+        from security_monkey.cloudaux_watcher import CloudAuxChangeItem
+        item = CloudAuxChangeItem(
+            index='alb',
+            account='TEST_ACCOUNT',
+            name='MyELB', 
+            arn=ARN_PREFIX + ":elasticloadbalancing:" + AWS_DEFAULT_REGION + ":012345678910:loadbalancer/MyELB",
+            config=alb)
+
+        def mock_get_auditor_support_items(*args, **kwargs):
+            class MockIngressIssue:
+                issue = 'Internet Accessible'
+                notes = 'Entity: [cidr:0.0.0.0/0] Access: [ingress:tcp:80]'
+                score = 10
+            
+            class MockIngressAllProtocolsIssue(MockIngressIssue):
+                notes = 'Entity: [cidr:0.0.0.0/0] Access: [ingress:all_protocols:all_ports]'
+
+            class MockIngressPortRangeIssue(MockIngressIssue):
+                notes = 'Entity: [cidr:0.0.0.0/0] Access: [ingress:tcp:77-1023]'
+
+            class MockEgressIssue(MockIngressIssue):
+                notes = 'Entity: [cidr:0.0.0.0/0] Access: [egress:tcp:80]'
+
+            class MockPortNotListenerPortIssue(MockIngressIssue):
+                notes = 'Entity: [cidr:0.0.0.0/0] Access: [ingress:tcp:66555]'
+
+            class MockNonConformingIssue(MockIngressIssue):
+                notes = 'Some random rule.'
+
+            class DBItem:
+                issues = list()
+
+            from security_monkey.watchers.security_group import SecurityGroupItem
+            sg_item = SecurityGroupItem(
+                region=AWS_DEFAULT_REGION,
+                account='TEST_ACCOUNT',
+                name='INTERNETSG',
+                config={
+                    'id': 'sg-12345678',
+                    'name': 'INTERNETSG',
+                    'rules': [
+                        {
+                            'cidr_ip': '0.0.0.0/0',
+                            'rule_type': 'ingress',
+                            'port': 80
+                        }
+                    ]
+                })
+
+            sg_item.db_item = DBItem()
+            sg_item.db_item.issues = [
+                MockIngressIssue(), MockIngressAllProtocolsIssue(), MockEgressIssue(),
+                MockNonConformingIssue(), MockPortNotListenerPortIssue(),
+                MockIngressPortRangeIssue()]
+            return [sg_item]
+
+        def mock_link_to_support_item_issues(item, sg, sub_issue_message, score):
+            auditor.add_issue(score, sub_issue_message, item, notes='Related to: INTERNETSG (sg-12345678 in vpc-49999999)')
+
+        auditor.get_auditor_support_items = mock_get_auditor_support_items
+        auditor.link_to_support_item_issues = mock_link_to_support_item_issues
+
+        auditor.check_internet_facing(item)
+
+        self.assertEqual(len(item.audit_issues), 1)
+        issue = item.audit_issues[0]
+        self.assertEqual(issue.issue, 'Internet Accessible')
+        self.assertEqual(issue.notes, 'Related to: INTERNETSG (sg-12345678 in vpc-49999999)')
+
+
+    def test_check_logging(self):
+        from security_monkey.auditors.elbv2 import ELBv2Auditor
+        auditor = ELBv2Auditor(accounts=['012345678910'])
+
+        alb = {
+            'Attributes': [{
+                'Key': 'access_logs.s3.enabled',
+                'Value': 'false'
+            }]}
+
+        from security_monkey.cloudaux_watcher import CloudAuxChangeItem
+        item = CloudAuxChangeItem(
+            index='alb',
+            account='TEST_ACCOUNT',
+            name='MyALB', 
+            arn=ARN_PREFIX + ":elasticloadbalancing:" + AWS_DEFAULT_REGION + ":012345678910:loadbalancer/app/MyALB/7f734113942",
+            config=alb)
+
+        auditor.check_logging(item)
+        self.assertEqual(len(item.audit_issues), 1)
+        issue = item.audit_issues[0]
+        self.assertEqual(issue.issue, 'ALB is not configured for logging.')
+
+    def test_check_deletion_protection(self):
+        from security_monkey.auditors.elbv2 import ELBv2Auditor
+        auditor = ELBv2Auditor(accounts=['012345678910'])
+
+        alb = {
+            'Attributes': [{
+                'Key': 'deletion_protection.enabled',
+                'Value': 'false'
+            }]}
+
+        from security_monkey.cloudaux_watcher import CloudAuxChangeItem
+        item = CloudAuxChangeItem(
+            index='alb',
+            account='TEST_ACCOUNT',
+            name='MyALB', 
+            arn=ARN_PREFIX + ":elasticloadbalancing:" + AWS_DEFAULT_REGION + ":012345678910:loadbalancer/app/MyALB/7f734113942",
+            config=alb)
+
+        auditor.check_deletion_protection(item)
+        self.assertEqual(len(item.audit_issues), 1)
+        issue = item.audit_issues[0]
+        self.assertEqual(issue.issue, 'ALB is not configured for deletion protection.')
+
+    def test_check_ssl_policy_no_policy(self):
+        from security_monkey.auditors.elbv2 import ELBv2Auditor
+        auditor = ELBv2Auditor(accounts=['012345678910'])
+
+        alb = {
+            'Listeners': [{
+                'Port': 80,
+                'SslPolicy': None
+            }]}
+            
+
+        from security_monkey.cloudaux_watcher import CloudAuxChangeItem
+        item = CloudAuxChangeItem(
+            index='alb',
+            account='TEST_ACCOUNT',
+            name='MyALB', 
+            arn=ARN_PREFIX + ":elasticloadbalancing:" + AWS_DEFAULT_REGION + ":012345678910:loadbalancer/app/MyALB/7f734113942",
+            config=alb)
+
+        auditor.check_ssl_policy(item)
+        self.assertEqual(len(item.audit_issues), 0)
+
+        item.new_config = {
+            'Listeners': [{
+                'Port': 443,
+                'SslPolicy': 'ELBSecurityPolicy-TLS-1-0-2015-04'
+            }]}
+
+        auditor.check_ssl_policy(item)
+        self.assertEqual(len(item.audit_issues), 1)
+        issue = item.audit_issues[0]
+        self.assertEqual(issue.issue,
+            'ELBSecurityPolicy-TLS-1-0-2015-04 contains a weaker cipher (DES-CBC3-SHA) for backwards compatibility with Windows XP systems. Vulnerable to SWEET32 CVE-2016-2183.')
+        self.assertEqual(issue.notes,
+            'Policy ELBSecurityPolicy-TLS-1-0-2015-04 on port 443')
+
+        item.audit_issues = []
+        item.new_config = {
+            'Listeners': [{
+                'Port': 443,
+                'SslPolicy': 'ELBSecurityPolicy-DoesntExist'
+            }]}
+
+        auditor.check_ssl_policy(item)
+        self.assertEqual(len(item.audit_issues), 1)
+        issue = item.audit_issues[0]
+        self.assertEqual(issue.issue, 'Unknown reference policy.')
+        self.assertEqual(issue.notes, 'ELBSecurityPolicy-DoesntExist')


### PR DESCRIPTION
ELBs and ALBs should link to their security groups where appropriate.

This will allow ELBs/ALBs to show issues for `Internet Accessible`, `Friendly Cross Account`, `Thirdparty Cross Account`, and `Unknown Access`.

The UI dropdowns have been updated accordingly.

TODO:
- [x] Make tests pass
- [x] Test new methods
- [x] Update other elb/alb issues to use issue categories
