### PR TITLE
Only require account_type specific dependencies be installed

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -94,7 +94,7 @@ Releases are on the master branch and are updated about every three months. Blee
     pip install --upgrade urllib3[secure]   # to prevent InsecurePlatformWarning
     pip install google-compute-engine  # Only required on GCP
     pip install cloudaux\[gcp\]
-    pip install cloudaux\[openstack\]
+    pip install cloudaux\[openstack\]    # Only required on OpenStack
     python setup.py develop
     
 ### 🚨⚠️🥁🎺 ULTRA SUPER IMPORTANT SPECIAL NOTE PLEASE READ THIS 🎺🥁⚠️🚨 ###

--- a/security_monkey/common/utils.py
+++ b/security_monkey/common/utils.py
@@ -134,8 +134,12 @@ def find_modules(folder):
         for fname in files:
             if os.path.splitext(fname)[-1] == '.py':
                 modname = os.path.splitext(fname)[0]
-                app.logger.debug("Loading module %s from %s", modname, os.path.join(root,fname))
-                module=imp.load_source(modname, os.path.join(root,fname))
+                try:
+                    module=imp.load_source(modname, os.path.join(root,fname))
+                except ImportError:
+                    app.logger.info("Failed to load module %s from %s", modname, os.path.join(root,fname))
+                else:
+                    app.logger.info("Loaded module %s from %s", modname, os.path.join(root,fname))
 
 
 def load_plugins(group):

--- a/security_monkey/common/utils.py
+++ b/security_monkey/common/utils.py
@@ -137,9 +137,9 @@ def find_modules(folder):
                 try:
                     module=imp.load_source(modname, os.path.join(root,fname))
                 except ImportError:
-                    app.logger.info("Failed to load module %s from %s", modname, os.path.join(root,fname))
+                    app.logger.debug("Failed to load module %s from %s", modname, os.path.join(root,fname))
                 else:
-                    app.logger.info("Loaded module %s from %s", modname, os.path.join(root,fname))
+                    app.logger.debug("Loaded module %s from %s", modname, os.path.join(root,fname))
 
 
 def load_plugins(group):


### PR DESCRIPTION
Every `monkey` command loads all the modules (auditors/watchers), across all account_types. Instead of requiring all the dependency cloudaux extras to be installed regardless of the account_type of the instance, catch ImportError exceptions in the module load. Both load failures and successes are logged at DEBUG.