### PR TITLE
cert.serial has been deprecated & replaced by cert.serial_number

### DIFF
--- a/security_monkey/watchers/iam/iam_ssl.py
+++ b/security_monkey/watchers/iam/iam_ssl.py
@@ -72,7 +72,7 @@ def cert_get_serial(cert):
     :param cert:
     :return:
     """
-    return cert.serial
+    return cert.serial_number
 
 
 def cert_get_not_before(cert):


### PR DESCRIPTION
Converted `cert.serial` to `cert.serial_number` because `cert.serial` has been deprecated and replaced by `cert.serial_number`.

For more clarity, I receive an error message when running

    monkey find_changes -a account -m iamssl

is

    /opt/security_monkey/security_monkey/watchers/iam/iam_ssl.py:75: DeprecationWarning: Certificate serial is deprecated, use serial_number instead.
