### PR TITLE
Bump minfds limit to resolve

### DIFF
--- a/scripts/secmonkey_auto_install.sh
+++ b/scripts/secmonkey_auto_install.sh
@@ -340,7 +340,7 @@ logfile_backups=2
 loglevel=trace
 pidfile=/tmp/supervisord.pid
 nodaemon=false
-minfds=1024
+minfds=64000
 minprocs=200
 user=ubuntu
 


### PR DESCRIPTION
The only entry in the FAQ is to resolve an issue with the minimum number of file handlers -- bumping this limit in the auto install script so that fewer people run into the error.