### PR TITLE
Quickstart updates for celery runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Packages
 *.egg
 *.egg-info
+.python-eggs
 dist
 build
 _build
@@ -65,3 +66,4 @@ docker-compose.override.yml
 .cache/
 dart/pubspec.lock
 celerybeat-schedule
+celerybeat.pid

--- a/docs/autostarting.md
+++ b/docs/autostarting.md
@@ -53,15 +53,14 @@ This file needs to be copied over to the supervisor configuration directory at `
 
 To enable NGINX and the supervisor, run the following commands (these also set the proper permissions):
 
-```
     sudo chgrp -R www-data /var/log/security_monkey
+    sudo chmod g+w /usr/local/src/security_monkey
     sudo cp /usr/local/src/security_monkey/supervisor/security_monkey_ui.conf /etc/supervisor/conf.d/security_monkey_ui.conf
     sudo systemctl enable nginx
     sudo systemctl enable supervisor
     sudo systemctl start nginx
     sudo systemctl start supervisor
     sudo supervisorctl status
-```
 
 The `supervisorctl status` should output details about the loaded supervisor job.
 
@@ -126,15 +125,13 @@ With the message broker configured, it's now time to copy over the supervisor co
 A sample is provided at: `security_monkey_scheduler.conf`(https://github.com/Netflix/security_monkey/tree/develop/supervisor/security_monkey_scheduler.conf)
 
 Run the following commands to set this up:
-```
-    sudo touch /var/run/sm-celerybeat-schedule
-    sudo chgrp www-data sm-celerybeat-schedule
+
     sudo chgrp -R www-data /var/log/security_monkey
+    sudo chmod g+w /usr/local/src/security_monkey
     sudo cp /usr/local/src/security_monkey/supervisor/security_monkey_scheduler.conf /etc/supervisor/conf.d/security_monkey_scheduler.conf
     sudo systemctl enable supervisor
     sudo systemctl start supervisor
     sudo supervisorctl status
-```
 
 The supervisor configuration will start the Celery `beat` service, which performs all the scheduling logic. 
 The full command that the supervisor runs to launch the the `beat` service is:
@@ -167,13 +164,16 @@ A sample Supervisor configuration is provided at `security_monkey_workers.conf`(
 that will automatically run the Celery worker processes for you.
 
 Run the following commands to set this up:
-```
+
     sudo chgrp -R www-data /var/log/security_monkey
+    sudo chmod g+w /usr/local/src/security_monkey
+    sudo mkdir -pm g+w /usr/local/src/security_monkey/.python-eggs
+    sudo chgrp www-data /usr/local/src/security_monkey/.python-eggs
     sudo cp /usr/local/src/security_monkey/supervisor/security_monkey_workers.conf /etc/supervisor/conf.d/security_monkey_workers.conf
     sudo systemctl enable supervisor
     sudo systemctl start supervisor
     sudo supervisorctl status
-```
+
 
 Supervisor will run the Celery `worker` command, which is:
 ```

--- a/docs/autostarting.md
+++ b/docs/autostarting.md
@@ -54,7 +54,6 @@ This file needs to be copied over to the supervisor configuration directory at `
 To enable NGINX and the supervisor, run the following commands (these also set the proper permissions):
 
     sudo chgrp -R www-data /var/log/security_monkey
-    sudo chmod g+w /usr/local/src/security_monkey
     sudo cp /usr/local/src/security_monkey/supervisor/security_monkey_ui.conf /etc/supervisor/conf.d/security_monkey_ui.conf
     sudo systemctl enable nginx
     sudo systemctl enable supervisor
@@ -124,10 +123,13 @@ use to fetch and audit your accounts.
 With the message broker configured, it's now time to copy over the supervisor configuration.
 A sample is provided at: `security_monkey_scheduler.conf`(https://github.com/Netflix/security_monkey/tree/develop/supervisor/security_monkey_scheduler.conf)
 
+Note that celery produces a few runtime files, that we will store under /tmp, adjust path as necessary for your environment:
+    sudo mkdir -pm g+w /tmp/security_monkey
+    sudo chgrp -R www-data /tmp/security_monkey
+
 Run the following commands to set this up:
 
     sudo chgrp -R www-data /var/log/security_monkey
-    sudo chmod g+w /usr/local/src/security_monkey
     sudo cp /usr/local/src/security_monkey/supervisor/security_monkey_scheduler.conf /etc/supervisor/conf.d/security_monkey_scheduler.conf
     sudo systemctl enable supervisor
     sudo systemctl start supervisor
@@ -166,9 +168,8 @@ that will automatically run the Celery worker processes for you.
 Run the following commands to set this up:
 
     sudo chgrp -R www-data /var/log/security_monkey
-    sudo chmod g+w /usr/local/src/security_monkey
-    sudo mkdir -pm g+w /usr/local/src/security_monkey/.python-eggs
-    sudo chgrp www-data /usr/local/src/security_monkey/.python-eggs
+    sudo mkdir -pm g+w /tmp/security_monkey/.python-eggs
+    sudo chgrp -R www-data /tmp/security_monkey/.python-eggs
     sudo cp /usr/local/src/security_monkey/supervisor/security_monkey_workers.conf /etc/supervisor/conf.d/security_monkey_workers.conf
     sudo systemctl enable supervisor
     sudo systemctl start supervisor

--- a/docs/autostarting.md
+++ b/docs/autostarting.md
@@ -123,10 +123,6 @@ use to fetch and audit your accounts.
 With the message broker configured, it's now time to copy over the supervisor configuration.
 A sample is provided at: `security_monkey_scheduler.conf`(https://github.com/Netflix/security_monkey/tree/develop/supervisor/security_monkey_scheduler.conf)
 
-Note that celery produces a few runtime files, that we will store under /tmp, adjust path as necessary for your environment:
-    sudo mkdir -pm g+w /tmp/security_monkey
-    sudo chgrp -R www-data /tmp/security_monkey
-
 Run the following commands to set this up:
 
     sudo chgrp -R www-data /var/log/security_monkey
@@ -168,8 +164,6 @@ that will automatically run the Celery worker processes for you.
 Run the following commands to set this up:
 
     sudo chgrp -R www-data /var/log/security_monkey
-    sudo mkdir -pm g+w /tmp/security_monkey/.python-eggs
-    sudo chgrp -R www-data /tmp/security_monkey/.python-eggs
     sudo cp /usr/local/src/security_monkey/supervisor/security_monkey_workers.conf /etc/supervisor/conf.d/security_monkey_workers.conf
     sudo systemctl enable supervisor
     sudo systemctl start supervisor

--- a/supervisor/security_monkey_scheduler.conf
+++ b/supervisor/security_monkey_scheduler.conf
@@ -12,7 +12,7 @@ autorestart=true
 numprocs=1
 directory=/usr/local/src/security_monkey/
 environment=PYTHONPATH='/usr/local/src/security_monkey/',PATH="/usr/local/src/security_monkey/venv/bin:%(ENV_PATH)s"
-command=/usr/local/src/security_monkey/venv/bin/celery -A security_monkey.task_scheduler.beat.CELERY beat -s /var/run/sm-celerybeat-schedule -l debug
+command=/usr/local/src/security_monkey/venv/bin/celery -A security_monkey.task_scheduler.beat.CELERY beat -l debug
 
 ; Causes supervisor to send the termination signal (SIGTERM) to the whole process group.
 stopasgroup=true

--- a/supervisor/security_monkey_scheduler.conf
+++ b/supervisor/security_monkey_scheduler.conf
@@ -12,7 +12,7 @@ autorestart=true
 numprocs=1
 directory=/usr/local/src/security_monkey/
 environment=PYTHONPATH='/usr/local/src/security_monkey/',PATH="/usr/local/src/security_monkey/venv/bin:%(ENV_PATH)s"
-command=/usr/local/src/security_monkey/venv/bin/celery -A security_monkey.task_scheduler.beat.CELERY beat -l debug
+command=/usr/local/src/security_monkey/venv/bin/celery -A security_monkey.task_scheduler.beat.CELERY -s /tmp/sm-celerybeat-schedule --pidfile=/tmp/sm-celerybeat-scheduler.pid beat -l debug
 
 ; Causes supervisor to send the termination signal (SIGTERM) to the whole process group.
 stopasgroup=true

--- a/supervisor/security_monkey_workers.conf
+++ b/supervisor/security_monkey_workers.conf
@@ -11,7 +11,7 @@ autostart=true
 autorestart=true
 numprocs=1
 directory=/usr/local/src/security_monkey/
-environment=PYTHONPATH='/usr/local/src/security_monkey/',PATH="/usr/local/src/security_monkey/venv/bin:%(ENV_PATH)s",PYTHON_EGG_CACHE='/usr/local/src/security_monkey/.python-eggs'
+environment=PYTHONPATH='/usr/local/src/security_monkey/',PATH="/usr/local/src/security_monkey/venv/bin:%(ENV_PATH)s",PYTHON_EGG_CACHE='/tmp/security_monkey/.python-eggs'
 startsecs=60
 command=/usr/local/src/security_monkey/venv/bin/celery -A security_monkey.task_scheduler.tasks.CELERY worker
 

--- a/supervisor/security_monkey_workers.conf
+++ b/supervisor/security_monkey_workers.conf
@@ -11,7 +11,7 @@ autostart=true
 autorestart=true
 numprocs=1
 directory=/usr/local/src/security_monkey/
-environment=PYTHONPATH='/usr/local/src/security_monkey/',PATH="/usr/local/src/security_monkey/venv/bin:%(ENV_PATH)s"
+environment=PYTHONPATH='/usr/local/src/security_monkey/',PATH="/usr/local/src/security_monkey/venv/bin:%(ENV_PATH)s",PYTHON_EGG_CACHE='/usr/local/src/security_monkey/.python-eggs'
 startsecs=60
 command=/usr/local/src/security_monkey/venv/bin/celery -A security_monkey.task_scheduler.tasks.CELERY worker
 

--- a/supervisor/security_monkey_workers.conf
+++ b/supervisor/security_monkey_workers.conf
@@ -11,9 +11,10 @@ autostart=true
 autorestart=true
 numprocs=1
 directory=/usr/local/src/security_monkey/
-environment=PYTHONPATH='/usr/local/src/security_monkey/',PATH="/usr/local/src/security_monkey/venv/bin:%(ENV_PATH)s",PYTHON_EGG_CACHE='/tmp/security_monkey/.python-eggs'
+environment=PYTHONPATH='/usr/local/src/security_monkey/',PATH="/usr/local/src/security_monkey/venv/bin:%(ENV_PATH)s",PYTHON_EGG_CACHE='/tmp/python-eggs'
 startsecs=60
-command=/usr/local/src/security_monkey/venv/bin/celery -A security_monkey.task_scheduler.tasks.CELERY worker
+command=/usr/local/src/security_monkey/venv/bin/celery -A security_monkey.task_scheduler.tasks.CELERY --pidfile=/tmp/sm-celerybeat-worker.pid worker
+
 
 ; Causes supervisor to send the termination signal (SIGTERM) to the whole process group.
 stopasgroup=true


### PR DESCRIPTION
Changes for runtime files and PYTHON_EGG_CACHE configs, storing both under /usr/local/src/security_monkey (or install root). 

Initially planned on using /var/run for celery runtime (schedule and pidfile), but remembered that /var/run gets cleaned out on a reboot and would require some manual sudo creation/chmod on a restart (or some init.d script). Added instructions to chmod g+w so www-data can create the files in the install root dir and added to .gitignore

For PYTHON_EGG_CACHE, which is needed on workers to store sqlalchemy files, initially in /tmp, which may get cleaned out at some interval by the OS and cause issues, storing in /usr/local/src/security_monkey/.python-egg (which appears to be somewhat of a convention if not in $HOME) and added to .gitignore.