### PR TITLE
Raise better errors during Google Auth faillure

### DIFF
--- a/security_monkey/exceptions.py
+++ b/security_monkey/exceptions.py
@@ -166,3 +166,15 @@ class InvalidResponseCodeFromGitHubRepoError(SecurityMonkeyException):
         return repr("Unable to load data from GitHub for the repo: {}/{} -- received HTTP response: {}".format(
             self.organization, self.repo, self.response_code
         ))
+
+class UnableToIssueGoogleAuthToken(SecurityMonkeyException):
+    '''Google oauth token was not issued'''
+    def __init__(self, error_message):
+        self.error_message = error_message
+        app.logger.error(self)
+        
+class UnableToAccessGoogleEmail(SecurityMonkeyException):
+    '''Google oauth token was issued but Google+ API can't be accessed to fetch user details'''
+    def __init__(self):
+        self.error_message = "Unable to fetch user e-mail. Please ensure your application has Google+ API access"
+        app.logger.error(self)

--- a/security_monkey/sso/views.py
+++ b/security_monkey/sso/views.py
@@ -264,14 +264,17 @@ class Google(Resource):
 
         r = requests.post(access_token_url, data=payload)
         token = r.json()
-
+        
+        if 'error' in token:
+            raise Exception("Error issuing token: %s" % (token['error']))
+            
         # Step 1bis. Validate (some information of) the id token (if necessary)
         google_hosted_domain = current_app.config.get("GOOGLE_HOSTED_DOMAIN")
         if google_hosted_domain is not None:
             current_app.logger.debug('We need to verify that the token was issued for this hosted domain: %s ' % (google_hosted_domain))
 
 	    # Get the JSON Web Token
-            id_token = r.json()['id_token']
+            id_token = token['id_token']
             current_app.logger.debug('The id_token is: %s' % (id_token))
 
             # Extract the payload
@@ -291,6 +294,9 @@ class Google(Resource):
         r = requests.get(people_api_url, headers=headers)
         profile = r.json()
 
+        if 'email' not in profile:
+            raise Exception("Unable to fetch user e-mail. Please ensure your application has Google+ API access")
+            
         user = setup_user(profile.get('email'), profile.get('groups', []), current_app.config.get('GOOGLE_DEFAULT_ROLE', 'View'))
 
         # Tell Flask-Principal the identity changed

--- a/security_monkey/sso/views.py
+++ b/security_monkey/sso/views.py
@@ -25,6 +25,7 @@ except ImportError:
 from .service import fetch_token_header_payload, get_rsa_public_key, setup_user
 
 from security_monkey.datastore import User
+from security_monkey.exceptions import UnableToIssueGoogleAuthToken, UnableToAccessGoogleEmail
 from security_monkey import db, rbac, csrf
 
 from urlparse import urlparse
@@ -266,7 +267,7 @@ class Google(Resource):
         token = r.json()
         
         if 'error' in token:
-            raise Exception("Error issuing token: %s" % (token['error']))
+            raise UnableToIssueGoogleAuthToken(token['error'])
             
         # Step 1bis. Validate (some information of) the id token (if necessary)
         google_hosted_domain = current_app.config.get("GOOGLE_HOSTED_DOMAIN")
@@ -295,7 +296,7 @@ class Google(Resource):
         profile = r.json()
 
         if 'email' not in profile:
-            raise Exception("Unable to fetch user e-mail. Please ensure your application has Google+ API access")
+            raise UnableToAccessGoogleEmail()
             
         user = setup_user(profile.get('email'), profile.get('groups', []), current_app.config.get('GOOGLE_DEFAULT_ROLE', 'View'))
 


### PR DESCRIPTION
Setting up two exceptions to help debugging when setting up Google authentication.
First exception happens when configuration is not set up properly. 
Second avoids a weird case where the user gets a valid logged in session, but is still considered anonymous.
