### PR TITLE
fix KeyError when services in SWAG account is not defined

### DIFF
--- a/security_monkey/manage.py
+++ b/security_monkey/manage.py
@@ -637,7 +637,8 @@ def sync_swag(owner, bucket_name, bucket_prefix, bucket_region, account_type, sp
 
     for account in swag.get_all("[?provider=='{provider}']".format(provider=account_type.lower())):
         active = False
-        for s in account['services']:
+        services = account.get('services', [])
+        for s in services:
             if s['name'] == 'security_monkey':
                 for status in s['status']:
                     if status['region'] == 'all':
@@ -664,7 +665,7 @@ def sync_swag(owner, bucket_name, bucket_prefix, bucket_region, account_type, sp
         if s3_name:
             custom_fields['s3_name'] = s3_name
 
-        for service in account['services']:
+        for service in services:
             if service['name'] == 's3':
                 c_id = service['metadata'].get('canonicalId')
                 if c_id:


### PR DESCRIPTION
We're using [SWAG](https://github.com/Netflix-Skunkworks/swag-client) but don't define services on all of our accounts. Some of them look like this:

```
    {
        "aliases": ["alias"],
        "contacts": [],
        "description": [],
        "email": "",
        "id": "86753098675",
        "name": "oh yes",
        "owner": "ukno",
        "provider": "aws",
        "sensitive": true
    }
```

SWAG spec says that the services key is optional: https://github.com/Netflix-Skunkworks/swag-client/blob/538366cedfe8536fc24705f3439a4d16a5e7dc7c/swag_client/schemas/v2.py#L55

So this PR fixes the following error and allows the command to complete:

```
$ monkey sync_swag -b our-bucket -p the-goods.json -o ukno                                              
Traceback (most recent call last):
  File "/usr/local/src/security_monkey/venv/bin/monkey", line 11, in <module>
    load_entry_point('security-monkey', 'console_scripts', 'monkey')()
  File "/usr/local/src/security_monkey/security_monkey/manage.py", line 728, in main
    manager.run()
  File "/usr/local/src/security_monkey/venv/lib/python2.7/site-packages/Flask_Script-0.6.3-py2.7.egg/flask_script/__init__.py", line 397, in run
    result = self.handle(sys.argv[0], sys.argv[1:])
  File "/usr/local/src/security_monkey/venv/lib/python2.7/site-packages/Flask_Script-0.6.3-py2.7.egg/flask_script/__init__.py", line 376, in handle
    return handle(app, *positional_args, **kwargs)
  File "/usr/local/src/security_monkey/venv/lib/python2.7/site-packages/Flask_Script-0.6.3-py2.7.egg/flask_script/commands.py", line 145, in handle
    return self.run(*args, **kwargs)
  File "/usr/local/src/security_monkey/security_monkey/manage.py", line 640, in sync_swag
    for s in account['services']:
KeyError: 'services'

```