### PR TITLE
Import network whitelists with the sync_networks command

### DIFF
--- a/docs/misc.md
+++ b/docs/misc.md
@@ -30,6 +30,50 @@ Edit `security_monkey/scheduler.py` to change daily check schedule:
 Edit `security_monkey/watcher.py` to change check interval from every 15 minutes:
 
     self.interval = 15
+    
+Synchronizing Network Whitelists
+--------------------------------
+
+Network whitelists can be imported from a JSON file in either an S3 bucket or local file. 
+
+```sh
+# add and update networks from an S3 bucket
+$ monkey sync_networks -b an-s3-bucket -f networks.json
+# in addition to the above, delete any networks not specified in networks.json
+$ monkey sync_networks -b an-s3-bucket -f networks.json -a
+# or just use a local file
+$ monkey sync_networks -f ~/networks.json
+```
+
+This JSON file should map between names and CIDRs like so:
+
+```json
+{
+    "net1": "2620:10D:C000::/40",
+    "net2": "199.201.64.0/22",
+    "net3": "2a03:2880:f10d:83:face:b00c:0:25de",
+}
+```
+
+If you're using S3 to store this file, make sure to give SecurityMonkeyInstanceProfile the appropriate policy permissions in IAM. For example, this will allow the example above to run:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowNetworkFileAccess",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+            ],
+            "Resource": [
+                "arn:aws:s3:::an-s3-bucket/networks.json",
+            ]
+        }
+    ]
+}
+```
 
 Overriding and Disabling Audit Checks
 -------------------------------------

--- a/security_monkey/tests/utilities/test_sync_network.py
+++ b/security_monkey/tests/utilities/test_sync_network.py
@@ -1,0 +1,94 @@
+"""
+.. module: security_monkey.tests.utilities.test_sync_network
+    :platform: Unix
+.. version:: $$VERSION$$
+.. moduleauthor::  Mark Ignacio <mignacio@fb.com>
+"""
+import json
+import tempfile
+
+from security_monkey.datastore import NetworkWhitelistEntry
+from security_monkey.manage import manager
+from security_monkey.tests import SecurityMonkeyTestCase
+
+import boto3
+from moto import mock_s3
+
+
+class SyncNetworksTestCase(SecurityMonkeyTestCase):
+    TEST_NETWORKS = {
+        'network-un': '23.246.2.0/24',
+        'network-deux': '2607:fb10:70b0::/44',
+    }
+
+    def test_add_whitelist_entries(self):
+        self.__sync_networks(self.TEST_NETWORKS)
+        for name, cidr in self.TEST_NETWORKS.items():
+            entry = NetworkWhitelistEntry.query.filter(
+                NetworkWhitelistEntry.name == name
+            ).first()
+            assert entry is not None
+            assert entry.cidr == cidr
+
+    def test_add_whitelist_entries_with_s3(self):
+        # this test exhausts the code path for the s3.get_object() call. The
+        # tests below are agnostic to storage, so it's just more convenient
+        # to use local files.
+        mock_s3().start()
+        s3 = boto3.client('s3')
+        s3.create_bucket(Bucket='testBucket')
+        s3.put_object(
+            Bucket='testBucket',
+            Key='networks.json',
+            Body=json.dumps(self.TEST_NETWORKS),
+        )
+        manager.handle(
+            'manage.py',
+            ['sync_networks', '-i', 'networks.json', '-b', 'testBucket'],
+        )
+        mock_s3().stop()
+        for name, cidr in self.TEST_NETWORKS.items():
+            entry = NetworkWhitelistEntry.query.filter(
+                NetworkWhitelistEntry.name == name
+            ).first()
+            assert entry is not None
+            assert entry.cidr == cidr
+
+    def test_update_whitelist_entry(self):
+        self.__sync_networks(self.TEST_NETWORKS)
+        modified_networks = self.TEST_NETWORKS.copy()
+        modified_networks['network-un'] = '23.246.2.0/24'
+        self.__sync_networks(modified_networks)
+        modified = NetworkWhitelistEntry.query.filter(
+            NetworkWhitelistEntry.name == 'network-un'
+        )
+        assert modified.count() == 1
+        entry = modified.first()
+        assert entry is not None
+        assert entry.cidr == '23.246.2.0/24'
+
+    def test_update_whitelist_authoritatively(self):
+        self.__sync_networks(self.TEST_NETWORKS, ['-a'])
+        # adding one and removing one should do it.
+        modified_networks = self.TEST_NETWORKS.copy()
+        del modified_networks['network-deux']
+        modified_networks['network-trois'] = '2a00:86c0:ff0a::/48'
+        self.__sync_networks(modified_networks, ['-a'])
+        assert NetworkWhitelistEntry.query.filter(
+            NetworkWhitelistEntry.name == 'network-deux'
+        ).count() == 0
+        assert NetworkWhitelistEntry.query.filter(
+            NetworkWhitelistEntry.name == 'network-trois'
+        ).count() == 1
+
+    @staticmethod
+    def __sync_networks(networks, additional_args=None):
+        if additional_args is None:
+            additional_args = []
+        with tempfile.NamedTemporaryFile() as tfile:
+            json.dump(networks, tfile)
+            tfile.seek(0)
+            manager.handle(
+                'manage.py',
+                ['sync_networks', '-i', tfile.name] + additional_args,
+            )


### PR DESCRIPTION
Implements #938 - I added the `--authoritative` option to allow folks to keep the whitelist tidy.

Tested on a Python 2.7 deployment.