### PR TITLE
During audit, enforce item reload if there are no existing issues setted

### DIFF
--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -741,7 +741,7 @@ class Auditor(object):
         for item in self.items:
             changes = False
             loaded = False
-            if not hasattr(item, 'db_item'):
+            if not hasattr(item, 'db_item') or not item.db_item.issues:
                 loaded = True
                 item.db_item = self.datastore._get_item(item.index, item.region, item.account, item.name)
 


### PR DESCRIPTION
Forcing reload when the db_item object has no issues.

It seems some items contain the db_item field, but they are not loading the current issues, and it can end up spamming the alerters