### PR TITLE
Ensure file modes are reasonable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,9 @@ RUN apt-get update && \
     pip install . && \
     /bin/mkdir -p /var/log/security_monkey/ && \
     chmod +x /usr/local/src/security_monkey/docker/*.sh && \
-    /usr/bin/touch /var/log/security_monkey/securitymonkey.log
+    /usr/bin/touch /var/log/security_monkey/securitymonkey.log && \
+    chmod -R guo+r /usr/local/src/security_monkey && \
+    find /usr/local/src/security_monkey -type d -exec chmod 755 {} \;
 
 WORKDIR /usr/local/src/security_monkey
 EXPOSE 5000

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -37,7 +37,9 @@ RUN cd /usr/local/src/security_monkey/dart &&\
 RUN /bin/rm /etc/nginx/conf.d/default.conf &&\
   /bin/mkdir -p /var/log/security_monkey/ /etc/nginx/ssl/ &&\
   ln -s /dev/stdout /var/log/security_monkey/security_monkey.access.log &&\
-  ln -s /dev/stderr /var/log/security_monkey/security_monkey.error.log
+  ln -s /dev/stderr /var/log/security_monkey/security_monkey.error.log &&\
+  chmod -R guo+r /usr/local/src/security_monkey &&\
+  find /usr/local/src/security_monkey -type d -exec chmod 755 {} \;
 
 WORKDIR /etc/nginx
 EXPOSE 443


### PR DESCRIPTION
Fixes #959 

This ensures that regardless of your shell umask, the files installed into the built Docker image are reasonable.