### PR TITLE
Modifying the risk scores as the scores are too low resulting in noise

### DIFF
--- a/dart/lib/component/issue_table_component/issue_table_component.dart
+++ b/dart/lib/component/issue_table_component/issue_table_component.dart
@@ -103,9 +103,9 @@ class IssueTableComponent extends PaginatedTable implements ScopeAware {
     String classForIssue(Issue issue) {
         if (issue.justified) {
             return "success";
-        } else if (issue.score > 3) {
+        } else if (issue.score > 8) {
             return "danger";
-        } else if (issue.score > 0) {
+        } else if (issue.score >= 3) {
             return "warning";
         }
         return "";


### PR DESCRIPTION
The risk scores are too low and, as a result, they cause too much noise and false-positives. This makes Security Monkey unusable.