### PR TITLE
Zero-interval watcher support

### DIFF
--- a/dart/lib/component/settings/watcher_config_component/watcher_config_component.html
+++ b/dart/lib/component/settings/watcher_config_component/watcher_config_component.html
@@ -40,10 +40,11 @@ supervisor&gt;
                   <td>
                     <select id="interval" ng-model="config.interval" class="form-control">
                       <option value="15">15 minute</option>
-                      <option value="60">hourly</option>
+                      <option value="60">Hourly</option>
                       <option value="720">12 hour</option>
-                      <option value="1440">daily</option>
-                      <option value="10080">weekly</option>
+                      <option value="1440">Daily</option>
+                      <option value="10080">Weekly</option>
+                      <option value="0">Manual (watched by a user-defined external process)</option>
                     </select>
                   </td>
                   <td>

--- a/security_monkey/watcher.py
+++ b/security_monkey/watcher.py
@@ -28,6 +28,8 @@ from dpath.exceptions import PathNotFound
 
 import logging
 
+# TODO: Find a better way for the sake of less hair-pulling during unit testing so that this is not a global variable
+#       that constantly breaks!!
 watcher_registry = {}
 abstract_classes = set(['Watcher', 'CloudAuxWatcher', 'CloudAuxBatchedWatcher'])
 


### PR DESCRIPTION
Added an option to have watchers with 0 interval -- this is useful if you want an external cron job to execute it via the `monkey find_changes` command instead of celery.

The use case here is for monitoring GitHub which has very small rate limits. This is useful for things you can't really use Celery for.