### PR TITLE
fix-basestring-reload-unicode-for-Python3

### DIFF
--- a/security_monkey/alerter.py
+++ b/security_monkey/alerter.py
@@ -19,6 +19,7 @@
 .. moduleauthor:: Patrick Kelley <pkelley@netfilx.com> @monkeysecurity
 
 """
+from six import string_types
 
 from security_monkey import app
 from security_monkey.common.jinja import get_jinja_env
@@ -61,7 +62,7 @@ class Alerter(object):
         self.emails = [user.email for user in users]
         self.team_emails = app.config.get('SECURITY_TEAM_EMAIL', [])
 
-        if type(self.team_emails) in (str, unicode):
+        if type(self.team_emails) in string_types:
             self.emails.append(self.team_emails)
         elif type(self.team_emails) in (list, tuple):
             self.emails.extend(self.team_emails)

--- a/security_monkey/auditor.py
+++ b/security_monkey/auditor.py
@@ -21,6 +21,8 @@
 
 """
 
+from six import string_types, text_type
+
 import datastore
 
 from security_monkey import app, db
@@ -176,7 +178,7 @@ class Auditor(object):
         self.override_scores = None
         self.current_method_name = None
 
-        if type(self.team_emails) in (str, unicode):
+        if type(self.team_emails) in string_types:
             self.emails.append(self.team_emails)
         elif type(self.team_emails) in (list, tuple):
             self.emails.extend(self.team_emails)
@@ -189,18 +191,18 @@ class Auditor(object):
 
     def load_policies(self, item, policy_keys):
         """For a given item, return a list of all resource policies.
-        
-        Most items only have a single resource policy, typically found 
+
+        Most items only have a single resource policy, typically found
         inside the config with the key, "Policy".
-        
+
         Some technologies have multiple resource policies.  A lambda function
         is an example of an item with multiple resource policies.
-        
+
         The lambda function auditor can define a list of `policy_keys`.  Each
         item in this list is the dpath to one of the resource policies.
-        
+
         The `policy_keys` defaults to ['Policy'] unless overriden by a subclass.
-        
+
         Returns:
             list of Policy objects
         """
@@ -356,7 +358,7 @@ class Auditor(object):
             add(cls.OBJECT_STORE['vpc'], item.latest_config.get('id'), item.account.identifier)
             add(cls.OBJECT_STORE['cidr'], item.latest_config.get('cidr_block'), item.account.identifier)
 
-            vpcnat_tags = unicode(item.latest_config.get('tags', {}).get('vpcnat', ''))
+            vpcnat_tags = text_type(item.latest_config.get('tags', {}).get('vpcnat', ''))
             vpcnat_tag_cidrs = vpcnat_tags.split(',')
             for vpcnat_tag_cidr in vpcnat_tag_cidrs:
                 add(cls.OBJECT_STORE['cidr'], vpcnat_tag_cidr.strip(), item.account.identifier)
@@ -443,22 +445,22 @@ class Auditor(object):
         if key == 'aws':
             return dict(name='AWS', identifier='AWS')
         for account in self.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS']:
-            if unicode(account.get(key, '')).lower() == value.lower():
+            if text_type(account.get(key, '')).lower() == value.lower():
                 return account
 
     def inspect_entity(self, entity, item):
         """A entity can represent an:
-        
+
         - ARN
         - Account Number
         - UserID
         - CIDR
         - VPC
         - VPCE
-        
+
         Determine if the who is in our current account. Add the associated account
         to the entity.
-        
+
         Return:
             'SAME' - The who is in our same account.
             'FRIENDLY' - The who is in an account Security Monkey knows about.
@@ -768,7 +770,7 @@ class Auditor(object):
                     item.confirmed_new_issues.append(new_issue)
                     item.db_item.issues.append(new_issue)
                     continue
-                
+
                 existing_issue = existing_issues[new_issue_key]
                 if existing_issue.fixed:
                     # regression

--- a/security_monkey/auditors/s3.py
+++ b/security_monkey/auditors/s3.py
@@ -19,6 +19,8 @@
 .. moduleauthor:: Patrick Kelley <pkelley@netflix.com> @monkeysecurity
 
 """
+from six import text_type
+
 from security_monkey.auditors.resource_policy_auditor import ResourcePolicyAuditor
 from security_monkey.auditor import Entity
 from security_monkey.watchers.s3 import S3
@@ -36,10 +38,10 @@ class S3Auditor(ResourcePolicyAuditor):
 
     def prep_for_audit(self):
         super(S3Auditor, self).prep_for_audit()
-        self.FRIENDLY_S3NAMES = [unicode(account['s3_name']).lower() for account in self.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'] if account['label'] == 'friendly']
-        self.THIRDPARTY_S3NAMES = [unicode(account['s3_name']).lower() for account in self.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'] if account['label'] == 'thirdparty']
-        self.FRIENDLY_S3CANONICAL = [unicode(account['s3_canonical_id']).lower() for account in self.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'] if account['label'] == 'friendly']
-        self.THIRDPARTY_S3CANONICAL = [unicode(account['s3_canonical_id']).lower() for account in self.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'] if account['label'] == 'thirdparty']
+        self.FRIENDLY_S3NAMES = [text_type(account['s3_name']).lower() for account in self.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'] if account['label'] == 'friendly']
+        self.THIRDPARTY_S3NAMES = [text_type(account['s3_name']).lower() for account in self.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'] if account['label'] == 'thirdparty']
+        self.FRIENDLY_S3CANONICAL = [text_type(account['s3_canonical_id']).lower() for account in self.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'] if account['label'] == 'friendly']
+        self.THIRDPARTY_S3CANONICAL = [text_type(account['s3_canonical_id']).lower() for account in self.OBJECT_STORE['ACCOUNTS']['DESCRIPTIONS'] if account['label'] == 'thirdparty']
         self.INTERNET_ACCESSIBLE = [
             'http://acs.amazonaws.com/groups/global/AuthenticatedUsers'.lower(),
             'http://acs.amazonaws.com/groups/global/AllUsers'.lower()]

--- a/security_monkey/decorators.py
+++ b/security_monkey/decorators.py
@@ -12,6 +12,8 @@ from datetime import timedelta
 from flask import make_response, request, current_app
 from functools import update_wrapper, wraps
 
+from six import string_types
+
 from security_monkey.datastore import Account, store_exception
 from security_monkey.exceptions import BotoConnectionIssue
 from security_monkey import app, sentry, AWS_DEFAULT_REGION, ARN_PREFIX, ARN_PARTITION
@@ -30,9 +32,9 @@ def crossdomain(allowed_origins=None, methods=None, headers=None,
     """
     if methods is not None:
         methods = ', '.join(sorted(x.upper() for x in methods))
-    if headers is not None and not isinstance(headers, basestring):
+    if headers is not None and not isinstance(headers, string_types):
         headers = ', '.join(x.upper() for x in headers)
-    if not isinstance(allowed_origins, basestring):
+    if not isinstance(allowed_origins, string_types):
         allowed_origins = ', '.join(allowed_origins)
     if isinstance(max_age, timedelta):
         max_age = max_age.total_seconds()

--- a/security_monkey/manage.py
+++ b/security_monkey/manage.py
@@ -17,6 +17,8 @@ import sys
 
 from flask.ext.script import Manager, Command, Option, prompt_pass
 
+from six import text_type
+
 from security_monkey.account_manager import bulk_disable_accounts, bulk_enable_accounts
 from security_monkey.common.s3_canonical import get_canonical_ids
 from security_monkey.datastore import clear_old_exceptions, store_exception, AccountType, ItemAudit, NetworkWhitelistEntry
@@ -63,7 +65,7 @@ def drop_db():
     db.drop_all()
 
 
-@manager.option('-a', '--accounts', dest='accounts', type=unicode, default=u'all')
+@manager.option('-a', '--accounts', dest='accounts', type=text_type, default=u'all')
 def run_change_reporter(accounts):
     """ Runs Reporter """
     try:
@@ -75,8 +77,8 @@ def run_change_reporter(accounts):
     manual_run_change_reporter(account_names)
 
 
-@manager.option('-a', '--accounts', dest='accounts', type=unicode, default=u'all')
-@manager.option('-m', '--monitors', dest='monitors', type=unicode, default=u'all')
+@manager.option('-a', '--accounts', dest='accounts', type=text_type, default=u'all')
+@manager.option('-m', '--monitors', dest='monitors', type=text_type, default=u'all')
 def find_changes(accounts, monitors):
     """ Runs watchers """
     monitor_names = _parse_tech_names(monitors)
@@ -89,8 +91,8 @@ def find_changes(accounts, monitors):
     manual_run_change_finder(account_names, monitor_names)
 
 
-@manager.option('-a', '--accounts', dest='accounts', type=unicode, default=u'all')
-@manager.option('-m', '--monitors', dest='monitors', type=unicode, default=u'all')
+@manager.option('-a', '--accounts', dest='accounts', type=text_type, default=u'all')
+@manager.option('-m', '--monitors', dest='monitors', type=text_type, default=u'all')
 @manager.option('-r', '--send_report', dest='send_report', type=bool, default=False)
 @manager.option('-s', '--skip_batch', dest='skip_batch', type=bool, default=False)
 def audit_changes(accounts, monitors, send_report, skip_batch):
@@ -105,8 +107,8 @@ def audit_changes(accounts, monitors, send_report, skip_batch):
     sm_audit_changes(account_names, monitor_names, send_report, skip_batch=skip_batch)
 
 
-@manager.option('-a', '--accounts', dest='accounts', type=unicode, default=u'all')
-@manager.option('-m', '--monitors', dest='monitors', type=unicode, default=u'all')
+@manager.option('-a', '--accounts', dest='accounts', type=text_type, default=u'all')
+@manager.option('-m', '--monitors', dest='monitors', type=text_type, default=u'all')
 def delete_unjustified_issues(accounts, monitors):
     """ Allows us to delete unjustified issues. """
     monitor_names = _parse_tech_names(monitors)
@@ -123,9 +125,9 @@ def delete_unjustified_issues(accounts, monitors):
     db.session.commit()
 
 
-@manager.option('-a', '--accounts', dest='accounts', type=unicode, default=u'all')
-@manager.option('-m', '--monitors', dest='monitors', type=unicode, default=u'all')
-@manager.option('-o', '--outputfolder', dest='outputfolder', type=unicode, default=u'backups')
+@manager.option('-a', '--accounts', dest='accounts', type=text_type, default=u'all')
+@manager.option('-m', '--monitors', dest='monitors', type=text_type, default=u'all')
+@manager.option('-o', '--outputfolder', dest='outputfolder', type=text_type, default=u'backups')
 def backup_config_to_json(accounts, monitors, outputfolder):
     """ Saves the most current item revisions to a json file. """
     monitor_names = _parse_tech_names(monitors)
@@ -205,7 +207,7 @@ def amazon_accounts():
 
 
 @manager.command
-@manager.option('-e', '--email', dest='email', type=unicode, required=True)
+@manager.option('-e', '--email', dest='email', type=text_type, required=True)
 @manager.option('-r', '--role', dest='role', type=str, required=True)
 def create_user(email, role):
     from flask_security import SQLAlchemyUserDatastore
@@ -252,7 +254,7 @@ def create_user(email, role):
     db.session.commit()
 
 
-@manager.option('-a', '--accounts', dest='accounts', type=unicode, default=u'all')
+@manager.option('-a', '--accounts', dest='accounts', type=text_type, default=u'all')
 def disable_accounts(accounts):
     """ Bulk disables one or more accounts """
     try:
@@ -264,7 +266,7 @@ def disable_accounts(accounts):
     bulk_disable_accounts(account_names)
 
 
-@manager.option('-a', '--accounts', dest='accounts', type=unicode, default=u'all')
+@manager.option('-a', '--accounts', dest='accounts', type=text_type, default=u'all')
 def enable_accounts(accounts):
     """ Bulk enables one or more accounts """
     try:
@@ -522,7 +524,7 @@ def _parse_accounts(account_str, active=True):
         return names
 
 
-@manager.option('-n', '--name', dest='name', type=unicode, required=True)
+@manager.option('-n', '--name', dest='name', type=text_type, required=True)
 def delete_account(name):
     from security_monkey.account_manager import delete_account_by_name
     delete_account_by_name(name)
@@ -625,10 +627,10 @@ class APIServer(Command):
             FlaskApplication().run()
 
 
-@manager.option('-o', '--owner', type=unicode, required=True, help="Owner of the accounts, this is often set to a company name.")
-@manager.option('-b', '--bucket-name', dest='bucket_name', type=unicode, required=True, help="S3 bucket where SWAG data is stored.")
-@manager.option('-p', '--bucket-prefix', dest='bucket_prefix', type=unicode, default='accounts.json', help="Prefix to fetch account data from. Default: accounts.json")
-@manager.option('-r', '--bucket-region', dest='bucket_region', type=unicode, default='us-east-1', help="Region SWAG S3 bucket is located. Default: us-east-1")
+@manager.option('-o', '--owner', type=text_type, required=True, help="Owner of the accounts, this is often set to a company name.")
+@manager.option('-b', '--bucket-name', dest='bucket_name', type=text_type, required=True, help="S3 bucket where SWAG data is stored.")
+@manager.option('-p', '--bucket-prefix', dest='bucket_prefix', type=text_type, default='accounts.json', help="Prefix to fetch account data from. Default: accounts.json")
+@manager.option('-r', '--bucket-region', dest='bucket_region', type=text_type, default='us-east-1', help="Region SWAG S3 bucket is located. Default: us-east-1")
 @manager.option('-t', '--account-type', dest='account_type', default='AWS', help="Type of account to sync from SWAG data. Default: AWS")
 @manager.option('-s', '--spinnaker', dest='spinnaker', default=False, action='store_true', help='Use the spinnaker names as account names.')
 def sync_swag(owner, bucket_name, bucket_prefix, bucket_region, account_type, spinnaker):
@@ -691,8 +693,8 @@ def sync_swag(owner, bucket_name, bucket_prefix, bucket_region, account_type, sp
     app.logger.info('SWAG sync successful.')
 
 
-@manager.option('-b', '--bucket-name', dest='bucket_name', type=unicode, help="S3 bucket where network whitelist data is stored.")
-@manager.option('-i', '--input-filename', dest='input_filename', type=unicode, default='networks.json', help="File path or bucket prefix to fetch account data from. Default: networks.json")
+@manager.option('-b', '--bucket-name', dest='bucket_name', type=text_type, help="S3 bucket where network whitelist data is stored.")
+@manager.option('-i', '--input-filename', dest='input_filename', type=text_type, default='networks.json', help="File path or bucket prefix to fetch account data from. Default: networks.json")
 @manager.option('-a', '--authoritative', dest='authoritative', default=False, action='store_true', help='Remove all networks not named in `input_filename`.')
 def sync_networks(bucket_name, input_filename, authoritative):
     """Imports a JSON file of networks to the Security Monkey whitelist."""
@@ -741,11 +743,11 @@ class AddAccount(Command):
 
     def get_options(self):
         options = [
-            Option('-n', '--name', type=unicode, required=True),
-            Option('--id', dest='identifier', type=unicode, required=True),
+            Option('-n', '--name', type=text_type, required=True),
+            Option('--id', dest='identifier', type=text_type, required=True),
             Option('--thirdparty', action='store_true'),
             Option('--active', action='store_true'),
-            Option('--notes', type=unicode),
+            Option('--notes', type=text_type),
             Option('--update-existing', action="store_true")
         ]
         for cf in self._account_manager.custom_field_configs:

--- a/security_monkey/task_scheduler/tasks.py
+++ b/security_monkey/task_scheduler/tasks.py
@@ -9,9 +9,12 @@
 
 """
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
-# ^^ Fixes UTF-8 issues
+try:
+    reload(sys)  # Python 2
+    sys.setdefaultencoding('utf8')
+    # ^^ Fixes UTF-8 issues
+except NameError:
+    pass         # Python 3
 
 import time
 import traceback

--- a/security_monkey/tests/core/test_exception_logging.py
+++ b/security_monkey/tests/core/test_exception_logging.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+from six import text_type
+
 from security_monkey.datastore import Account, Technology, Item
 from security_monkey.datastore import store_exception, ExceptionLogs
 from security_monkey.datastore import clear_old_exceptions, AccountType
@@ -153,7 +155,7 @@ class ExceptionLoggingTestCase(SecurityMonkeyTestCase):
 
             for x in range(0, i):
                 attr = getattr(exc_log, attrs[x][0])
-                if isinstance(attr, unicode):
+                if isinstance(attr, text_type):
                     assert attr == attrs[x][1]
                 else:
                     assert attr.name == attrs[x][1]

--- a/security_monkey/views/account_pattern_audit_score.py
+++ b/security_monkey/views/account_pattern_audit_score.py
@@ -20,6 +20,8 @@
 .. moduleauthor:: Bridgewater OSS <opensource@bwater.com>
 
 """
+from six import text_type
+
 from security_monkey.views import AuthenticatedService
 from security_monkey.views import ACCOUNT_PATTERN_AUDIT_SCORE_FIELDS
 from security_monkey.datastore import AccountPatternAuditScore
@@ -164,14 +166,14 @@ class AccountPatternAuditScorePost(AuthenticatedService):
             :statuscode 401: Authentication Error. Please Login.
         """
 
-        self.reqparse.add_argument('account_type', required=False, type=unicode, location='json')
-        self.reqparse.add_argument('account_field', required=True, type=unicode, help='Must provide account field',
+        self.reqparse.add_argument('account_type', required=False, type=text_type, location='json')
+        self.reqparse.add_argument('account_field', required=True, type=text_type, help='Must provide account field',
                                    location='json')
-        self.reqparse.add_argument('account_pattern', required=True, type=unicode, help='Must provide account pattern',
+        self.reqparse.add_argument('account_pattern', required=True, type=text_type, help='Must provide account pattern',
                                    location='json')
-        self.reqparse.add_argument('score', required=True, type=unicode, help='Override score required',
+        self.reqparse.add_argument('score', required=True, type=text_type, help='Override score required',
                                    location='json')
-        self.reqparse.add_argument('itemauditscores_id', required=True, type=unicode, help='Audit Score ID required',
+        self.reqparse.add_argument('itemauditscores_id', required=True, type=text_type, help='Audit Score ID required',
                                    location='json')
         args = self.reqparse.parse_args()
 
@@ -306,14 +308,14 @@ class AccountPatternAuditScoreGetPutDelete(AuthenticatedService):
             :statuscode 401: Authentication failure. Please login.
         """
 
-        self.reqparse.add_argument('account_type', required=False, type=unicode,
+        self.reqparse.add_argument('account_type', required=False, type=text_type,
                                    help='Must provide account type.', location='json')
-        self.reqparse.add_argument('account_field', required=False, type=unicode,
+        self.reqparse.add_argument('account_field', required=False, type=text_type,
                                    help='Must provide account field.', location='json')
-        self.reqparse.add_argument('account_pattern', required=False, type=unicode,
+        self.reqparse.add_argument('account_pattern', required=False, type=text_type,
                                    help='Must provide account pattern.', location='json')
         self.reqparse.add_argument(
-            'score', required=False, type=unicode, help='Must provide score.', location='json')
+            'score', required=False, type=text_type, help='Must provide score.', location='json')
         args = self.reqparse.parse_args()
 
         result = AccountPatternAuditScore.query.filter(

--- a/security_monkey/views/audit_scores.py
+++ b/security_monkey/views/audit_scores.py
@@ -20,6 +20,8 @@
 
 
 """
+from six import text_type
+
 from security_monkey.views import AuthenticatedService
 from security_monkey.views import AUDIT_SCORE_FIELDS
 from security_monkey.views import ACCOUNT_PATTERN_AUDIT_SCORE_FIELDS
@@ -147,13 +149,13 @@ class AuditScoresGet(AuthenticatedService):
             :statuscode 401: Authentication Error. Please Login.
         """
 
-        self.reqparse.add_argument('method', required=True, type=unicode, help='Must provide method name',
+        self.reqparse.add_argument('method', required=True, type=text_type, help='Must provide method name',
                                    location='json')
-        self.reqparse.add_argument('technology', required=True, type=unicode, help='Technology required.',
+        self.reqparse.add_argument('technology', required=True, type=text_type, help='Technology required.',
                                    location='json')
-        self.reqparse.add_argument('score', required=False, type=unicode, help='Override score required',
+        self.reqparse.add_argument('score', required=False, type=text_type, help='Override score required',
                                    location='json')
-        self.reqparse.add_argument('disabled', required=True, type=unicode, help='Disabled flag',
+        self.reqparse.add_argument('disabled', required=True, type=text_type, help='Disabled flag',
                                    location='json')
         args = self.reqparse.parse_args()
 
@@ -292,13 +294,13 @@ class AuditScoreGetPutDelete(AuthenticatedService):
             :statuscode 401: Authentication failure. Please login.
         """
 
-        self.reqparse.add_argument('method', required=True, type=unicode, help='Must provide method name',
+        self.reqparse.add_argument('method', required=True, type=text_type, help='Must provide method name',
                                    location='json')
-        self.reqparse.add_argument('technology', required=True, type=unicode, help='Technology required.',
+        self.reqparse.add_argument('technology', required=True, type=text_type, help='Technology required.',
                                    location='json')
-        self.reqparse.add_argument('score', required=False, type=unicode, help='Must provide score.',
+        self.reqparse.add_argument('score', required=False, type=text_type, help='Must provide score.',
                                    location='json')
-        self.reqparse.add_argument('disabled', required=True, type=unicode, help='Must disabled flag.',
+        self.reqparse.add_argument('disabled', required=True, type=text_type, help='Must disabled flag.',
                                    location='json')
 
         args = self.reqparse.parse_args()

--- a/security_monkey/views/ignore_list.py
+++ b/security_monkey/views/ignore_list.py
@@ -12,6 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from six import text_type
+
 from security_monkey.views import AuthenticatedService
 from security_monkey.views import IGNORELIST_FIELDS
 from security_monkey.datastore import IgnoreListEntry
@@ -125,9 +127,9 @@ class IgnoreListGetPutDelete(AuthenticatedService):
             :statuscode 401: Authentication failure. Please login.
         """
 
-        self.reqparse.add_argument('prefix', required=True, type=unicode, help='A prefix must be provided which matches the objects you wish to ignore.', location='json')
-        self.reqparse.add_argument('notes', required=False, type=unicode, help='Add context.', location='json')
-        self.reqparse.add_argument('technology', required=True, type=unicode, help='Technology name required.', location='json')
+        self.reqparse.add_argument('prefix', required=True, type=text_type, help='A prefix must be provided which matches the objects you wish to ignore.', location='json')
+        self.reqparse.add_argument('notes', required=False, type=text_type, help='Add context.', location='json')
+        self.reqparse.add_argument('technology', required=True, type=text_type, help='Technology name required.', location='json')
         args = self.reqparse.parse_args()
 
         prefix = args['prefix']
@@ -307,9 +309,9 @@ class IgnorelistListPost(AuthenticatedService):
             :statuscode 401: Authentication Error. Please Login.
         """
 
-        self.reqparse.add_argument('prefix', required=True, type=unicode, help='A prefix must be provided which matches the objects you wish to ignore.', location='json')
-        self.reqparse.add_argument('notes', required=False, type=unicode, help='Add context.', location='json')
-        self.reqparse.add_argument('technology', required=True, type=unicode, help='Technology name required.', location='json')
+        self.reqparse.add_argument('prefix', required=True, type=text_type, help='A prefix must be provided which matches the objects you wish to ignore.', location='json')
+        self.reqparse.add_argument('notes', required=False, type=text_type, help='Add context.', location='json')
+        self.reqparse.add_argument('technology', required=True, type=text_type, help='Technology name required.', location='json')
         args = self.reqparse.parse_args()
 
         prefix = args['prefix']

--- a/security_monkey/views/item_comment.py
+++ b/security_monkey/views/item_comment.py
@@ -12,6 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from six import text_type
+
 from security_monkey.views import AuthenticatedService
 from security_monkey.views import ITEM_COMMENT_FIELDS
 from security_monkey.datastore import ItemComment
@@ -167,7 +169,7 @@ class ItemCommentPost(AuthenticatedService):
             :statuscode 401: Authentication Error. Please Login.
         """
 
-        self.reqparse.add_argument('text', required=False, type=unicode, help='Must provide comment', location='json')
+        self.reqparse.add_argument('text', required=False, type=text_type, help='Must provide comment', location='json')
         args = self.reqparse.parse_args()
 
         ic = ItemComment()

--- a/security_monkey/views/revision_comment.py
+++ b/security_monkey/views/revision_comment.py
@@ -12,6 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from six import text_type
+
 from security_monkey.views import AuthenticatedService
 from security_monkey.views import REVISION_COMMENT_FIELDS
 from security_monkey.datastore import ItemRevisionComment
@@ -174,7 +176,7 @@ class RevisionCommentPost(AuthenticatedService):
             :statuscode 201: Revision Comment Created
             :statuscode 401: Authentication Error. Please Login.
         """
-        self.reqparse.add_argument('text', required=False, type=unicode, help='Must provide comment', location='json')
+        self.reqparse.add_argument('text', required=False, type=text_type, help='Must provide comment', location='json')
         args = self.reqparse.parse_args()
 
         irc = ItemRevisionComment()

--- a/security_monkey/views/users.py
+++ b/security_monkey/views/users.py
@@ -1,3 +1,5 @@
+from six import text_type
+
 from security_monkey.auth.models import RBACRole
 
 from security_monkey.views import AuthenticatedService
@@ -204,7 +206,7 @@ class UserDetail(AuthenticatedService):
         """
 
         self.reqparse.add_argument('id', required=True, location='json', type=int)
-        self.reqparse.add_argument('email', required=True, location='json', type=unicode)
+        self.reqparse.add_argument('email', required=True, location='json', type=text_type)
         self.reqparse.add_argument('active', required=True, location='json', type=bool)
         self.reqparse.add_argument('role_id', required=True, location='json', type=str)
         args = self.reqparse.parse_args()

--- a/security_monkey/views/watcher_config.py
+++ b/security_monkey/views/watcher_config.py
@@ -20,6 +20,8 @@
 
 
 """
+from six import text_type
+
 from security_monkey.views import AuthenticatedService
 from security_monkey.datastore import WatcherConfig, Item, Technology
 from security_monkey.watcher import watcher_registry
@@ -84,7 +86,7 @@ class WatcherConfigPut(AuthenticatedService):
         super(WatcherConfigPut, self).__init__()
 
     def put(self, id):
-        self.reqparse.add_argument('index', required=True, type=unicode, location='json')
+        self.reqparse.add_argument('index', required=True, type=text_type, location='json')
         self.reqparse.add_argument('interval', required=True, type=int, location='json')
         self.reqparse.add_argument('active', required=True, type=bool, location='json')
         self.reqparse.add_argument('remove_items', required=False, type=bool, location='json')

--- a/security_monkey/views/whitelist.py
+++ b/security_monkey/views/whitelist.py
@@ -12,6 +12,8 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
+from six import text_type
+
 from security_monkey.views import AuthenticatedService
 from security_monkey.views import WHITELIST_FIELDS
 from security_monkey.datastore import NetworkWhitelistEntry
@@ -133,9 +135,9 @@ class WhitelistListPost(AuthenticatedService):
             :statuscode 401: Authentication Error. Please Login.
         """
 
-        self.reqparse.add_argument('name', required=True, type=unicode, help='Must provide account name', location='json')
-        self.reqparse.add_argument('cidr', required=True, type=unicode, help='Network CIDR required.', location='json')
-        self.reqparse.add_argument('notes', required=False, type=unicode, help='Add context.', location='json')
+        self.reqparse.add_argument('name', required=True, type=text_type, help='Must provide account name', location='json')
+        self.reqparse.add_argument('cidr', required=True, type=text_type, help='Network CIDR required.', location='json')
+        self.reqparse.add_argument('notes', required=False, type=text_type, help='Add context.', location='json')
         args = self.reqparse.parse_args()
 
         name = args['name']
@@ -259,9 +261,9 @@ class WhitelistGetPutDelete(AuthenticatedService):
             :statuscode 401: Authentication failure. Please login.
         """
 
-        self.reqparse.add_argument('name', required=True, type=unicode, help='Must provide account name', location='json')
-        self.reqparse.add_argument('cidr', required=True, type=unicode, help='Network CIDR required.', location='json')
-        self.reqparse.add_argument('notes', required=False, type=unicode, help='Add context.', location='json')
+        self.reqparse.add_argument('name', required=True, type=text_type, help='Must provide account name', location='json')
+        self.reqparse.add_argument('cidr', required=True, type=text_type, help='Network CIDR required.', location='json')
+        self.reqparse.add_argument('notes', required=False, type=text_type, help='Add context.', location='json')
         args = self.reqparse.parse_args()
 
         name = args['name']

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
                 ('data', ['data/aws_accounts.json'])],
     zip_safe=False,
     install_requires=[
+        'six>=1.11.0',
         'cloudaux==1.4.7',
         'celery==4.1.0',
         'celery[redis]==4.1.0',


### PR DESCRIPTION
__unicode()__ was removed in Python 3 because all str are Unicode so this PR:
* Changes all calls to __unicode()__ into calls to [__six.text_type()__](https://pythonhosted.org/six/#six.text_type)
* Change all instances of __(str, unicode)__ to [__six.string_types__](https://pythonhosted.org/six/#six.string_types)
* Change remaining instances of __unicode__ to [__six.text_type__](https://pythonhosted.org/six/#six.text_type)

__basestring__ was removed in Python 3 so for each Python file that contains __basestring__, this PR adds __from six import string_types__ and replaces __basestring__ with __string_types__.

The builtin __reload()__ was moved into [importlib](https://docs.python.org/3/library/importlib.html#importlib.reload) in Python 3 because it was being overused and led to odd behavior that was often difficult to diagnose.  Here we are trying to __reload(sys)__ probably because 'utf-8' encoding and Unicode strs are not the default in Python 2.  They are however the default in Python 3 so this PR therefor suggests that a __pass__ would be satisfactory in Python 3.