### PR TITLE
Travis CI: Add Python 3 in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,11 @@
 # Only way to get multiple builds to work without having the "default" job working was to
 # duplicate everything :/  See: https://github.com/travis-ci/travis-ci/issues/4681
 matrix:
+  allow_failures:
+  - python: "3.6"
+
   include:
-    ##### UNIT TEST JOB #####
+##### LEGACY PYTHON UNIT TEST JOB #####
     - dist: trusty
       sudo: required
       language: python
@@ -43,6 +46,7 @@ matrix:
         - sed -i '/WTF_CSRF_ENABLED = True/c\WTF_CSRF_ENABLED = False' `pwd`/env-config/config.py
         - pip install bandit
         - pip install pylint
+        - pip install flake8
 
       script:
         - coverage run -a -m py.test security_monkey/tests/auditors || exit 1
@@ -54,6 +58,65 @@ matrix:
         - coverage run -a -m py.test security_monkey/tests/utilities || exit 1
         - bandit -r -ll -ii -x security_monkey/tests .
         - pylint -E -d E1101,E0611,F0401 --ignore=service.py,datastore.py,datastore_utils.py,watcher.py,test_celery_scheduler.py security_monkey
+        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+
+      after_success:
+        - coveralls
+        - coverage report
+    #####################################################
+
+    ##### PYTHON UNIT TEST JOB #####
+    - dist: trusty
+      sudo: required
+      language: python
+      python: "3.6"
+
+      env:
+      - UNIT_TEST_JOB=true
+      - PIP_DOWNLOAD_CACHE=".pip_download_cache"
+
+      addons:
+        postgresql: "9.4"
+
+      before_script:
+      - psql -c "CREATE DATABASE secmonkey;" -U postgres
+      - psql -c "CREATE ROLE securitymonkeyuser LOGIN PASSWORD 'securitymonkeypassword';" -U postgres
+      - psql -c "CREATE SCHEMA secmonkey GRANT Usage, Create ON SCHEMA secmonkey TO securitymonkeyuser;" -U postgres
+      - psql -c "set timezone TO 'GMT';" -U postgres
+      - pip install pip --upgrade
+      - pip install setuptools --upgrade
+      - pip install google-compute-engine
+      - pip install openstacksdk
+      - pip install cloudaux\[gcp\]
+      - pip install cloudaux\[openstack\]
+      - python setup.py develop
+      - pip install .[tests]
+      - pip install coveralls
+      - monkey db upgrade
+      - monkey amazon_accounts
+
+      before_install:
+        - sudo mkdir -p /var/log/security_monkey/
+        - sudo touch /var/log/security_monkey/securitymonkey.log
+        - sudo chown travis /var/log/security_monkey/securitymonkey.log
+
+      install:
+        - sed -i '/WTF_CSRF_ENABLED = True/c\WTF_CSRF_ENABLED = False' `pwd`/env-config/config.py
+        - pip install bandit
+        - pip install pylint
+        - pip install flake8
+
+      script:
+        - coverage run -a -m py.test security_monkey/tests/auditors || exit 1
+        - coverage run -a -m py.test security_monkey/tests/watchers || exit 1
+        - coverage run -a -m py.test security_monkey/tests/core || exit 1
+        - coverage run -a -m py.test security_monkey/tests/scheduling || exit 1
+        - coverage run -a -m py.test security_monkey/tests/views || exit 1
+        - coverage run -a -m py.test security_monkey/tests/interface || exit 1
+        - coverage run -a -m py.test security_monkey/tests/utilities || exit 1
+        - bandit -r -ll -ii -x security_monkey/tests .
+        - pylint -E -d E1101,E0611,F0401 --ignore=service.py,datastore.py,datastore_utils.py,watcher.py,test_celery_scheduler.py security_monkey
+        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 
       after_success:
         - coveralls

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'Jinja2>=2.8.1',
         'SQLAlchemy==0.9.2',
         'boto>=2.41.0',
-        'ipaddr==2.1.11',
+        'ipaddr==2.2.0',
         'itsdangerous==0.23',
         'psycopg2==2.7.3.2',
         'bcrypt==3.1.2',


### PR DESCRIPTION
Add Python 3 testing to Travis CI.  Given that these are early daze, lets leave it in __allow_failures__ mode until we get the kinks worked out.  Also added some key falke8 tests to find undefined names (like __unicode__ in Python 3) and Syntax Errors (like legacy style print statements).  PyLint and Bandit do _not_ find undefined names.