### PR TITLE
Fix flask deprecation warnings #976 

### DIFF
--- a/security_monkey/auth/modules.py
+++ b/security_monkey/auth/modules.py
@@ -5,7 +5,7 @@ from flask_security.core import AnonymousUser
 from security_monkey.datastore import User
 
 try:
-    from flask.ext.login import current_user
+    from flask_login import current_user
 except ImportError:
     current_user = None
 

--- a/security_monkey/manage.py
+++ b/security_monkey/manage.py
@@ -15,7 +15,7 @@ from datetime import datetime
 import json
 import sys
 
-from flask.ext.script import Manager, Command, Option, prompt_pass
+from flask_script import Manager, Command, Option, prompt_pass
 
 from six import text_type
 
@@ -26,7 +26,7 @@ from security_monkey.datastore import clear_old_exceptions, store_exception, Acc
 from security_monkey import app, db, jirasync
 from security_monkey.common.route53 import Route53Service
 
-from flask.ext.migrate import Migrate, MigrateCommand
+from flask_migrate import Migrate, MigrateCommand
 
 from security_monkey.task_scheduler.tasks import manual_run_change_reporter, manual_run_change_finder
 from security_monkey.task_scheduler.tasks import audit_changes as sm_audit_changes

--- a/security_monkey/sso/service.py
+++ b/security_monkey/sso/service.py
@@ -12,7 +12,7 @@ import binascii
 
 from flask import g, current_app
 
-from flask.ext.principal import identity_loaded, RoleNeed, UserNeed
+from flask_principal import identity_loaded, RoleNeed, UserNeed
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization

--- a/security_monkey/sso/views.py
+++ b/security_monkey/sso/views.py
@@ -11,8 +11,8 @@ import requests
 
 from flask import Blueprint, current_app, redirect, request
 
-from flask.ext.restful import reqparse, Resource, Api
-from flask.ext.principal import Identity, identity_changed
+from flask_restful import reqparse, Resource, Api
+from flask_principal import Identity, identity_changed
 from flask_security.utils import login_user
 
 try:

--- a/security_monkey/views/account_config.py
+++ b/security_monkey/views/account_config.py
@@ -28,7 +28,7 @@ from security_monkey.datastore import AccountType
 from security_monkey.account_manager import account_registry, load_all_account_types
 from security_monkey import rbac
 
-from flask.ext.restful import reqparse
+from flask_restful import reqparse
 
 class AccountConfigGet(AuthenticatedService):
     decorators = [

--- a/security_monkey/views/account_pattern_audit_score.py
+++ b/security_monkey/views/account_pattern_audit_score.py
@@ -28,7 +28,7 @@ from security_monkey.datastore import AccountPatternAuditScore
 from security_monkey.datastore import ItemAuditScore
 from security_monkey import db, app, rbac
 
-from flask.ext.restful import marshal, reqparse
+from flask_restful import marshal, reqparse
 
 
 class AccountPatternAuditScoreGet(AuthenticatedService):

--- a/security_monkey/views/audit_scores.py
+++ b/security_monkey/views/audit_scores.py
@@ -28,7 +28,7 @@ from security_monkey.views import ACCOUNT_PATTERN_AUDIT_SCORE_FIELDS
 from security_monkey.datastore import ItemAuditScore
 from security_monkey import db, rbac
 
-from flask.ext.restful import marshal, reqparse
+from flask_restful import marshal, reqparse
 
 
 class AuditScoresGet(AuthenticatedService):


### PR DESCRIPTION
This RP fixes all ExtDeprecationWarning except those which inside `/path/to/code/file/lib/python2.7/site-packages/`.
I suppose that upgrading our requirements(https://requires.io/github/cclauss/security_monkey/requirements/?branch=develop) should go in one of next PRs. #976 