### PR TITLE
Try to pass the pytests on Python 3

### DIFF
--- a/security_monkey/auditors/github/repo.py
+++ b/security_monkey/auditors/github/repo.py
@@ -21,6 +21,8 @@
 .. moduleauthor:: Mike Grima <mgrima@netflix.com>
 
 """
+from six import itervalues
+
 from security_monkey.auditor import Auditor
 from security_monkey.watchers.github.repo import GitHubRepo
 
@@ -111,6 +113,6 @@ class GitHubRepoAuditor(Auditor):
         """
         tag = "Repo has teams with admin permissions."
 
-        for permission in repo_item.config["team_permissions"].itervalues():
+        for permission in itervalues(repo_item.config["team_permissions"]):
             if permission == "admin":
                 self.add_issue(3, tag, repo_item, notes="Repo has a team with admin permissions to it.")


### PR DESCRIPTION
This PR clears up one of the tests by converting __my_dict.itervalues()__ --> __six.itervalues(my_dict)__.

One file that is problematic is __security_monkey/tests/auditors/test_resource_policy_auditor.py__ because its tests hang so you can not see the results of any of the tests.  There are two tests that fail __outside__ of that file:
* One about a [dictionary changing size during iteration](https://travis-ci.org/Netflix/security_monkey/jobs/349831772#L1912) which Python 3 does not allow and
* One about [bytes vs. strings](https://travis-ci.org/Netflix/security_monkey/jobs/349831772#L1957) which Python 3 is much more strict about.