### PR TITLE
Fixing Travis CI build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:latest
+FROM ubuntu:xenial
 MAINTAINER Netflix Open Source Development <talent@netflix.com>
 
 ENV SECURITY_MONKEY_VERSION=v1.0 \
@@ -22,10 +22,12 @@ SHELL ["/bin/bash", "-c"]
 WORKDIR /usr/local/src/security_monkey
 COPY requirements.txt /usr/local/src/security_monkey/
 
+RUN echo "UTC" > /etc/timezone
+
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y build-essential python-pip python-dev && \
-    apt-get install --no-install-recommends -y wget postgresql postgresql-contrib libpq-dev libffi-dev libxml2-dev libxmlsec1-dev && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y build-essential python-pip python-dev && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y wget postgresql postgresql-contrib libpq-dev libffi-dev libxml2-dev libxmlsec1-dev && \
     apt-get clean -y && \
     pip install setuptools --upgrade && \
     pip install pip --upgrade && \

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -15,7 +15,7 @@
 FROM nginx:stable
 MAINTAINER Netflix Open Source Development <talent@netflix.com>
 
-ENV SECURITY_MONKEY_VERSION=v1.0
+ENV SECURITY_MONKEY_VERSION=v1.1.0
 RUN apt-get update &&\
   apt-get install -y curl git sudo apt-transport-https gnupg &&\
   curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &&\

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ cloudaux==1.4.13
 celery==4.2.0rc2
 celery[redis]==4.2.0rc2
 redis==2.10.6
-Flask>=0.12.2
+Flask==0.12.2           # Need to upgrade this with Flask-SqlAlchemy.
 Flask-Mail==0.9.1
 Flask-Migrate==2.1.1
 Flask-Principal==0.4.0
 Flask-RESTful==0.3.6
-Flask-SQLAlchemy==1.0
+Flask-SQLAlchemy==1.0    # Upgrade this for SM release 1.2.0
 Flask-Script==0.6.3
 Flask-Security>=3.0.0
 Flask-WTF>=0.14.2


### PR DESCRIPTION
Fixing the builds.

Pinned Flask to version 0.12.2, and also fixed Docker pulling in Bionic.

Changes made to the `Dockerfile` should work properly with Bionic, but we will need to spend additional time with Bionic to see what other changes will need to happen for SM to work properly on it.

For now, users are recommended to utilize Xenial (16.04).