### PR TITLE
Fix docker init after docker changes

### DIFF
--- a/docker/api-init.sh
+++ b/docker/api-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Wait the database
 sleep 10
@@ -19,7 +19,6 @@ mkdir -p /var/log/security_monkey/
 touch "/var/log/security_monkey/security_monkey-deploy.log"
 
 cd /usr/local/src/security_monkey
-source venv/bin/activate
 monkey db upgrade
 
 # -------------ADD ADDITIONAL MONKEY COMMANDS TO EXEUTE HERE-------------


### PR DESCRIPTION
Quick small fix. Removes call to virtualenv, since they were removed from the docker environment. Also set the script to explode on errors, to prevent zombie containers.