### PR TITLE
Pin openstacksdk versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       - pip install pip --upgrade
       - pip install setuptools --upgrade
       - pip install google-compute-engine
-      - pip install openstacksdk
+      - pip install "openstacksdk==0.9.18"
       - pip install cloudaux\[gcp\]
       - pip install cloudaux\[openstack\]
       - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
       - pip install pip --upgrade
       - pip install setuptools --upgrade
       - pip install google-compute-engine
+      - pip install "os-client-config==1.28.0"
       - pip install "openstacksdk==0.9.18"
       - pip install cloudaux\[gcp\]
       - pip install cloudaux\[openstack\]


### PR DESCRIPTION
Pinning openstacksdk to 0.9.18 and os-client-config to 1.28.0 (which is floating dependency), as is root cause of test failures.