### PR TITLE
Enhancements for OpenStack security group auditor

### DIFF
--- a/security_monkey/auditors/openstack/openstack_security_group.py
+++ b/security_monkey/auditors/openstack/openstack_security_group.py
@@ -31,3 +31,10 @@ class OpenStackSecurityGroupAuditor(SecurityGroupAuditor):
 
     def __init__(self, accounts=None, debug=False):
         super(OpenStackSecurityGroupAuditor, self).__init__(accounts=accounts, debug=debug)
+
+    def check_securitygroup_ec2_rfc1918(self, sg_item):
+        pass
+
+    def _check_internet_cidr(self, cidr):
+        ''' some public clouds default to none for any source '''
+        return not cidr or super(OpenStackSecurityGroupAuditor, self)._check_internet_cidr(cidr)

--- a/security_monkey/auditors/security_group.py
+++ b/security_monkey/auditors/security_group.py
@@ -143,6 +143,9 @@ class SecurityGroupAuditor(Auditor):
     def check_unknown_cross_account_egress(self, item):
         self._check_cross_account(item, 'UNKNOWN', self.record_unknown_access, direction='egress', severity=10)
 
+    def _check_internet_cidr(self, cidr):
+        return str(cidr).endswith('/0')
+
     def _check_internet_accessible(self, item, direction='ingress', severity=10):
         """
         Make sure the SG does not contain any 0.0.0.0/0 or ::/0 rules.
@@ -162,7 +165,7 @@ class SecurityGroupAuditor(Auditor):
                 continue
 
             cidr = rule.get("cidr_ip")
-            if not str(cidr).endswith('/0'):
+            if not self._check_internet_cidr(cidr):
                 continue
 
             actions = self._port_for_rule(rule)

--- a/security_monkey/tests/auditors/openstack/test_openstack_security_group.py
+++ b/security_monkey/tests/auditors/openstack/test_openstack_security_group.py
@@ -1,0 +1,118 @@
+#     Copyright (c) 2018 AT&T Intellectual Property. All rights reserved.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.tests.test_security_group
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Michael Stair <mstair@att.com>
+
+"""
+from security_monkey import AWS_DEFAULT_REGION
+from security_monkey.tests import SecurityMonkeyTestCase
+from security_monkey.auditors.openstack.openstack_security_group import OpenStackSecurityGroupAuditor
+from security_monkey.watchers.openstack.openstack_watcher import OpenStackChangeItem
+from security_monkey.datastore import Account, AccountType
+from security_monkey import db
+
+INTERNET_SG_EGRESS = {
+    'id': 'sg-12345678',
+    'name': 'INTERNETSG',
+    'rules': [
+        {
+            'cidr_ip': None,
+            'rule_type': 'egress',
+            'from_port': 80,
+            'to_port': 80,
+            'ip_protocol': 'TCP'
+        }
+    ]
+}
+
+INTERNET_SG_INGRESS = {
+    'id': 'sg-12345679',
+    'name': 'INTERNETSG',
+    'rules': [
+        {        
+            'cidr_ip': '0.0.0.0/0',
+            'rule_type': 'ingress',
+            'from_port': 80,
+            'to_port': 80,
+            'ip_protocol': 'TCP'
+        }        
+    ]        
+}       
+
+INTERNAL_SG = {
+    'id': 'sg-87654321',
+    'name': 'INTERNALSG',
+    'rules': [
+        {       
+            'cidr_ip': '10.0.0.0/8',
+            'rule_type': 'ingress',
+            'from_port': 80,
+            'to_port': 80,
+            'ip_protocol': 'TCP'
+        }       
+    ]       
+}  
+
+class OpenStackSecurityGroupAuditorTestCase(SecurityMonkeyTestCase):
+
+    def pre_test_setup(self):
+
+        OpenStackSecurityGroupAuditor(accounts=['TEST_ACCOUNT']).OBJECT_STORE.clear()
+        account_type_result = AccountType(name='AWS')
+        db.session.add(account_type_result)
+        db.session.commit()
+
+        # main
+        account = Account(identifier="123456789123", name="TEST_ACCOUNT",
+                          account_type_id=account_type_result.id, notes="TEST_ACCOUNT",
+                          third_party=False, active=True)
+
+        db.session.add(account)
+        db.session.commit()
+
+    def test_check_securitygroup_ec2_rfc1918(self):
+        auditor = OpenStackSecurityGroupAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+
+        item = OpenStackChangeItem(region=AWS_DEFAULT_REGION, account='TEST_ACCOUNT', name='INTERNAL_SG', 
+                                    config=INTERNAL_SG)
+
+        auditor.check_securitygroup_ec2_rfc1918(item)
+        self.assertEquals(len(item.audit_issues), 0)
+
+    def test_check_internet_accessible_ingress(self):
+        auditor = OpenStackSecurityGroupAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+
+        item = OpenStackChangeItem(region=AWS_DEFAULT_REGION, account='TEST_ACCOUNT', name='INTERNET_SG_INGRESS', 
+                                    config=INTERNET_SG_INGRESS)
+
+        auditor.check_internet_accessible_ingress(item)
+        self.assertEquals(len(item.audit_issues), 1)
+        self.assertEquals(item.audit_issues[0].score, 0)
+
+    def test_check_internet_accessible_egress(self):
+        auditor = OpenStackSecurityGroupAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+
+        item = OpenStackChangeItem(region=AWS_DEFAULT_REGION, account='TEST_ACCOUNT', name='INTERNET_SG_EGRESS', 
+                                    config=INTERNET_SG_EGRESS)
+
+        auditor.check_internet_accessible_egress(item)
+        self.assertEquals(len(item.audit_issues), 1)
+        self.assertEquals(item.audit_issues[0].score, 0)

--- a/security_monkey/tests/auditors/test_security_group.py
+++ b/security_monkey/tests/auditors/test_security_group.py
@@ -1,0 +1,119 @@
+#     Copyright (c) 2018 AT&T Intellectual Property. All rights reserved.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.tests.test_security_group
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Michael Stair <mstair@att.com>
+
+"""
+from security_monkey import AWS_DEFAULT_REGION
+from security_monkey.tests import SecurityMonkeyTestCase
+from security_monkey.auditors.security_group import SecurityGroupAuditor
+from security_monkey.watchers.security_group import SecurityGroupItem
+from security_monkey.datastore import Account, AccountType
+from security_monkey import db
+
+INTERNET_SG_EGRESS = {
+    'id': 'sg-12345678',
+    'name': 'INTERNETSG',
+    'rules': [
+        {
+            'cidr_ip': '0.0.0.0/0',
+            'rule_type': 'egress',
+            'from_port': 80,
+            'to_port': 80,
+            'ip_protocol': 'TCP'
+        }
+    ]
+}
+
+INTERNET_SG_INGRESS = {
+    'id': 'sg-12345679',
+    'name': 'INTERNETSG',
+    'rules': [
+        {
+            'cidr_ip': '0.0.0.0/0',
+            'rule_type': 'ingress',
+            'from_port': 80,
+            'to_port': 80,
+            'ip_protocol': 'TCP'
+        }
+    ]
+}
+
+INTERNAL_SG = {
+    'id': 'sg-87654321',
+    'name': 'INTERNALSG',
+    'rules': [
+        {
+            'cidr_ip': '10.0.0.0/8',
+            'rule_type': 'ingress',
+            'from_port': 80,
+            'to_port': 80,
+            'ip_protocol': 'TCP'
+        }
+    ]
+}
+
+class SecurityGroupAuditorTestCase(SecurityMonkeyTestCase):
+
+    def pre_test_setup(self):
+
+        SecurityGroupAuditor(accounts=['TEST_ACCOUNT']).OBJECT_STORE.clear()
+        account_type_result = AccountType(name='AWS')
+        db.session.add(account_type_result)
+        db.session.commit()
+
+        # main
+        account = Account(identifier="123456789123", name="TEST_ACCOUNT",
+                          account_type_id=account_type_result.id, notes="TEST_ACCOUNT",
+                          third_party=False, active=True)
+
+        db.session.add(account)
+        db.session.commit()
+
+    def test_check_securitygroup_ec2_rfc1918(self):
+        auditor = SecurityGroupAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+
+        item = SecurityGroupItem(region=AWS_DEFAULT_REGION, account='TEST_ACCOUNT', name='INTERNAL_SG', 
+                                    config=INTERNAL_SG)
+
+        auditor.check_securitygroup_ec2_rfc1918(item)
+        self.assertEquals(len(item.audit_issues), 1)
+        self.assertEquals(item.audit_issues[0].score, 0)
+
+    def test_check_internet_accessible_ingress(self):
+        auditor = SecurityGroupAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+
+        item = SecurityGroupItem(region=AWS_DEFAULT_REGION, account='TEST_ACCOUNT', name='INTERNET_SG_INGRESS', 
+                                    config=INTERNET_SG_INGRESS)
+
+        auditor.check_internet_accessible_ingress(item)
+        self.assertEquals(len(item.audit_issues), 1)
+        self.assertEquals(item.audit_issues[0].score, 0)
+
+    def test_check_internet_accessible_egress(self):
+        auditor = SecurityGroupAuditor(accounts=['TEST_ACCOUNT'])
+        auditor.prep_for_audit()
+
+        item = SecurityGroupItem(region=AWS_DEFAULT_REGION, account='TEST_ACCOUNT', name='INTERNET_SG_EGRESS', 
+                                    config=INTERNET_SG_EGRESS)
+
+        auditor.check_internet_accessible_egress(item)
+        self.assertEquals(len(item.audit_issues), 1)
+        self.assertEquals(item.audit_issues[0].score, 0)

--- a/security_monkey/watchers/openstack/network/openstack_security_group.py
+++ b/security_monkey/watchers/openstack/network/openstack_security_group.py
@@ -27,8 +27,8 @@ from cloudaux.orchestration.openstack.security_group import get_security_group, 
 
 class OpenStackSecurityGroup(OpenStackWatcher):
     index = 'openstack_securitygroup'
-    i_am_singular = 'Subnet'
-    i_am_plural = 'Subnets'
+    i_am_singular = 'Security Group'
+    i_am_plural = 'Security Groups'
     account_type = 'OpenStack'
 
     def __init__(self, *args, **kwargs):

--- a/security_monkey/watchers/openstack/object_store/openstack_object_container.py
+++ b/security_monkey/watchers/openstack/object_store/openstack_object_container.py
@@ -25,8 +25,8 @@ from cloudaux.openstack.object_container import get_container_metadata
 
 class OpenStackObjectContainer(OpenStackWatcher):
     index = 'openstack_objectcontainer'
-    i_am_singular = 'ObjectContainer'
-    i_am_plural = 'ObjectContainers'
+    i_am_singular = 'Object Container'
+    i_am_plural = 'Object Containers'
     account_type = 'OpenStack'
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
- Handle null cidrs for Rackspace Internet accessible security groups with unit tests
- Officially add #1039 fix to OpenStack security group auditor with unit test
- Fix singular/plural names in a few OpenStack watchers