### PR TITLE
Update docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     image: postgres:10.1
     #volumes:
     #  - ./postgres-data/:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=secmonkey
 
   redis:
       container_name: secmonkey-redis


### PR DESCRIPTION
Spinning up the compose in clean build environment, secmonkey-data
was throwing the error beacuse the postgres docker was not made to
create database with the name of secmonkey. This commit handles the
same.