### PR TITLE
Justified issues should stay justified (issue #946)

### DIFF
--- a/security_monkey/auditors/iam/iam_policy.py
+++ b/security_monkey/auditors/iam/iam_policy.py
@@ -208,8 +208,9 @@ class IAMPolicyAuditor(Auditor):
                 mp_arn = mp_item.config.get('arn', mp_item.config.get('Arn'))
                 if mp_arn == item_mp_arn:
                     found = True
-                    if mp_item.db_item.issues:
-                        self.link_to_support_item_issues(iam_item, mp_item.db_item, None, "Found issue(s) in attached Managed Policy")
+                    for issue in mp_item.db_item.issues:
+                        if not issue.justified:
+                            self.link_to_support_item_issues(iam_item, mp_item.db_item, None, "Found issue(s) in attached Managed Policy")
 
             if not found:
                 app.logger.error("IAM Managed Policy defined but not found for {}-{}".format(iam_item.index, iam_item.name))

--- a/security_monkey/auditors/iam/iam_policy.py
+++ b/security_monkey/auditors/iam/iam_policy.py
@@ -211,6 +211,7 @@ class IAMPolicyAuditor(Auditor):
                     for issue in mp_item.db_item.issues:
                         if not issue.justified:
                             self.link_to_support_item_issues(iam_item, mp_item.db_item, None, "Found issue(s) in attached Managed Policy")
+                            break
 
             if not found:
                 app.logger.error("IAM Managed Policy defined but not found for {}-{}".format(iam_item.index, iam_item.name))


### PR DESCRIPTION
This is a patch for issues #946.

After running auditors, a justified issue for an IAM role becomes unjustified again if an attached managed policy has an issue. The problem is that even if the issue in the attached policy is justified the issue in the IAM role pops up again. It may create a lot of noise.

The patch updates the IAM policy auditor to prevent it from linking justified issues from attached policies.