### PR TITLE
Add header-based authentication support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ matrix:
         - coverage run -a -m py.test security_monkey/tests/views || exit 1
         - coverage run -a -m py.test security_monkey/tests/interface || exit 1
         - coverage run -a -m py.test security_monkey/tests/utilities || exit 1
+        - coverage run -a -m py.test security_monkey/tests/sso/header_auth.py || exit 1
         - bandit -r -ll -ii -x security_monkey/tests .
         - pylint -E -d E1101,E0611,F0401 --ignore=service.py,datastore.py,datastore_utils.py,watcher.py,test_celery_scheduler.py security_monkey
         - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics

--- a/env-config/config-docker.py
+++ b/env-config/config-docker.py
@@ -259,5 +259,13 @@ REMEMBER_COOKIE_DURATION=timedelta(minutes=60)  # Can make longer if you want re
 REMEMBER_COOKIE_SECURE=True
 REMEMBER_COOKIE_HTTPONLY=True
 
+# Header auth allows you to trust a header set by a reverse proxy to
+# authenticate the current user. This is useful if you have an authn
+# wall in front of your intranet that already knows the identity of
+# the requester and can pass it along to Security Monkey.
+USE_HEADER_AUTH=env_to_bool(os.getenv("SECURITY_MONKEY_USE_HEADER_AUTH", False))
+HEADER_AUTH_USERNAME_HEADER=os.getenv("SECURITY_MONKEY_HEADER_AUTH_USERNAME_HEADER", "Remote-User")
+HEADER_AUTH_GROUPS_HEADER=os.getenv("SECURITY_MONKEY_HEADER_AUTH_GROUPS_HEADER")
+
 # Log SSL Cert SubjectAltName errors
 LOG_SSL_SUBJ_ALT_NAME_ERRORS = True

--- a/env-config/config-local.py
+++ b/env-config/config-local.py
@@ -210,5 +210,13 @@ ONELOGIN_SETTINGS = {
     }
 }
 
+# Header auth allows you to trust a header set by a reverse proxy to
+# authenticate the current user. This is useful if you have an authn
+# wall in front of your intranet that already knows the identity of
+# the requester and can pass it along to Security Monkey.
+USE_HEADER_AUTH=False
+HEADER_AUTH_USERNAME_HEADER="Remote-User"
+HEADER_AUTH_GROUPS_HEADER=None
+
 # Log SSL Cert SubjectAltName errors
 LOG_SSL_SUBJ_ALT_NAME_ERRORS = True

--- a/env-config/config.py
+++ b/env-config/config.py
@@ -246,6 +246,14 @@ REMEMBER_COOKIE_DURATION=timedelta(minutes=60)  # Can make longer if you want re
 REMEMBER_COOKIE_SECURE=True
 REMEMBER_COOKIE_HTTPONLY=True
 
+# Header auth allows you to trust a header set by a reverse proxy to
+# authenticate the current user. This is useful if you have an authn
+# wall in front of your intranet that already knows the identity of
+# the requester and can pass it along to Security Monkey.
+USE_HEADER_AUTH=False
+HEADER_AUTH_USERNAME_HEADER="Remote-User"
+HEADER_AUTH_GROUPS_HEADER=None
+
 # Apscheduler Configurations
 # Length of time, in seconds, before a scheduled job is cancelled due to thread contention or other issues
 MISFIRE_GRACE_TIME=30

--- a/security_monkey/__init__.py
+++ b/security_monkey/__init__.py
@@ -355,6 +355,11 @@ def setup_logging():
 setup_logging()
 
 
+from .sso.header_auth import HeaderAuthExtension
+header_auth = HeaderAuthExtension()
+header_auth.init_app(app)
+
+
 ### Sentry ###
 try:
     from raven.contrib.flask import Sentry

--- a/security_monkey/sso/header_auth.py
+++ b/security_monkey/sso/header_auth.py
@@ -12,7 +12,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 """
-.. module: security_monkey.tests.watchers.openstack
+.. module: security_monkey.sso.header_auth
     :platform: Unix
 
 .. version:: $$VERSION$$

--- a/security_monkey/sso/header_auth.py
+++ b/security_monkey/sso/header_auth.py
@@ -1,0 +1,76 @@
+#     Copyright (c) 2018 Reddit Inc. All rights reserved.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.tests.watchers.openstack
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Jordan Milne <jordan.milne@reddit.com>
+
+"""
+
+import functools
+
+from flask import request
+from flask_login import current_user
+from flask_principal import Identity, identity_changed
+from flask_security.utils import login_user
+
+from security_monkey.sso.service import setup_user
+from security_monkey import db
+
+
+class HeaderAuthExtension(object):
+    """
+    Extension for handling login via authn headers set by a trusted reverse proxy
+    """
+    def __init__(self, app=None):
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        orig_login = app.view_functions['security.login']
+
+        # Wrap Flask-Security's login view with logic to try header-based authn
+        @functools.wraps(orig_login)
+        def _wrapped_login_view():
+            if app.config.get("USE_HEADER_AUTH"):
+                username_header_name = app.config["HEADER_AUTH_USERNAME_HEADER"]
+                groups_header_name = app.config.get("HEADER_AUTH_GROUPS_HEADER")
+
+                authed_user = request.headers.get(username_header_name)
+                # Don't have a valid session but have a trusted authn header
+                if not current_user.is_authenticated and authed_user:
+                    groups = []
+                    if groups_header_name and groups_header_name in request.headers:
+                        groups = request.headers[groups_header_name].split(",")
+                    user = setup_user(
+                        authed_user,
+                        groups=groups,
+                        default_role=app.config.get('HEADER_AUTH_DEFAULT_ROLE', 'View')
+                    )
+                    # Tell Flask-Principal the identity changed
+                    identity_changed.send(app, identity=Identity(user.id))
+                    login_user(user)
+                    db.session.commit()
+                    db.session.refresh(user)
+
+            return orig_login()
+
+        # Tell the RBAC module that this view is meant to be reachable pre-auth
+        rbac = app.extensions['rbac'].rbac
+        rbac.exempt(_wrapped_login_view)
+
+        # Replace Flask-Security's login endpoint with our wrapped version
+        app.view_functions['security.login'] = _wrapped_login_view

--- a/security_monkey/sso/header_auth.py
+++ b/security_monkey/sso/header_auth.py
@@ -1,4 +1,4 @@
-#     Copyright (c) 2018 Reddit Inc. All rights reserved.
+#     Copyright 2018 Netflix, Inc.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
 #     you may not use this file except in compliance with the License.

--- a/security_monkey/tests/sso/header_auth.py
+++ b/security_monkey/tests/sso/header_auth.py
@@ -12,7 +12,7 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 """
-.. module: security_monkey.tests.watchers.openstack
+.. module: security_monkey.tests.sso.header_auth
     :platform: Unix
 
 .. version:: $$VERSION$$

--- a/security_monkey/tests/sso/header_auth.py
+++ b/security_monkey/tests/sso/header_auth.py
@@ -1,4 +1,4 @@
-#     Copyright (c) 2018 Reddit Inc. All rights reserved.
+#     Copyright 2018 Netflix, Inc.
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
 #     you may not use this file except in compliance with the License.

--- a/security_monkey/tests/sso/header_auth.py
+++ b/security_monkey/tests/sso/header_auth.py
@@ -1,0 +1,59 @@
+#     Copyright (c) 2018 Reddit Inc. All rights reserved.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+"""
+.. module: security_monkey.tests.watchers.openstack
+    :platform: Unix
+
+.. version:: $$VERSION$$
+.. moduleauthor:: Jordan Milne <jordan.milne@reddit.com>
+
+"""
+
+from mock import patch
+
+from security_monkey.tests import SecurityMonkeyTestCase
+from security_monkey.datastore import User
+
+
+class HeaderAuthTestCase(SecurityMonkeyTestCase):
+    def _get_user(self, email):
+        return User.query.filter(User.email == email).scalar()
+
+    def test_header_auth_disabled(self):
+        with patch.dict(self.app.config, {"USE_HEADER_AUTH": False}):
+            r = self.test_app.get('/login', headers={"Remote-User": "foo@example.com"})
+            self.assertFalse(self._get_user("foo@example.com"))
+            self.assertEqual(r.status_code, 200)
+
+    def test_header_auth_enabled(self):
+        with patch.dict(self.app.config, {"USE_HEADER_AUTH": True}):
+            r = self.test_app.get('/login', headers={"Remote-User": "foo@example.com"})
+            user = self._get_user("foo@example.com")
+            self.assertIsNotNone(user)
+            self.assertEqual(user.role, "View")
+            self.assertEqual(r.status_code, 302)
+
+    def test_header_auth_groups_used(self):
+        with patch.dict(self.app.config, {"USE_HEADER_AUTH": True,
+                                          "HEADER_AUTH_GROUPS_HEADER": "Remote-Groups",
+                                          "ADMIN_GROUP": "admingroup",
+                                          }):
+            r = self.test_app.get('/login', headers={
+                "Remote-User": "foo@example.com",
+                "Remote-Groups": "foo,admingroup"
+            })
+            user = self._get_user("foo@example.com")
+            self.assertIsNotNone(user)
+            self.assertEqual(user.role, "Admin")
+            self.assertEqual(r.status_code, 302)


### PR DESCRIPTION
This allows Security Monkey to use the value of a specified header to identity the current user. This is mostly useful if you already have strong authentication in front of your reverse proxy and your reverse proxy can pass along the current user's email in a header.

Resolves #951