### PR TITLE
Slackbot API for Security Monkey Custom Alerting

### DIFF
--- a/security_monkey/alerters/custom_alerter.py
+++ b/security_monkey/alerters/custom_alerter.py
@@ -1,4 +1,4 @@
-#     Copyright 2016 Bridgewater Associates
+#     Copyright 2018 Willowtree Inc
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
 #     you may not use this file except in compliance with the License.
@@ -14,32 +14,52 @@
 """
 .. module: security_monkey.alerters.custom_alerter
     :platform: Unix
-
-.. version:: $$VERSION$$
-.. moduleauthor:: Bridgewater OSS <opensource@bwater.com>
-
-
+.. version:: SlackBot Integration Alerter w/ Security_Monkey
+.. moduleauthor:: Drew Gallis <drew.gallis@willowtreeapps.com>
 """
 from security_monkey import app
+from slacktest import postMessage
+import os
 
 alerter_registry = []
 
-
 class AlerterType(type):
-
-    def __init__(cls, name, bases, attrs):
+    print(os.environ) #remove if you don't need to check your env for your slack api token
+    def __init__(self, cls, name, bases, attrs):
         if getattr(cls, "report_auditor_changes", None) and getattr(cls, "report_watcher_changes", None):
             app.logger.debug("Registering alerter %s", cls.__name__)
             alerter_registry.append(cls)
 
 
 def report_auditor_changes(auditor):
-    for alerter_class in alerter_registry:
-        alerter = alerter_class()
-        alerter.report_auditor_changes(auditor)
-
+       for item in auditor.items:
+            for issue in item.confirmed_new_issues:
+                # Create a text output of your auditor new issue in scope
+                attachment = "ID: {!s}\n Index: {!s}\n Account: {!s}\n Region: {!s}\n Name: {!s}\n Issue: {!s}".format(issue.id, item.index, item.account, item.region, item.name, issue.issue)
+                print("attachment: " + attachment)
+                postMessage(attachment, "Auditor - Reporting on Issue Created", item.index, item.name) 
+            for issue in item.confirmed_fixed_issues:
+                # Create a text output of your auditor fixed issue in scope
+                attachment = "ID: {!s}\n Index: {!s}\n Account: {!s}\n Region: {!s}\n Name: {!s}\n Issue: {!s}".format(issue.id, item.index, item.account, item.region, item.name, issue.issue)
+                print("attachment: " + attachment)
+                postMessage(attachment, "Auditor - Reporting on Issue Fixed", item.index, item.name) 
 
 def report_watcher_changes(watcher):
-    for alerter_class in alerter_registry:
-        alerter = alerter_class()
-        alerter.report_watcher_changes(watcher)
+    print(watcher.created_items)
+    for item in watcher.created_items:
+        attachment = "Index: {!s}\n Account: {!s}\n Region: {!s}\n Name: {!s}".format(item.index, item.account, item.region, item.name)
+        print("attachment: " + attachment)
+        postMessage(attachment, "Watcher - Created Items", item.index, item.name) 
+
+    print(watcher.deleted_items)
+    for item in watcher.deleted_items:
+        attachment = "Index: {!s}\n Account: {!s}\n Region: {!s}\n Name: {!s}".format(item.index, item.account, item.region, item.name)
+        print("attachment: " + attachment)
+        postMessage(attachment, "Watcher - Deleted Items", item.index, item.name) 
+
+    print(watcher.changed_items)
+    for item in watcher.changed_items:
+        attachment = "Index: {!s}\n Account: {!s}\n Region: {!s}\n Name: {!s}".format(item.index, item.account, item.region, item.name)
+        print("attachment: " + attachment)
+        postMessage(attachment, "Watcher - Changed Items", item.index, item.name)  
+

--- a/security_monkey/alerters/custom_alerter.py
+++ b/security_monkey/alerters/custom_alerter.py
@@ -18,7 +18,7 @@
 .. moduleauthor:: Drew Gallis <drew.gallis@willowtreeapps.com>
 """
 from security_monkey import app
-from slacktest import postMessage
+from slack_post import postMessage
 import os
 
 alerter_registry = []

--- a/security_monkey/alerters/slack_integration.md
+++ b/security_monkey/alerters/slack_integration.md
@@ -1,0 +1,87 @@
+# Slack Integration w/Security Monkey
+
+---
+
+[Click here to read the slackAPI Documentation](https://api.slack.com/#read_the_docs)
+
+---
+
+### Integration Tutorial for Instances using a Scheduler:
+
+#### Installing the bot on your Security Monkey EC2 instance:
+
+```
+cd /usr/local/src/security_monkey
+```
+
+```
+source venv/bin/activate
+```
+
+```
+pip install slackclient
+```
+
+#### Setting up your "APP" on Slack
+
+[Handy Link to Create a Slackbot App](https://api.slack.com/apps/new)
+
+When prompted to give a App Name you can name it whatever relates to your project (ex: SMSlackBot).
+Make sure your App is in the correct development workspace in reference to where you would like it to be present
+
+#### Creating a bot to send/receive the requests:
+
+After creating the application, we need to create a bot user which handles the conversations and messaging between security monkey and slack. Create a new [bot user](https://api.slack.com/bot-users) and then continue by saving the changes.
+
+#### Setting up communication/authentication:
+
+After your new bot is now created with it's username, Click on the "Install App" under the "Settings" section. The button on this page will install the App into our your workspace you selected the app to be in at the start. Once the App is installed, it displays a bot user oauth access token for authentication as the bot user. We want the "Bot User OAuth Access Token", since this is the one that is linked to our bot we just created. Using this key generated we need to add it to our environment on our Security Monkey instance.
+
+The tricky part about this is depending on the Implementation it may either need to be in the scheduler environment, user environment, or "root" environment.
+
+##### a. Scheduler environment (Supervisor/Celery Conf Setup):
+
+```
+cd /usr/local/src/security_monkey/supervisor/security_monkey_scheduler.conf
+```
+
+```
+vi security_monkey_scheduler.conf or nano 
+security_monkey_scheduler.conf
+```
+
+```
+add env location your SLACK_API_TOKEN information to make sure when the supervisor runs that it actually is present in the environment.
+```
+
+##### b. User environment (Manual Setup - Ran as user):
+
+```
+cd /usr/local/src/security_monkey
+```
+
+```
+source venv/bin/activate
+```
+
+```
+export SLACK_API_TOKEN=OAUTH TOKEN HERE
+```
+
+##### c. Root environment (Manual Setup - Ran as root):
+
+```
+cd /usr/local/src/security_monkey
+```
+
+```
+source venv/bin/activate
+```
+
+```
+export SLACK_API_TOKEN=OAUTH TOKEN HERE
+```
+
+```
+sudo -E bash -c 'echo $SLACK_API_TOKEN'
+```

--- a/security_monkey/alerters/slack_post.py
+++ b/security_monkey/alerters/slack_post.py
@@ -1,0 +1,43 @@
+# Houses functions used to compose slack messages to send to Slack
+#
+# Changes in here will directly affect what messages you receive in slack
+# Written by :: Drew Gallis <drew.gallis@willowtreeapps.com>
+# Date :: June 2018
+#
+
+from slackclient import SlackClient
+import os
+import json
+import requests
+
+
+def postMessage(attachment, type, tech, name):
+
+    # Post to slack
+    slack_token = os.environ["SLACK_API_TOKEN"] #env variable stored key 
+    sc = SlackClient(slack_token)
+    channel = 'CHANNEL ID HERE' #test by posting to your own slack channel id, can be changed to any channel
+
+    sc.api_call(
+        "chat.postMessage",
+        channel=channel,
+        attachments=[
+            {
+            "fallback": "New Security Monkey Notification!",
+            "color": "#36a64f",
+            "title": type
+			},
+			{
+            "author_name": "TEST AUTHOR",
+            "title": "NAME OF YOUR TITLE LINK",
+			"title_link": "https://SECURITYMONKEYURL/#/items/-/" + tech + "/-/-/" + name + "/-/-/-/-/-/1/25" #CHANGE THIS TO YOUR WEBHOOK FOR YOUR UI TO LINK TO YOUR ITEM PAGE OF THE ITEM IN SCOPE
+			},
+			{
+            "text": attachment
+           	}
+        ],
+        as_user = True,
+        username='SLACKBOT USERNAME',
+        unfurl_links = 'true',
+        unfurl_media = 'true'
+        )  

--- a/security_monkey/alerters/test_slack_message.py
+++ b/security_monkey/alerters/test_slack_message.py
@@ -1,0 +1,18 @@
+#Just a quick program to test your communication of your slack bot and security monkey
+from slack_post import postMessage
+
+type = "changedItem"
+text = "Index: ec2image\n Account: test\n Region: test\n Name: test"
+
+postMessage(text, type, "ec2", "amiImage")
+
+type = "addedItem"
+text = "Index: ec2image\n Account: test\n Region: test\n Name: test"
+
+postMessage(text, type, "ec2", "instanceName")
+
+type = "deletedItem"
+text = "Index: ec2image\n Account: test\n Region: test\n Name: test"
+
+postMessage(text, type, "s3", "bucketID")
+


### PR DESCRIPTION
Adding a Custom Alerter - SlackBot API to send custom alerts, posting auditor/watcher changes on a slack channel. Fully integrates with automated scheduler, posting to slack channel when watchers/auditors are ran. Note: make sure you have it integrated as a custom alerter so it is called by watcher.py and auditor.py!