### PR TITLE
Add optional ExternalId to sts.assume_role calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six>=1.11.0
-cloudaux==1.4.13
+cloudaux==1.5.0
 celery==4.2.0
 celery[redis]==4.2.0
 redis==2.10.6

--- a/security_monkey/account_managers/aws_account.py
+++ b/security_monkey/account_managers/aws_account.py
@@ -42,10 +42,12 @@ class AWSAccountManager(AccountManager):
                        'requires a \'list_buckets\' API call against AWS to obtain.')
     role_name_label = ("Optional custom role name, otherwise the default 'SecurityMonkey' is used. "
                        "When deploying roles via CloudFormation, this is the Physical ID of the generated IAM::ROLE.")
+    external_id_label = ("Optional custom external id. See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html")
     custom_field_configs = [
         CustomFieldConfig('canonical_id', "Canonical ID", True, s3_canonical_id),
         CustomFieldConfig('s3_name', 'S3 Name', True, s3_name_label),
-        CustomFieldConfig('role_name', 'Role Name', True, role_name_label)
+        CustomFieldConfig('role_name', 'Role Name', True, role_name_label),
+        CustomFieldConfig('external_id', 'External Id', True, external_id_label)
     ]
 
     def __init__(self):
@@ -53,7 +55,7 @@ class AWSAccountManager(AccountManager):
 
     def sanitize_account_identifier(self, identifier):
         """AWS identifer sanitization will strip and remove any hyphens.
-        
+
         Returns:
             stripped identifier with hyphens removed
         """

--- a/security_monkey/common/sts_connect.py
+++ b/security_monkey/common/sts_connect.py
@@ -54,10 +54,20 @@ def connect(account_name, connection_type, **args):
         account = Account.query.filter(Account.name == account_name).first()
         sts = boto3.client('sts', region_name=region)
         role_name = 'SecurityMonkey'
+        external_id = None
         if account.getCustom("role_name") and account.getCustom("role_name") != '':
             role_name = account.getCustom("role_name")
-        arn =ARN_PREFIX + ':iam::' + account.identifier +':role/' + role_name
-        role = sts.assume_role(RoleArn=arn, RoleSessionName='secmonkey')
+        if account.getCustom("external_id") and account.getCustom("external_id") != '':
+            external_id = account.getCustom("external_id")
+        arn = ARN_PREFIX + ':iam::' + account.identifier + ':role/' + role_name
+        assume_role_kwargs = {
+            'RoleArn': arn,
+            'RoleSessionName': 'secmonkey'
+        }
+        if external_id:
+            assume_role_kwargs['ExternalId'] = external_id
+
+        role = sts.assume_role(**assume_role_kwargs)
 
     if connection_type == 'botocore':
         botocore_session = botocore.session.get_session()

--- a/security_monkey/decorators.py
+++ b/security_monkey/decorators.py
@@ -166,11 +166,21 @@ def get_regions(account, service_name):
 
     sts = boto3.client('sts')
     role_name = 'SecurityMonkey'
+    external_id = None
     if account.getCustom("role_name") and account.getCustom("role_name") != '':
         role_name = account.getCustom("role_name")
+    if account.getCustom("external_id") and account.getCustom("external_id") != '':
+        external_id = account.getCustom("external_id")
 
     arn = ARN_PREFIX + ':iam::' + account.identifier + ':role/' + role_name
-    role = sts.assume_role(RoleArn=arn, RoleSessionName='secmonkey')
+    assume_role_kwargs = {
+        'RoleArn': arn,
+        'RoleSessionName': 'secmonkey'
+    }
+    if external_id:
+        assume_role_kwargs['ExternalId'] = external_id
+
+    role = sts.assume_role(**assume_role_kwargs)
 
     session = boto3.Session(
         aws_access_key_id=role['Credentials']['AccessKeyId'],

--- a/security_monkey/export/__init__.py
+++ b/security_monkey/export/__init__.py
@@ -124,14 +124,14 @@ def export_issues():
         query = query.join((ItemRevision, Item.latest_revision_id == ItemRevision.id))
         query = query.filter(ItemRevision.active == active)
     if 'searchconfig' in args:
-	 search = args['searchconfig'].split(',')
-	 conditions = []
-	 for searchterm in search:
-	     conditions.append(ItemAudit.issue.ilike('%{}%'.format(searchterm)))
-	     conditions.append(ItemAudit.notes.ilike('%{}%'.format(searchterm)))
-	     conditions.append(ItemAudit.justification.ilike('%{}%'.format(searchterm)))
-	     conditions.append(Item.name.ilike('%{}%'.format(searchterm)))
-	 query = query.filter(or_(*conditions))
+        search = args['searchconfig'].split(',')
+        conditions = []
+        for searchterm in search:
+            conditions.append(ItemAudit.issue.ilike('%{}%'.format(searchterm)))
+            conditions.append(ItemAudit.notes.ilike('%{}%'.format(searchterm)))
+            conditions.append(ItemAudit.justification.ilike('%{}%'.format(searchterm)))
+            conditions.append(Item.name.ilike('%{}%'.format(searchterm)))
+        query = query.filter(or_(*conditions))
     if 'enabledonly' in args:
         query = query.join((AuditorSettings, AuditorSettings.id == ItemAudit.auditor_setting_id))
         query = query.filter(AuditorSettings.disabled == False)

--- a/security_monkey/tests/utilities/test_account_utils.py
+++ b/security_monkey/tests/utilities/test_account_utils.py
@@ -45,7 +45,7 @@ class AccountTestUtils(SecurityMonkeyTestCase):
         assert account
         assert account.identifier == "99999999999"
         assert account.active
-        assert len(account.custom_fields) == 3
+        assert len(account.custom_fields) == 4
 
         # Get the canonical ID field:
         c_id = AccountTypeCustomValues.query.filter(AccountTypeCustomValues.name == "canonical_id",

--- a/security_monkey/tests/utilities/test_s3_canonical.py
+++ b/security_monkey/tests/utilities/test_s3_canonical.py
@@ -139,7 +139,7 @@ class S3CanonicalTestCase(SecurityMonkeyTestCase):
         assert account
         assert account.identifier == "99999999999"
         assert account.active
-        assert len(account.custom_fields) == 3
+        assert len(account.custom_fields) == 4
 
         # Get the canonical ID field:
         c_id = AccountTypeCustomValues.query.filter(AccountTypeCustomValues.name == "canonical_id",
@@ -167,7 +167,7 @@ class S3CanonicalTestCase(SecurityMonkeyTestCase):
         assert account
         assert account.identifier == "012345678910"
         assert account.active
-        assert len(account.custom_fields) == 3
+        assert len(account.custom_fields) == 4
 
         # Get the canonical ID field:
         c_id = AccountTypeCustomValues.query.filter(AccountTypeCustomValues.name == "canonical_id",


### PR DESCRIPTION
This PR adds an optional `External Id` field to the AWS account model. It also updates all calls to `sts.assume_role` to include that `external_id` if it's present. Resolves #1100.