### PR TITLE
Update cloudaux dependency to version 1.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six>=1.11.0
-cloudaux==1.5.0
+cloudaux==1.5.2
 celery==4.2.0
 celery[redis]==4.2.0
 redis==2.10.6


### PR DESCRIPTION
Based on our last merge request in [cloudaux](https://github.com/Netflix-Skunkworks/cloudaux/pull/85) the version of the cloudaux dependency is updated to version 1.5.2. The version update include some fixes to improve the stability and flexible for gcp. 
