### PR TITLE
Fix for item view on AccountType filter

### DIFF
--- a/security_monkey/views/item.py
+++ b/security_monkey/views/item.py
@@ -219,17 +219,17 @@ class ItemList(AuthenticatedService):
         # Read more about filtering:
         # https://docs.sqlalchemy.org/en/latest/orm/query.html
         query = Item.query.join((ItemRevision, Item.latest_revision_id == ItemRevision.id))
-        join_accounts = False
+        
         if 'regions' in args:
             regions = args['regions'].split(',')
             query = query.filter(Item.region.in_(regions))
         if 'accounts' in args:
             accounts = args['accounts'].split(',')
-            join_accounts = True
+            query = query.join((Account, Account.id == Item.account_id))
             query = query.filter(Account.name.in_(accounts))
         if 'accounttypes' in args:
             accounttypes = args['accounttypes'].split(',')
-            join_accounts = True
+            query = query.join((Account, Account.id == Item.account_id))
             query = query.join((AccountType, AccountType.id == Account.account_type_id))
             query = query.filter(AccountType.name.in_(accounttypes))
         if 'technologies' in args:
@@ -248,7 +248,7 @@ class ItemList(AuthenticatedService):
         if 'active' in args:
             active = args['active'].lower() == "true"
             query = query.filter(ItemRevision.active == active)
-            join_accounts = True
+            query = query.join((Account, Account.id == Item.account_id))
             query = query.filter(Account.active == True)
         if 'searchconfig' in args:
             searchconfig = args['searchconfig']
@@ -259,9 +259,6 @@ class ItemList(AuthenticatedService):
         if 'min_unjustified_score' in args:
             min_unjustified_score = args['min_unjustified_score']
             query = query.filter(Item.unjustified_score >= min_unjustified_score)
-
-        if join_accounts:
-            query = query.join((Account, Account.id == Item.account_id))
 
         # Eager load the joins except for the revisions because of the dynamic lazy relationship
         query = query.options(joinedload('issues'))


### PR DESCRIPTION
## Description
When selecting the AccountType filter on the Search Page aka. item view the site shows an error because of an api error (see attached screenshot). From the stacktrace (see below) that root cause is in security_monkey/views/item.py due to a premature join on AccountType with referencing Account. This PR inlines the logic of the join_accounts flag to resolve this issue.

## UI
![screenshot_2018-10-12 security monkey](https://user-images.githubusercontent.com/9693458/46996366-b58ce780-d11c-11e8-8a86-9b6c44e86332.png)

## Stacktrace 
````
2018-10-12 10:44:11 +0000] [22191] [ERROR] Error handling request /api/1/items?accounts=&accounttypes=GCP&arns=&count=25&names=&page=1®ions=&technologies=
Traceback (most recent call last):
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/gunicorn-19.7.1-py2.7.egg/gunicorn/workers/sync.py", line 135, in handle
self.handle_request(listener, req, client, addr)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/gunicorn-19.7.1-py2.7.egg/gunicorn/workers/sync.py", line 176, in handle_request
respiter = self.wsgi(environ, resp.start_response)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask-0.12.2-py2.7.egg/flask/app.py", line 1997, in __call__
return self.wsgi_app(environ, start_response)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask-0.12.2-py2.7.egg/flask/app.py", line 1985, in wsgi_app
response = self.handle_exception(e)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask_RESTful-0.3.6-py2.7.egg/flask_restful/__init__.py", line 273, in error_router
return original_handler(e)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask_RESTful-0.3.6-py2.7.egg/flask_restful/__init__.py", line 273, in error_router
return original_handler(e)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask-0.12.2-py2.7.egg/flask/app.py", line 1540, in handle_exception
reraise(exc_type, exc_value, tb)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask_RESTful-0.3.6-py2.7.egg/flask_restful/__init__.py", line 270, in error_router
return self.handle_error(e)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask-0.12.2-py2.7.egg/flask/app.py", line 1982, in wsgi_app
response = self.full_dispatch_request()
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask-0.12.2-py2.7.egg/flask/app.py", line 1614, in full_dispatch_request
rv = self.handle_user_exception(e)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask_RESTful-0.3.6-py2.7.egg/flask_restful/__init__.py", line 273, in error_router
return original_handler(e)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask_RESTful-0.3.6-py2.7.egg/flask_restful/__init__.py", line 273, in error_router
return original_handler(e)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask-0.12.2-py2.7.egg/flask/app.py", line 1517, in handle_user_exception
reraise(exc_type, exc_value, tb)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask_RESTful-0.3.6-py2.7.egg/flask_restful/__init__.py", line 270, in error_router
return self.handle_error(e)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask-0.12.2-py2.7.egg/flask/app.py", line 1612, in full_dispatch_request
rv = self.dispatch_request()
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask-0.12.2-py2.7.egg/flask/app.py", line 1598, in dispatch_request
return self.view_functions[rule.endpoint](**req.view_args)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask_RESTful-0.3.6-py2.7.egg/flask_restful/__init__.py", line 480, in wrapper
resp = resource(*args, **kwargs)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask-0.12.2-py2.7.egg/flask/views.py", line 84, in view
return self.dispatch_request(*args, **kwargs)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask_RESTful-0.3.6-py2.7.egg/flask_restful/__init__.py", line 595, in dispatch_request
resp = meth(*args, **kwargs)
File "/home/lukas/security_monkey/security_monkey/views/item.py", line 272, in get
items = query.paginate(page, count)
File "/home/lukas/virtual_envs/security_monkey/lib/python2.7/site-packages/Flask_SQLAlchemy-1.0-py2.7.egg/flask_sqlalchemy/__init__.py", line 405, in paginate
items = self.limit(per_page).offset((page - 1) * per_page).all()
File "build/bdist.linux-x86_64/egg/sqlalchemy/orm/query.py", line 2773, in all
return list(self)
File "build/bdist.linux-x86_64/egg/sqlalchemy/orm/query.py", line 2925, in __iter__
return self._execute_and_instances(context)
File "build/bdist.linux-x86_64/egg/sqlalchemy/orm/query.py", line 2948, in _execute_and_instances
result = conn.execute(querycontext.statement, self._params)
File "build/bdist.linux-x86_64/egg/sqlalchemy/engine/base.py", line 948, in execute
return meth(self, multiparams, params)
File "build/bdist.linux-x86_64/egg/sqlalchemy/sql/elements.py", line 269, in _execute_on_connection
return connection._execute_clauseelement(self, multiparams, params)
File "build/bdist.linux-x86_64/egg/sqlalchemy/engine/base.py", line 1060, in _execute_clauseelement
compiled_sql, distilled_params
File "build/bdist.linux-x86_64/egg/sqlalchemy/engine/base.py", line 1200, in _execute_context
context)
File "build/bdist.linux-x86_64/egg/sqlalchemy/engine/base.py", line 1413, in _handle_dbapi_exception
exc_info
File "build/bdist.linux-x86_64/egg/sqlalchemy/util/compat.py", line 203, in raise_from_cause
reraise(type(exception), exception, tb=exc_tb, cause=cause)
File "build/bdist.linux-x86_64/egg/sqlalchemy/engine/base.py", line 1193, in _execute_context
context)
File "build/bdist.linux-x86_64/egg/sqlalchemy/engine/default.py", line 507, in do_execute
cursor.execute(statement, parameters)
ProgrammingError: (psycopg2.ProgrammingError) missing FROM-clause entry for table "account"
LINE 3: ...evision.id JOIN account_type ON account_type.id = account.ac...
^
[SQL: 'SELECT anon_1.item_id AS anon_1_item_id, anon_1.item_region AS anon_1_item_region, anon_1.item_name AS anon_1_item_name, anon_1.item_arn AS anon_1_item_arn, anon_1.item_latest_revision_complete_hash AS anon_1_item_latest_revision_complete_hash, anon_1.item_latest_revision_durable_hash AS anon_1_item_latest_revision_durable_hash, anon_1.item_tech_id AS anon_1_item_tech_id, anon_1.item_account_id AS anon_1_item_account_id, anon_1.item_latest_revision_id AS anon_1_item_latest_revision_id, anon_1.itemrevision_date_created AS anon_1_itemrevision_date_created, itemaudit_1.id AS itemaudit_1_id, itemaudit_1.score AS itemaudit_1_score, itemaudit_1.issue AS itemaudit_1_issue, itemaudit_1.notes AS itemaudit_1_notes, itemaudit_1.action_instructions AS itemaudit_1_action_instructions, itemaudit_1.background_info AS itemaudit_1_background_info, itemaudit_1.origin AS itemaudit_1_origin, itemaudit_1.origin_summary AS itemaudit_1_origin_summary, itemaudit_1.class_uuid AS itemaudit_1_class_uuid, itemaudit_1.fixed AS itemaudit_1_fixed, itemaudit_1.justified AS itemaudit_1_justified, itemaudit_1.justified_user_id AS itemaudit_1_justified_user_id, itemaudit_1.justification AS itemaudit_1_justification, itemaudit_1.justified_date AS itemaudit_1_justified_date, itemaudit_1.item_id AS itemaudit_1_item_id, itemaudit_1.auditor_setting_id AS itemaudit_1_auditor_setting_id, account_1.id AS account_1_id, account_1.active AS account_1_active, account_1.third_party AS account_1_third_party, account_1.name AS account_1_name, account_1.notes AS account_1_notes, account_1.identifier AS account_1_identifier, account_1.account_type_id AS account_1_account_type_id, technology_1.id AS technology_1_id, technology_1.name AS technology_1_name \nFROM (SELECT item.id AS item_id, item.region AS item_region, item.name AS item_name, item.arn AS item_arn, item.latest_revision_complete_hash AS item_latest_revision_complete_hash, item.latest_revision_durable_hash AS item_latest_revision_durable_hash, item.tech_id AS item_tech_id, item.account_id AS item_account_id, item.latest_revision_id AS item_latest_revision_id, itemrevision.date_created AS itemrevision_date_created \nFROM item JOIN itemrevision ON item.latest_revision_id = itemrevision.id JOIN account_type ON account_type.id = account.account_type_id JOIN account ON account.id = item.account_id \nWHERE account_type.name IN (%(name_1)s) ORDER BY itemrevision.date_created DESC \n LIMIT %(param_1)s OFFSET %(param_2)s) AS anon_1 LEFT OUTER JOIN (issue_item_association AS issue_item_association_1 JOIN itemaudit AS itemaudit_1 ON itemaudit_1.id = issue_item_association_1.super_issue_id) ON anon_1.item_id = issue_item_association_1.sub_item_id LEFT OUTER JOIN account AS account_1 ON account_1.id = anon_1.item_account_id LEFT OUTER JOIN technology AS technology_1 ON technology_1.id = anon_1.item_tech_id ORDER BY anon_1.itemrevision_date_created DESC'] [parameters: {'name_1': 'GCP', 'param_1': 25, 'param_2': 0}] (Background on this error at: http://sqlalche.me/e/f405)
```