### PR TITLE
bug fix for when `None` type object is passed or returned to functions.

### DIFF
--- a/security_monkey/datastore.py
+++ b/security_monkey/datastore.py
@@ -526,11 +526,12 @@ class Datastore(object):
         :return: hash of the sorted json dump of the item with all ephemeral paths removed.
         """
         durable_item = deepcopy(item)
-        for path in ephemeral_paths:
-            try:
-                dpath.util.delete(durable_item, path, separator='$')
-            except PathNotFound:
-                pass
+        if ephemeral_paths:
+            for path in ephemeral_paths:
+                try:
+                    dpath.util.delete(durable_item, path, separator='$')
+                except PathNotFound:
+                    pass
         return self.hash_config(durable_item)
 
     def hash_config(self, config):

--- a/security_monkey/task_scheduler/tasks.py
+++ b/security_monkey/task_scheduler/tasks.py
@@ -226,7 +226,7 @@ def find_changes(account_name, monitor_name, debug=True):
             batch_logic(mon, cw, account_name, debug)
         else:
             # Just fetch normally...
-            (items, exception_map) = cw.slurp()
+            (items, exception_map) = cw.slurp() or ([], {})
 
             _post_metric(
                 'queue_items_added',

--- a/security_monkey/watcher.py
+++ b/security_monkey/watcher.py
@@ -336,12 +336,13 @@ class Watcher(object):
                 dur_prev_item = deepcopy(prev_item)
                 dur_curr_item = deepcopy(curr_item)
                 # filter-out ephemeral paths in both old and new config dicts
-                for path in self.ephemeral_paths:
-                    for cfg in [dur_prev_item.config, dur_curr_item.config]:
-                        try:
-                            dpath.util.delete(cfg, path, separator='$')
-                        except PathNotFound:
-                            pass
+                if self.ephemeral_paths:
+                    for path in self.ephemeral_paths:
+                        for cfg in [dur_prev_item.config, dur_curr_item.config]:
+                            try:
+                                dpath.util.delete(cfg, path, separator='$')
+                            except PathNotFound:
+                                pass
 
                 # now, compare only non-ephemeral paths
                 if not sub_dict(dur_prev_item.config) == sub_dict(dur_curr_item.config):


### PR DESCRIPTION
I ran into some bugs while developing a plugin for my employer's installation of `security-monkey` on GCP. Here are the fixes I did after comparing other to other corrections in this repo.