### PR TITLE
Bug: Scheduler Missing Registered Plugins

### DIFF
--- a/security_monkey/task_scheduler/util.py
+++ b/security_monkey/task_scheduler/util.py
@@ -10,7 +10,7 @@
 from __future__ import absolute_import
 from celery import Celery
 from security_monkey import app
-from security_monkey.common.utils import find_modules
+from security_monkey.common.utils import find_modules, load_plugins
 
 import os
 import importlib
@@ -57,6 +57,7 @@ def setup():
     find_modules('alerters')
     find_modules('watchers')
     find_modules('auditors')
+    load_plugins('security_monkey.plugins')
 
 
 def get_sm_celery_config_value(celery_config, variable_name, variable_type):


### PR DESCRIPTION
When plugins where added to the features the `manage.py` included a change to load the plugins with `load_plugins('security_monkey.plugins')`, however when the scheduler was refactored to use Celery it did not include loading the plugins to be schduled. See the following files for reference 

+ `security_monkey/manage.py` line 59
+ `security_monkey/task_scheduler/util.py` line 60
 