### PR TITLE
Schedule worker tasks at full hour

### DIFF
--- a/docs/autostarting.md
+++ b/docs/autostarting.md
@@ -121,6 +121,9 @@ configured to a `localhost` Redis.
 You may optionally adjust the `worker_concurrency`, which set the number of processes on an instance that the workers will
 use to fetch and audit your accounts.
 
+#### Tuning the scheduler
+The scheduler will register its periodic tasks with the selected interval (default 1 hour) beginning when the scheduler starts. Another option is to register the periodic tasks at a full hours. This is controlled via the variable `schedule_at_full_hour` which is per default False. The latter option has the benefit that the execution time of tasks are more deterministic which comes in handy particularly when using [alerter](./misc.md#custom-alerters). The downside of this option is that in worst case the execution of the initial task can take twice the interval.
+
 ### Supervisor
 With the message broker configured, it's now time to copy over the supervisor configuration.
 A sample is provided at: `security_monkey_scheduler.conf`(https://github.com/Netflix/security_monkey/tree/develop/supervisor/security_monkey_scheduler.conf)

--- a/security_monkey/celeryconfig.py
+++ b/security_monkey/celeryconfig.py
@@ -19,6 +19,9 @@ broker_url = 'redis://{}/{}'.format(
 # How many processes per worker instance?
 worker_concurrency = 10
 
+# Schedule tasks at full hour or scheduler boot up time
+schedule_at_full_hour = False
+
 # Running dedicated stacks? If you want to have dedicated stacks to watch specific technologies (or ignore them)
 # for added priority, then set the two variables below:
 


### PR DESCRIPTION
## Background
We often do deployment of security-monkey components like the scheduler. We also use alerters for saving monitoring relevant metrics. In this scenario we notices that it is more beneficial for the scheduler to schedule tasks at a more deterministic intervals so that our logic for monitoring dashboards can assume a replication frequency of events.  

# Changes
This PR introduces a new variable ```schedule_at_full_hour ``` for beat.py which will lead to scheduling worker tasks at full hour rates based on crontab from celery. The crontabs are intentionally based on the selection box of the frontend.
