### PR TITLE
Jira Sync: Configure only update on change

### DIFF
--- a/docs/jirasync.md
+++ b/docs/jirasync.md
@@ -20,10 +20,12 @@ To use JIRA sync, you will need to create a YAML configuration file, specifying 
  url: https://securitymonkey.example.com
  ip_proxy: example.proxy.com
  port_proxy: 443
- assignee: SecMonkeyJIRA}
+ assignee: SecMonkeyJIRA
+ only_update_on_change: false
+}
 ~~~~
 
-`server` - The location of the JIRA server. `account` - The account with which Security Monkey will create tickets `password` - The password to the account. `project` - The project key where tickets will be created. `issue_type` - The type of issue each ticket will be created as. `url` - The URL for Security Monkey. This will be used to create links back to Security Monkey. `disable_transitions` - If true, Security Monkey will not close or reopen tickets. This is false by default. `ip_proxy` - Optional proxy endpoint for JIRA client. NOTE: Proxy authentication not currently supported. `port_proxy` - Optional proxy port for JIRA client. NOTE: Proxy authentication not currently supported. `assignee` - Optional default assignee for generated JIRA tickets. Assignee should be username.
+`server` - The location of the JIRA server. `account` - The account with which Security Monkey will create tickets `password` - The password to the account. `project` - The project key where tickets will be created. `issue_type` - The type of issue each ticket will be created as. `url` - The URL for Security Monkey. This will be used to create links back to Security Monkey. `disable_transitions` - If true, Security Monkey will not close or reopen tickets. This is false by default. `ip_proxy` - Optional proxy endpoint for JIRA client. NOTE: Proxy authentication not currently supported. `port_proxy` - Optional proxy port for JIRA client. NOTE: Proxy authentication not currently supported. `assignee` - Optional default assignee for generated JIRA tickets. Assignee should be username. `only_update_on_change` - Optional (defaults to false), if true tickets only update if the count has changed.
 
 ### Using JIRA Synchronization
 


### PR DESCRIPTION
This change allows users to turn off Jira updates when there is no change. This is useful in scenarios where you aren't quite keeping on top of tickets fast enough (but you're aware of the problem) and Security Monkey spams Jira in retaliation.

* Added `only_update_on_change`option to Jira Sync yaml configuration.
  * This defaults to `false` so existing deployments won't be affected if they were to update.
  * When set to `true`, the Jira Sync logic will check whether the new issue count is different to the existing one and will only update Jira if it this is true.
* Updated Jira Sync docs accordingly.
