### PR TITLE
 Set AWS_DEFAULT_REGION environment variable

### DIFF
--- a/security_monkey/__init__.py
+++ b/security_monkey/__init__.py
@@ -71,6 +71,9 @@ if app.config.get("AWS_GOVCLOUD"):
 
 ARN_PREFIX = 'arn:' + ARN_PARTITION
 
+# Avoid the need for configuring ~/.aws/config file with default region especially in govcloud
+os.environ['AWS_DEFAULT_REGION'] = AWS_DEFAULT_REGION
+
 db = SQLAlchemy(app)
 
 # For ELB and/or Eureka


### PR DESCRIPTION
Set AWS_DEFAULT_REGION environment variable to one set as default region in security monkey.

This fix addresses following issue in aws govcloud:
------
`botocore.exceptions.ClientError: An error occurred (InvalidClientTokenId) when calling the AssumeRole operation` exception in absence of `.aws/config` file for all `find_changes` calls.
