### PR TITLE
Update documentation: GCP libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ matrix:
       - pip install pip --upgrade
       - pip install setuptools --upgrade
       - pip install google-compute-engine
+      - pip install oauth2client
+      - pip install google-api-python-client
+      - pip install httplib2 
       - pip install "os-client-config==1.28.0"
       - pip install "openstacksdk==0.9.18"
       - pip install cloudaux\[gcp\]

--- a/docs/installation/03-install-sm.md
+++ b/docs/installation/03-install-sm.md
@@ -58,6 +58,9 @@ Releases are on the master branch and are updated about every three months. Blee
     pip install --upgrade pip
     pip install --upgrade urllib3[secure]   # to prevent InsecurePlatformWarning
     pip install google-compute-engine  # Only required on GCP
+    pip install oauth2client # Required to retrieve GCP data
+    pip install google-api-python-client # Required to retrieve GCP data
+    pip install httplib2 # Required to retrieve GCP data
     pip install cloudaux\[gcp\]
     pip install cloudaux\[openstack\]    # Only required on OpenStack
     python setup.py develop

--- a/docs/update.md
+++ b/docs/update.md
@@ -105,6 +105,9 @@ pip install --upgrade setuptools
 pip install --upgrade pip
 pip install --upgrade urllib3[secure]   # to prevent InsecurePlatformWarning
 pip install google-compute-engine  # Only required on GCP
+pip install oauth2client # Required to retrieve GCP data
+pip install google-api-python-client # Required to retrieve GCP data
+pip install httplib2 # Required to retrieve GCP data
 pip install cloudaux\[gcp\]
 pip install cloudaux\[openstack\]    # Only required on OpenStack
 pip install -e .


### PR DESCRIPTION
Update documentation in order to reflect required python libraries needed to retrieve GCP data