### PR TITLE
Update redis-py.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ six>=1.11.0
 cloudaux==1.5.5
 celery==4.2.0
 celery[redis]==4.2.0
-redis==2.10.6
+redis==3.2.0
 Flask==0.12.4           # Need to upgrade this with Flask-SqlAlchemy.
 Flask-Mail==0.9.1
 Flask-Migrate==2.1.1


### PR DESCRIPTION
I couldn't get the docker-compose workflow to work without upgrading redis-py in the base image. I don't have the exact error message off-hand, but it when running the scheduler/worker i was getting error messages about a redis-py version mismatch which caused the containers to stop entirely.