### PR TITLE
Pinning to deepdiff 3.3.0 because later versions no longer support py2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 six>=1.11.0
 cloudaux==1.6.2
+deepdiff==3.3.0
 celery==4.2.0
 celery[redis]==4.2.0
 redis==2.10.6


### PR DESCRIPTION
(FYI - Deepdiff is a requirement of the swag client. Trying to see if I can pin to 3.3.0 in SM without modifying swag.)