### PR TITLE
Updated permission docs for IAM role tag support

### DIFF
--- a/docs/iam_aws.md
+++ b/docs/iam_aws.md
@@ -153,6 +153,7 @@ You will need to create this role in all AWS accounts that you want to monitor.
                     "iam:listpolicies",
                     "iam:listrolepolicies",
                     "iam:listroles",
+                    "iam:listroletags",
                     "iam:listsamlproviders",
                     "iam:listservercertificates",
                     "iam:listsigningcertificates",

--- a/scripts/secmonkey_role_setup.py
+++ b/scripts/secmonkey_role_setup.py
@@ -121,6 +121,7 @@ policy = \
            "iam:listpolicies",
            "iam:listrolepolicies",
            "iam:listroles",
+           "iam:listroletags",
            "iam:listsamlproviders",
            "iam:listservercertificates",
            "iam:listsigningcertificates",


### PR DESCRIPTION
Added `iam:ListRoleTags` to the docs as a new required permission.