### PR TITLE
Add alternative method to providing service account key

### DIFF
--- a/env-config/config-docker.py
+++ b/env-config/config-docker.py
@@ -147,6 +147,7 @@ GOOGLE_SECRET = os.getenv('SECURITY_MONKEY_GOOGLE_SECRET', '')
 GOOGLE_HOSTED_DOMAIN = os.getenv('SECURITY_MONKEY_GOOGLE_HOSTED_DOMAIN', '') # Verify that token issued by comes from domain
 # Details about domain-wide-delegation https://developers.google.com/admin-sdk/directory/v1/guides/delegation
 GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_PATH = os.getenv('SECURITY_MONKEY_GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_PATH', '') # path to service account key with enabled domain wide delegation
+GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_JSON = os.getenv('SECURITY_MONKEY_GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_JSON', '') # json of service account key with enabled domain wide delegation
 GOOGLE_ADMIN_ROLE_GROUP_NAME = '' # Google group name which should map to security-monkey role Admin
 GOOGLE_AUTH_API_METHOD = 'People' # alternative 'Directory' to use Google SSO against Directory API
 GOOGLE_DOMAIN_WIDE_DELEGATION_SUBJECT = '' # perform google directory api calls as the this subject 

--- a/env-config/config-local.py
+++ b/env-config/config-local.py
@@ -119,6 +119,7 @@ GOOGLE_SECRET = ''
 # GOOGLE_HOSTED_DOMAIN = 'example.com' # Verify that token issued by comes from domain
 # Details about domain-wide-delegation https://developers.google.com/admin-sdk/directory/v1/guides/delegation
 GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_PATH = '' # path to service account key with enabled domain wide delegation
+GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_JSON = '' # json of service account key with enabled domain wide delegation
 GOOGLE_ADMIN_ROLE_GROUP_NAME = '' # Google group name which should map to security-monkey role Admin
 GOOGLE_AUTH_API_METHOD = 'People' # alternative 'Directory' to use Google SSO against Directory API
 GOOGLE_DOMAIN_WIDE_DELEGATION_SUBJECT = '' # perform google directory api calls as the this subject 

--- a/env-config/config.py
+++ b/env-config/config.py
@@ -142,6 +142,7 @@ GOOGLE_SECRET = ''
 GOOGLE_DEFAULT_ROLE = 'View'
 # Details about domain-wide-delegation https://developers.google.com/admin-sdk/directory/v1/guides/delegation
 GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_PATH = '' # path to service account key with enabled domain wide delegation
+GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_JSON = '' # json of service account key with enabled domain wide delegation
 GOOGLE_ADMIN_ROLE_GROUP_NAME = '' # Google group name which should map to security-monkey role Admin
 GOOGLE_AUTH_API_METHOD = 'People' # alternative 'Directory' to use Google SSO against Directory API
 GOOGLE_DOMAIN_WIDE_DELEGATION_SUBJECT = '' # perform google directory api calls as the this subject 

--- a/security_monkey/sso/views.py
+++ b/security_monkey/sso/views.py
@@ -240,7 +240,7 @@ class Google(Resource):
                 creds = service_account.Credentials.from_service_account_file(
                     current_app.config.get("GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_PATH"),
                     scopes=['https://www.googleapis.com/auth/admin.directory.group.readonly'])
-            except FileNotFoundError:    
+            except OSError:    
                 creds = service_account.Credentials.from_service_account_info(
                     json.loads(current_app.config.get("GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_JSON")),
                     scopes=['https://www.googleapis.com/auth/admin.directory.group.readonly'])

--- a/security_monkey/sso/views.py
+++ b/security_monkey/sso/views.py
@@ -5,8 +5,11 @@
     :license: Apache, see LICENSE for more details.
 .. moduleauthor:: Patrick Kelley <patrick@netflix.com>
 """
-import jwt
+import json
 import base64
+import uuid
+
+import jwt
 import requests
 
 from flask import Blueprint, current_app, redirect, request
@@ -36,7 +39,6 @@ from security_monkey.exceptions import UnableToIssueGoogleAuthToken, UnableToAcc
 from security_monkey import db, rbac, csrf
 
 from six.moves.urllib.parse import urlparse
-import uuid
 
 mod = Blueprint('sso', __name__)
 # SSO providers implement their own CSRF protection
@@ -234,8 +236,14 @@ class Google(Resource):
         super(Google, self).__init__()
 
         if self._isAuthMethod('directory'):
-            creds = service_account.Credentials.from_service_account_file(
-                current_app.config.get("GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_PATH"), scopes=['https://www.googleapis.com/auth/admin.directory.group.readonly'])
+            try:
+                creds = service_account.Credentials.from_service_account_file(
+                    current_app.config.get("GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_PATH"),
+                    scopes=['https://www.googleapis.com/auth/admin.directory.group.readonly'])
+            except FileNotFoundError:    
+                creds = service_account.Credentials.from_service_account_info(
+                    json.loads(current_app.config.get("GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_JSON")),
+                    scopes=['https://www.googleapis.com/auth/admin.directory.group.readonly'])
             self.credentials = creds.with_subject(current_app.config.get("GOOGLE_DOMAIN_WIDE_DELEGATION_SUBJECT"))
 
     def _isAuthMethod(self, method):


### PR DESCRIPTION
-Add means to getting key without specifying key path
-Add `GOOGLE_DOMAIN_WIDE_DELEGATION_KEY_JSON` to config scripts 