### PR TITLE
Fixed an issue in the API where a null auditor_setting throws an exception

### DIFF
--- a/security_monkey/views/item.py
+++ b/security_monkey/views/item.py
@@ -113,7 +113,7 @@ class ItemGet(AuthenticatedService):
         retval['comments'] = comments_marshaled
 
         for issue in result.issues:
-            if issue.auditor_setting.disabled:
+            if not issue.auditor_setting or issue.auditor_setting.disabled:
                 continue
             issue_marshaled = marshal(issue.__dict__, AUDIT_FIELDS)
             if issue.user is not None:


### PR DESCRIPTION
Fix an issue in the API where a null auditor_setting throws an exception

- The ItemAudit's auditor_setting_id can be null. Not sure why, but if it's null
  it raises an Exception. This will ignore this and skip showing the issues in these cases.